### PR TITLE
opt: Sorting through the use of strings

### DIFF
--- a/src/article_maker.cc
+++ b/src/article_maker.cc
@@ -468,7 +468,7 @@ ArticleRequest::ArticleRequest( Config::InputPhrase const & phrase,
   // Accumulate main forms
   for( unsigned x = 0; x < activeDicts.size(); ++x )
   {
-    sptr< Dictionary::WordSearchRequest > s = activeDicts[ x ]->findHeadwordsForSynonym( gd::toWString( word ) );
+    sptr< Dictionary::WordSearchRequest > s = activeDicts[ x ]->findHeadwordsForSynonym( gd::removeTrailingZero( word ) );
 
     connect( s.get(), &Dictionary::Request::finished, this, &ArticleRequest::altSearchFinished, Qt::QueuedConnection );
 
@@ -529,7 +529,7 @@ void ArticleRequest::altSearchFinished()
       {
         sptr< Dictionary::DataRequest > r =
           activeDicts[ x ]->getArticle( wordStd, altsVector,
-                                        gd::toWString( contexts.value( QString::fromStdString( activeDicts[ x ]->getId() ) ) ),
+                                        gd::removeTrailingZero( contexts.value( QString::fromStdString( activeDicts[ x ]->getId() ) ) ),
                                         ignoreDiacritics );
 
         connect( r.get(), &Dictionary::Request::finished, this, &ArticleRequest::bodyFinished, Qt::QueuedConnection );

--- a/src/article_maker.cc
+++ b/src/article_maker.cc
@@ -514,7 +514,7 @@ void ArticleRequest::altSearchFinished()
 #ifdef QT_DEBUG
     for( unsigned x = 0; x < altsVector.size(); ++x )
     {
-      qDebug() << "Alt:" << gd::toQString( altsVector[ x ] );
+      qDebug() << "Alt:" << QString::fromStdU32String( altsVector[ x ] );
     }
 #endif
 
@@ -1012,7 +1012,7 @@ QString ArticleRequest::makeSplittedWordCompound()
 
       Folding::normalizeWhitespace( ws );
 
-      result.append( gd::toQString( ws ) );
+      result.append( QString::fromStdU32String( ws ) );
     }
   }
 

--- a/src/btreeidx.cc
+++ b/src/btreeidx.cc
@@ -184,7 +184,7 @@ void BtreeWordSearchRequest::findMatches()
 
   if( useWildcards )
   {
-    regexp.setPattern( wildcardsToRegexp( gd::toQString( Folding::applyDiacriticsOnly( Folding::applySimpleCaseOnly( str ) ) ) ) );
+    regexp.setPattern( wildcardsToRegexp( QString::fromStdU32String( Folding::applyDiacriticsOnly( Folding::applySimpleCaseOnly( str ) ) ) ) );
     if( !regexp.isValid() )
       regexp.setPattern( QRegularExpression::escape( regexp.pattern() ) );
     regexp.setPatternOptions( QRegularExpression::CaseInsensitiveOption );
@@ -337,7 +337,7 @@ void BtreeWordSearchRequest::findMatches()
               wstring result = Folding::applyDiacriticsOnly( word );
               if( result.size() >= (wstring::size_type)minMatchLength )
               {
-                QRegularExpressionMatch match = regexp.match( gd::toQString( result ) );
+                QRegularExpressionMatch match = regexp.match( QString::fromStdU32String( result ) );
                 if( match.hasMatch() && match.capturedStart() == 0 )
                 {
                   addMatch( word );

--- a/src/btreeidx.cc
+++ b/src/btreeidx.cc
@@ -67,8 +67,10 @@ void BtreeIndex::openIndex( IndexInfo const & indexInfo,
   rootNode.clear();
 }
 
-vector< WordArticleLink > BtreeIndex::findArticles( wstring const & word, bool ignoreDiacritics )
+vector< WordArticleLink > BtreeIndex::findArticles( wstring const & search_word, bool ignoreDiacritics )
 {
+  //First trim ending zero
+  wstring word = gd::removeTrailingZero( search_word );
   vector< WordArticleLink > result;
 
   try
@@ -1003,8 +1005,9 @@ static uint32_t buildBtreeNode( IndexedWords::const_iterator & nextIndex,
   return offset;
 }
 
-void IndexedWords::addWord( wstring const & word, uint32_t articleOffset, unsigned int maxHeadwordSize )
+void IndexedWords::addWord( wstring const & index_word, uint32_t articleOffset, unsigned int maxHeadwordSize )
 {
+  wstring const & word = gd::removeTrailingZero( index_word );
   wchar const * wordBegin = word.c_str();
   string::size_type wordSize = word.size();
 
@@ -1095,8 +1098,9 @@ void IndexedWords::addWord( wstring const & word, uint32_t articleOffset, unsign
   }
 }
 
-void IndexedWords::addSingleWord( wstring const & word, uint32_t articleOffset )
+void IndexedWords::addSingleWord( wstring const & index_word, uint32_t articleOffset )
 {
+  wstring const & word = gd::removeTrailingZero( index_word );
   wstring folded = Folding::apply( word );
   if( folded.empty() )
       folded = Folding::applyWhitespaceOnly( word );

--- a/src/common/folding.cc
+++ b/src/common/folding.cc
@@ -4,6 +4,8 @@
 #include "folding.hh"
 #include <QRegularExpression>
 
+#include "wstring_qt.hh"
+
 namespace Folding {
 
 #include "inc_case_folding.hh"
@@ -25,8 +27,7 @@ bool isCombiningMark( wchar ch )
 
 wstring apply( wstring const & in, bool preserveWildcards )
 {
-  // First, strip diacritics and apply ws/punctuation removal
-
+  //First, strip diacritics and apply ws/punctuation removal
   wstring withoutDiacritics;
 
   withoutDiacritics.reserve( in.size() );
@@ -35,7 +36,7 @@ wstring apply( wstring const & in, bool preserveWildcards )
 
   size_t consumed;
 
-  for( size_t left = in.size(); left; )
+  for(int left=in.size() ; left; )
   {
     wchar ch = foldDiacritic( nextChar, left, consumed );
 

--- a/src/common/iconv.cc
+++ b/src/common/iconv.cc
@@ -114,7 +114,7 @@ gd::wstring Iconv::toWstring( char const * fromEncoding, void const * fromData,
   /// behaviour in that regard.
 
   if ( !dataSize )
-    return gd::wstring();
+    return {};
 
   Iconv ic( Utf8, fromEncoding );
 
@@ -129,7 +129,7 @@ std::string Iconv::toUtf8( char const * fromEncoding, void const * fromData,
   // Similar to toWstring
 
   if ( !dataSize )
-    return std::string();
+    return {};
 
   Iconv ic( Utf8, fromEncoding );
 

--- a/src/common/iconv.cc
+++ b/src/common/iconv.cc
@@ -133,7 +133,7 @@ std::string Iconv::toUtf8( char const * fromEncoding, void const * fromData,
 
   Iconv ic( Utf8, fromEncoding );
 
-  QString outStr = ic.convert(fromData, dataSize);
-  return gd::toStdString(outStr);
+  const QString outStr = ic.convert(fromData, dataSize);
+  return outStr.toStdString();
 }
 

--- a/src/common/wstring_qt.cc
+++ b/src/common/wstring_qt.cc
@@ -3,11 +3,10 @@
 
 namespace gd
 {
-  QString toQString( wstring const & in )
-  {
-    return QString::fromStdU32String( in );
-  }
 
+  //This is not only about non-BMP characters.even without non-BMP. this wrapper has removed the tailing \0
+  //so even https://bugreports.qt-project.org/browse/QTBUG-25536 has been fixed . It can not directly be replaced by
+  // QString::toStd32String();
   wstring toWString( QString const & in )
   {
     QVector< unsigned int > v = in.toUcs4();
@@ -25,12 +24,9 @@ namespace gd
 
   wstring normalize( const wstring & str )
   {
-    return gd::toWString( gd::toQString( str ).normalized( QString::NormalizationForm_C ) );
+    return gd::toWString( QString::fromStdU32String( str ).normalized( QString::NormalizationForm_C ) );
   }
 
-  std::string toStdString(const QString& str)
-  {
-      return str.toStdString();
-  }
+
 
 }

--- a/src/common/wstring_qt.cc
+++ b/src/common/wstring_qt.cc
@@ -3,28 +3,37 @@
 
 namespace gd
 {
-
-  //This is not only about non-BMP characters.even without non-BMP. this wrapper has removed the tailing \0
-  //so even https://bugreports.qt-project.org/browse/QTBUG-25536 has been fixed . It can not directly be replaced by
-  // QString::toStd32String();
   wstring toWString( QString const & in )
+  {
+    return in.toStdU32String();
+  }
+
+  // When convert non-BMP characters to wstring,the ending char maybe \0 .This method remove the tailing \0 from the wstring
+  // as \0 is sensitive in the index.  This method will be only used with index related operations like store/query.
+  wstring removeTrailingZero( wstring const & v )
+  {
+    int n = v.size();
+    while ( n > 0 && v[ n - 1 ] == 0 )
+      n--;
+    return wstring( v.data(), n );
+  }
+
+  wstring removeTrailingZero( QString const & in )
   {
     QVector< unsigned int > v = in.toUcs4();
 
-    // Fix for QString instance which contains non-BMP characters
-    // Qt will created unexpected null characters may confuse btree indexer.
-    // Related: https://bugreports.qt-project.org/browse/QTBUG-25536
     int n = v.size();
-    while ( n > 0 && v[ n - 1 ] == 0 ) n--;
+    while ( n > 0 && v[ n - 1 ] == 0 )
+      n--;
     if ( n != v.size() )
       v.resize( n );
 
-    return wstring( ( const wchar * ) v.constData(), v.size() );
+    return wstring( (const wchar *)v.constData(), v.size() );
   }
 
   wstring normalize( const wstring & str )
   {
-    return gd::toWString( QString::fromStdU32String( str ).normalized( QString::NormalizationForm_C ) );
+    return toWString( QString::fromStdU32String( str ).normalized( QString::NormalizationForm_C ) );
   }
 
 

--- a/src/common/wstring_qt.hh
+++ b/src/common/wstring_qt.hh
@@ -10,10 +10,11 @@
 #include "wstring.hh"
 #include <QString>
 
-namespace gd
-{
-  wstring toWString( QString const & );
-  wstring normalize( wstring const & );
+namespace gd {
+wstring toWString( QString const & );
+wstring removeTrailingZero( wstring const & v );
+wstring removeTrailingZero( QString const & in );
+wstring normalize( wstring const & );
 }
 
 #endif

--- a/src/common/wstring_qt.hh
+++ b/src/common/wstring_qt.hh
@@ -12,10 +12,8 @@
 
 namespace gd
 {
-  QString toQString( wstring const & );
   wstring toWString( QString const & );
   wstring normalize( wstring const & );
-  std::string toStdString(const QString& );
 }
 
 #endif

--- a/src/config.cc
+++ b/src/config.cc
@@ -206,7 +206,7 @@ InputPhrase Preferences::sanitizeInputPhrase( QString const & inputPhrase ) cons
   }
 
   const QString withPunct = _phase.simplified().remove( QChar( 0xAD ) ); // Simplify whitespaces and remove soft hyphens;
-  result.phrase = gd::toQString( Folding::trimWhitespaceOrPunct( gd::toWString( withPunct ) ) );
+  result.phrase = QString::fromStdU32String( Folding::trimWhitespaceOrPunct( gd::toWString( withPunct ) ) );
   if ( !result.isValid() )
     return result; // The suffix of an invalid input phrase must be empty.
 

--- a/src/dict/bgl.cc
+++ b/src/dict/bgl.cc
@@ -451,7 +451,7 @@ namespace
         }
       }
 
-      text = Html::unescape( gd::toQString( wstr ) );
+      text = Html::unescape( QString::fromStdU32String( wstr ) );
     }
     catch( std::exception &ex )
     {

--- a/src/dict/bgl_babylon.cc
+++ b/src/dict/bgl_babylon.cc
@@ -763,10 +763,9 @@ void Babylon::convertToUtf8( std::string &s, unsigned int type )
 
   size_t inbufbytes = s.size();
 
-  char *inbuf;
-  inbuf = (char *)s.data();
+  char* inbuf = (char*)s.data();
   const void* test = inbuf;
 
-  QString convStr = conv_.convert(test,inbufbytes);
-  s = gd::toStdString(convStr);
+  const QString convStr = conv_.convert(test,inbufbytes);
+  s               = convStr.toStdString();
 }

--- a/src/dict/dictserver.cc
+++ b/src/dict/dictserver.cc
@@ -433,7 +433,7 @@ void DictServerWordSearchRequest::run()
         QString matchReq = QString( "MATCH " )
                            + dict.databases.at( i )
                            + " " + dict.strategies.at( ns )
-                           + " \"" + gd::toQString( word )
+                           + " \"" + QString::fromStdU32String( word )
                            + "\"\r\n";
         socket->write( matchReq.toUtf8() );
         socket->waitForBytesWritten( 1000 );
@@ -644,7 +644,7 @@ void DictServerArticleRequest::run()
     {
       QString defineReq = QString( "DEFINE " )
                          + dict.databases.at( i )
-                         + " \"" + gd::toQString( word ) + "\"\r\n";
+                         + " \"" + QString::fromStdU32String( word ) + "\"\r\n";
       socket->write( defineReq.toUtf8() );
       socket->waitForBytesWritten( 1000 );
 

--- a/src/dict/dsl.cc
+++ b/src/dict/dsl.cc
@@ -1063,7 +1063,7 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
     {
       // Find ISO 639-1 code
       string langcode;
-      QString attr = gd::toQString( node.tagAttrs );
+      QString attr = QString::fromStdU32String( node.tagAttrs );
       int n = attr.indexOf( "id=" );
       if( n >= 0 )
       {
@@ -1097,10 +1097,10 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
     url.setHost( "localhost" );
     wstring nodeStr = node.renderAsText();
     normalizeHeadword( nodeStr );
-    url.setPath( Utils::Url::ensureLeadingSlash( gd::toQString( nodeStr ) ) );
+    url.setPath( Utils::Url::ensureLeadingSlash( QString::fromStdU32String( nodeStr ) ) );
     if( !node.tagAttrs.empty() )
     {
-      QString attr = gd::toQString( node.tagAttrs ).remove( '\"' );
+      QString attr = QString::fromStdU32String( node.tagAttrs ).remove( '\"' );
       int n = attr.indexOf( '=' );
       if( n > 0 )
       {
@@ -1123,7 +1123,7 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
     url.setHost( "localhost" );
     wstring nodeStr = node.renderAsText();
     normalizeHeadword( nodeStr );
-    url.setPath( Utils::Url::ensureLeadingSlash( gd::toQString( nodeStr ) ) );
+    url.setPath( Utils::Url::ensureLeadingSlash( QString::fromStdU32String( nodeStr ) ) );
 
     result += string( R"(<a class="dsl_ref" href=")" ) + url.toEncoded().data() +"\">"
               + processNodeChildren( node ) + "</a>";
@@ -1147,12 +1147,12 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
   else
   {
     gdWarning( R"(DSL: Unknown tag "%s" with attributes "%s" found in "%s", article "%s".)",
-               gd::toQString( node.tagName ).toUtf8().data(), gd::toQString( node.tagAttrs ).toUtf8().data(),
-               getName().c_str(), gd::toQString( currentHeadword ).toUtf8().data() );
+               QString::fromStdU32String( node.tagName ).toUtf8().data(), QString::fromStdU32String( node.tagAttrs ).toUtf8().data(),
+               getName().c_str(), QString::fromStdU32String( currentHeadword ).toUtf8().data() );
 
-    result += "<span class=\"dsl_unknown\">[" + string( gd::toQString( node.tagName ).toUtf8().data() );
+    result += "<span class=\"dsl_unknown\">[" + string( QString::fromStdU32String( node.tagName ).toUtf8().data() );
     if( !node.tagAttrs.empty() )
-      result += " " + string( gd::toQString( node.tagAttrs ).toUtf8().data() );
+      result += " " + string( QString::fromStdU32String( node.tagAttrs ).toUtf8().data() );
     result += "]" + processNodeChildren( node ) + "</span>";
   }
 
@@ -1410,7 +1410,7 @@ void DslDictionary::getArticleText( uint32_t articleAddress, QString & headword,
   {
     unescapeDsl( articleHeadword );
     normalizeHeadword( articleHeadword );
-    headword = gd::toQString( articleHeadword );
+    headword = QString::fromStdU32String( articleHeadword );
   }
 
   wstring articleText;
@@ -1433,7 +1433,7 @@ void DslDictionary::getArticleText( uint32_t articleAddress, QString & headword,
 
   if( !articleText.empty() )
   {
-    text = gd::toQString( articleText ).normalized( QString::NormalizationForm_C );
+    text = QString::fromStdU32String( articleText ).normalized( QString::NormalizationForm_C );
 
     articleText.clear();
 
@@ -1524,7 +1524,7 @@ void DslDictionary::getArticleText( uint32_t articleAddress, QString & headword,
     {
       // Use base DSL parser for articles with insided cards
       ArticleDom dom( gd::toWString( text ), getName(), articleHeadword );
-      text = gd::toQString( dom.root.renderAsText( true ) );
+      text = QString::fromStdU32String( dom.root.renderAsText( true ) );
     }
     else
     {
@@ -1946,7 +1946,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries(
           initializing.indexingDictionary( Utf8::encode( scanner.getDictionaryName() ) );
 
           gdDebug( "Dsl: Building the index for dictionary: %s\n",
-                   gd::toQString( scanner.getDictionaryName() ).toUtf8().data() );
+                   QString::fromStdU32String( scanner.getDictionaryName() ).toUtf8().data() );
 
           File::Class idx( indexFile, "wb" );
 
@@ -2136,7 +2136,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries(
               break; // No more headwords
 
 #ifdef QT_DEBUG
-            qDebug() << "Alt headword" << gd::toQString( curString );
+            qDebug() << "Alt headword" << QString::fromStdU32String( curString );
 #endif
 
             processUnsortedParts( curString, true );

--- a/src/dict/dsl_details.cc
+++ b/src/dict/dsl_details.cc
@@ -146,7 +146,7 @@ bool isAtSignFirst( wstring const & str )
 {
   // Test if '@' is first in string except spaces and dsl tags
   QRegularExpression reg( R"([ \t]*(?:\[[^\]]+\][ \t]*)*@)", QRegularExpression::PatternOption::CaseInsensitiveOption);
-  return gd::toQString( str ).indexOf (reg) == 0;
+  return QString::fromStdU32String( str ).indexOf (reg) == 0;
 }
 
 /////////////// ArticleDom
@@ -357,11 +357,11 @@ ArticleDom::ArticleDom( wstring const & str, string const & dictName,
         {
           if( !dictionaryName.empty() )
             gdWarning( R"(DSL: Unfinished tag "%s" with attributes "%s" found in "%s", article "%s".)",
-                       gd::toQString( name ).toUtf8().data(), gd::toQString( attrs ).toUtf8().data(),
-                       dictionaryName.c_str(), gd::toQString( headword ).toUtf8().data() );
+                       QString::fromStdU32String( name ).toUtf8().data(), QString::fromStdU32String( attrs ).toUtf8().data(),
+                       dictionaryName.c_str(), QString::fromStdU32String( headword ).toUtf8().data() );
           else
             gdWarning( R"(DSL: Unfinished tag "%s" with attributes "%s" found)",
-                       gd::toQString( name ).toUtf8().data(), gd::toQString( attrs ).toUtf8().data() );
+                       QString::fromStdU32String( name ).toUtf8().data(), QString::fromStdU32String( attrs ).toUtf8().data() );
 
           throw eot();
         }
@@ -659,7 +659,7 @@ ArticleDom::ArticleDom( wstring const & str, string const & dictName,
     list< Node * >::iterator it = std::find_if( stack.begin(), stack.end(), MustTagBeClosed() );
     if( it == stack.end() )
       return; // no unclosed tags that must be closed => nothing to warn about
-    QByteArray const firstTagName = gd::toQString( ( *it )->tagName ).toUtf8();
+    QByteArray const firstTagName = QString::fromStdU32String( ( *it )->tagName ).toUtf8();
     ++it;
     unsigned const unclosedTagCount = 1 + std::count_if( it, stack.end(), MustTagBeClosed() );
 
@@ -671,7 +671,7 @@ ArticleDom::ArticleDom( wstring const & str, string const & dictName,
     else
     {
       gdWarning( "Warning: %u tag(s) were unclosed in \"%s\", article \"%s\", first tag name \"%s\".\n",
-                 unclosedTagCount, dictName.c_str(), gd::toQString( headword ).toUtf8().constData(),
+                 unclosedTagCount, dictName.c_str(), QString::fromStdU32String( headword ).toUtf8().constData(),
                  firstTagName.constData() );
     }
   }
@@ -815,11 +815,11 @@ void ArticleDom::closeTag( wstring const & name,
   {
     if( !dictionaryName.empty() )
       gdWarning( R"(No corresponding opening tag for closing tag "%s" found in "%s", article "%s".)",
-                 gd::toQString( name ).toUtf8().data(), dictionaryName.c_str(),
-                 gd::toQString( headword ).toUtf8().data() );
+                 QString::fromStdU32String( name ).toUtf8().data(), dictionaryName.c_str(),
+                 QString::fromStdU32String( headword ).toUtf8().data() );
     else
       gdWarning( "No corresponding opening tag for closing tag \"%s\" found.",
-                 gd::toQString( name ).toUtf8().data() );
+                 QString::fromStdU32String( name ).toUtf8().data() );
   }
 }
 

--- a/src/dict/epwing.cc
+++ b/src/dict/epwing.cc
@@ -561,7 +561,7 @@ void EpwingHeadwordsRequest::run()
     return;
   }
 
-  QRegularExpressionMatch m = RX::Epwing::refWord.match( gd::toQString( str ) );
+  QRegularExpressionMatch m = RX::Epwing::refWord.match( QString::fromStdU32String( str ) );
   if ( !m.hasMatch() ) {
     finish();
     return;
@@ -728,7 +728,7 @@ void EpwingArticleRequest::run()
     articlesIncluded.insert( x.articleOffset );
   }
 
-  QRegularExpressionMatch m = RX::Epwing::refWord.match( gd::toQString( word ) );
+  QRegularExpressionMatch m = RX::Epwing::refWord.match( QString::fromStdU32String( word ) );
   bool ref                  = m.hasMatch();
 
   // Also try to find word in the built-in dictionary index
@@ -806,7 +806,7 @@ void EpwingArticleRequest::getBuiltInArticle( wstring const & word_,
     QVector< int > pg, off;
     {
       Mutex::Lock _( dict.eBook.getLibMutex() );
-      dict.eBook.getArticlePos( gd::toQString( word_ ), pg, off );
+      dict.eBook.getArticlePos( QString::fromStdU32String( word_ ), pg, off );
     }
 
     for( int i = 0; i < pg.size(); i++ )
@@ -843,7 +843,7 @@ void EpwingDictionary::getHeadwordPos( wstring const & word_, QVector< int > & p
 {
   try {
     Mutex::Lock _( eBook.getLibMutex() );
-    eBook.getArticlePos( gd::toQString( word_ ), pg, off );
+    eBook.getArticlePos( QString::fromStdU32String( word_ ), pg, off );
   }
   catch ( ... ) {
     //ignore
@@ -1079,7 +1079,7 @@ void EpwingWordSearchRequest::findMatches()
       if( Utils::AtomicInt::loadAcquire( isCancelled ) )
         break;
 
-      if( !edict.eBook.getMatches( gd::toQString( str ), headwords ) )
+      if( !edict.eBook.getMatches( QString::fromStdU32String( str ), headwords ) )
         break;
     }
 

--- a/src/dict/epwing_book.cc
+++ b/src/dict/epwing_book.cc
@@ -1122,7 +1122,7 @@ void EpwingBook::fixHeadword( QString & headword )
   //}
 
   gd::wstring folded = Folding::applyPunctOnly( gd::toWString( fixed ) );
-  //fixed = gd::toQString( folded );
+  //fixed = QString::fromStdU32String( folded );
 
   //if( isHeadwordCorrect( fixed ) )
   //{
@@ -1131,7 +1131,7 @@ void EpwingBook::fixHeadword( QString & headword )
   //}
 
   folded = Folding::applyDiacriticsOnly( folded );
-  fixed = gd::toQString( folded );
+  fixed = QString::fromStdU32String( folded );
 
   //if( isHeadwordCorrect( fixed ) )
   //{
@@ -1140,7 +1140,7 @@ void EpwingBook::fixHeadword( QString & headword )
   //}
 
   //folded = Folding::applyWhitespaceOnly( folded );
-  //fixed = gd::toQString( folded );
+  //fixed = QString::fromStdU32String( folded );
 
   //if( isHeadwordCorrect( fixed ) )
   //  headword = fixed;

--- a/src/dict/forvo.cc
+++ b/src/dict/forvo.cc
@@ -122,7 +122,7 @@ ForvoArticleRequest::ForvoArticleRequest( wstring const & str,
 void ForvoArticleRequest::addQuery( QNetworkAccessManager & mgr,
                                     wstring const & str )
 {
-  gdDebug( "Forvo: requesting article %s\n", gd::toQString( str ).toUtf8().data() );
+  gdDebug( "Forvo: requesting article %s\n", QString::fromStdU32String( str ).toUtf8().data() );
 
   QString key = apiKey;
 
@@ -131,7 +131,7 @@ void ForvoArticleRequest::addQuery( QNetworkAccessManager & mgr,
                "/key/" + key +
                "/action/word-pronunciations"
                "/format/xml"
-               "/word/" + QLatin1String( QUrl::toPercentEncoding( gd::toQString( str ) ) ) +
+               "/word/" + QLatin1String( QUrl::toPercentEncoding( QString::fromStdU32String( str ) ) ) +
                "/language/" + languageCode +
                "/order/rate-desc"
        ).toUtf8() );

--- a/src/dict/gls.cc
+++ b/src/dict/gls.cc
@@ -850,9 +850,7 @@ void GlsDictionary::getArticleText( uint32_t articleAddress, QString & headword,
     if( !headwords.empty() )
       headword = QString::fromUtf8( headwords.front().data(), headwords.front().size() );
 
-    wstring wstr = Utf8::decode( articleStr );
-
-    text = Html::unescape( QString::fromStdU32String( wstr ) );
+    text = Html::unescape( QString::fromStdString( articleStr ) );
   }
   catch( std::exception &ex )
   {

--- a/src/dict/gls.cc
+++ b/src/dict/gls.cc
@@ -852,7 +852,7 @@ void GlsDictionary::getArticleText( uint32_t articleAddress, QString & headword,
 
     wstring wstr = Utf8::decode( articleStr );
 
-    text = Html::unescape( gd::toQString( wstr ) );
+    text = Html::unescape( QString::fromStdU32String( wstr ) );
   }
   catch( std::exception &ex )
   {
@@ -1414,7 +1414,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries(
           initializing.indexingDictionary( Utf8::encode( scanner.getDictionaryName() ) );
 
           gdDebug( "Gls: Building the index for dictionary: %s\n",
-                   gd::toQString( scanner.getDictionaryName() ).toUtf8().data() );
+                   QString::fromStdU32String( scanner.getDictionaryName() ).toUtf8().data() );
 
           File::Class idx( indexFile, "wb" );
 

--- a/src/dict/hunspell.cc
+++ b/src/dict/hunspell.cc
@@ -476,7 +476,7 @@ QVector< wstring > suggest( wstring & word, Mutex & hunspellMutex, Hunspell & hu
 
       for( vector< string >::size_type x = 0; x < suggestions.size(); ++x )
       {
-        QString suggestion = gd::toQString( decodeFromHunspell( hunspell, suggestions[ x ].c_str() ) );
+        QString suggestion = QString::fromStdU32String( decodeFromHunspell( hunspell, suggestions[ x ].c_str() ) );
 
         // Strip comments
         int n = suggestion.indexOf( '#' );
@@ -492,7 +492,7 @@ QVector< wstring > suggest( wstring & word, Mutex & hunspellMutex, Hunspell & hu
           if ( Folding::applySimpleCaseOnly( alt ) != lowercasedWord ) // No point in providing same word
           {
 #ifdef QT_DEBUG
-            qDebug() << ">>>>>Alt:" << gd::toQString( alt );
+            qDebug() << ">>>>>Alt:" << QString::fromStdU32String( alt );
 #endif
             result.append( alt );
           }

--- a/src/dict/mediawiki.cc
+++ b/src/dict/mediawiki.cc
@@ -128,7 +128,7 @@ MediaWikiWordSearchRequest::MediaWikiWordSearchRequest( wstring const & str,
 
   GlobalBroadcaster::instance()->addWhitelist( reqUrl.host() );
 
-  Utils::Url::addQueryItem( reqUrl, "apfrom", gd::toQString( str ).replace( '+', "%2B" ) );
+  Utils::Url::addQueryItem( reqUrl, "apfrom", QString::fromStdU32String( str ).replace( '+', "%2B" ) );
 
   netReply = std::shared_ptr<QNetworkReply>(mgr.get( QNetworkRequest( reqUrl ) ));
 
@@ -418,11 +418,11 @@ MediaWikiArticleRequest::MediaWikiArticleRequest( wstring const & str,
 void MediaWikiArticleRequest::addQuery( QNetworkAccessManager & mgr,
                                         wstring const & str )
 {
-  gdDebug( "MediaWiki: requesting article %s\n", gd::toQString( str ).toUtf8().data() );
+  gdDebug( "MediaWiki: requesting article %s\n", QString::fromStdU32String( str ).toUtf8().data() );
 
   QUrl reqUrl( url + "/api.php?action=parse&prop=text|revid|sections&format=xml&redirects" );
 
-  Utils::Url::addQueryItem( reqUrl, "page", gd::toQString( str ).replace( '+', "%2B" ) );
+  Utils::Url::addQueryItem( reqUrl, "page", QString::fromStdU32String( str ).replace( '+', "%2B" ) );
   QNetworkRequest req( reqUrl ) ;
   //millseconds.
   req.setTransferTimeout(3000);

--- a/src/dict/programs.cc
+++ b/src/dict/programs.cc
@@ -62,7 +62,7 @@ sptr< WordSearchRequest > ProgramsDictionary::prefixMatch( wstring const & word,
   
 {
   if ( prg.type == Config::Program::PrefixMatch )
-    return  std::make_shared<ProgramWordSearchRequest>( gd::toQString( word ), prg );
+    return  std::make_shared<ProgramWordSearchRequest>( QString::fromStdU32String( word ), prg );
   else
   {
     sptr< WordSearchRequestInstant > sr =  std::make_shared<WordSearchRequestInstant>();
@@ -112,7 +112,7 @@ sptr< Dictionary::DataRequest > ProgramsDictionary::getArticle(
 
     case Config::Program::Html:
     case Config::Program::PlainText:
-      return  std::make_shared<ProgramDataRequest>( gd::toQString( word ), prg );
+      return  std::make_shared<ProgramDataRequest>( QString::fromStdU32String( word ), prg );
 
     default:
       return  std::make_shared<DataRequestInstant>( false );

--- a/src/dict/sdict.cc
+++ b/src/dict/sdict.cc
@@ -454,8 +454,7 @@ void SdictDictionary::getArticleText( uint32_t articleAddress, QString & headwor
 
     try
     {
-      wstring wstr = Utf8::decode( articleStr );
-      text = Html::unescape( QString::fromStdU32String( wstr ) );
+      text = Html::unescape( QString::fromStdString( articleStr ) );
     }
     catch( std::exception & )
     {

--- a/src/dict/sdict.cc
+++ b/src/dict/sdict.cc
@@ -455,7 +455,7 @@ void SdictDictionary::getArticleText( uint32_t articleAddress, QString & headwor
     try
     {
       wstring wstr = Utf8::decode( articleStr );
-      text = Html::unescape( gd::toQString( wstr ) );
+      text = Html::unescape( QString::fromStdU32String( wstr ) );
     }
     catch( std::exception & )
     {

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -1199,7 +1199,7 @@ void StardictDictionary::getArticleText( uint32_t articleAddress, QString & head
 
     wstring wstr = Utf8::decode( articleStr );
 
-    text = Html::unescape( gd::toQString( wstr ) );
+    text = Html::unescape( QString::fromStdU32String( wstr ) );
   }
   catch( std::exception &ex )
   {

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -1197,9 +1197,7 @@ void StardictDictionary::getArticleText( uint32_t articleAddress, QString & head
 
     headword = QString::fromUtf8( headwordStr.data(), headwordStr.size() );
 
-    wstring wstr = Utf8::decode( articleStr );
-
-    text = Html::unescape( QString::fromStdU32String( wstr ) );
+    text = Html::unescape( QString::fromStdString( articleStr ) );
   }
   catch( std::exception &ex )
   {

--- a/src/dict/website.cc
+++ b/src/dict/website.cc
@@ -331,7 +331,7 @@ sptr< DataRequest > WebSiteDictionary::getArticle( wstring const & str,
   {
     urlString = urlTemplate;
 
-    QString inputWord = gd::toQString( str );
+    QString inputWord = QString::fromStdU32String( str );
 
     urlString.replace( "%25GDWORD%25", inputWord.toUtf8().toPercentEncoding() );
 

--- a/src/dict/xdxf.cc
+++ b/src/dict/xdxf.cc
@@ -423,9 +423,7 @@ void XdxfDictionary::getArticleText( uint32_t articleAddress, QString & headword
     string articleStr;
     loadArticle( articleAddress, articleStr, &headword );
 
-    wstring wstr = Utf8::decode( articleStr );
-
-    text = Html::unescape( QString::fromStdU32String( wstr ) );
+    text = Html::unescape( QString::fromStdString( articleStr ) );
   }
   catch( std::exception &ex )
   {

--- a/src/dict/xdxf.cc
+++ b/src/dict/xdxf.cc
@@ -425,7 +425,7 @@ void XdxfDictionary::getArticleText( uint32_t articleAddress, QString & headword
 
     wstring wstr = Utf8::decode( articleStr );
 
-    text = Html::unescape( gd::toQString( wstr ) );
+    text = Html::unescape( QString::fromStdU32String( wstr ) );
   }
   catch( std::exception &ex )
   {

--- a/src/dict/xdxf2html.cc
+++ b/src/dict/xdxf2html.cc
@@ -463,7 +463,7 @@ string convert( string const & in, DICT_TYPE type, map < string, string > const 
           }
           else
             title = i->second;
-          el.setAttribute( "title", gd::toQString( Utf8::decode( title ) ) );
+          el.setAttribute( "title", QString::fromStdU32String( Utf8::decode( title ) ) );
         }
     }
   }

--- a/src/ftshelpers.cc
+++ b/src/ftshelpers.cc
@@ -683,7 +683,7 @@ void FTSResultsRequest::checkSingleArticle( uint32_t  offset,
       articleText = articleText.normalized( QString::NormalizationForm_C );
 
       if( ignoreDiacritics )
-        articleText = gd::toQString( Folding::applyDiacriticsOnly( gd::toWString( articleText ) ) );
+        articleText = QString::fromStdU32String( Folding::applyDiacriticsOnly( gd::toWString( articleText ) ) );
 
       if( articleText.contains( searchRegularExpression ) )
       {
@@ -726,7 +726,7 @@ void FTSResultsRequest::checkSingleArticle( uint32_t  offset,
       articleText = articleText.normalized( QString::NormalizationForm_C );
 
       if( ignoreDiacritics )
-        articleText = gd::toQString( Folding::applyDiacriticsOnly( gd::toWString( articleText ) ) );
+        articleText = QString::fromStdU32String( Folding::applyDiacriticsOnly( gd::toWString( articleText ) ) );
 
       if( ignoreWordsOrder )
       {
@@ -1106,7 +1106,7 @@ void FTSResultsRequest::fullIndexSearch( BtreeIndexing::BtreeIndex & ftsIndex,
     QString word = QString::fromUtf8( links[ x ].word.data(), links[ x ].word.size() );
 
     if( ignoreDiacritics )
-      word = gd::toQString( Folding::applyDiacriticsOnly( gd::toWString( word ) ) );
+      word = QString::fromStdU32String( Folding::applyDiacriticsOnly( gd::toWString( word ) ) );
 
     for( int i = 0; i < indexWords.size(); i++ )
     {

--- a/src/ftshelpers.cc
+++ b/src/ftshelpers.cc
@@ -864,7 +864,7 @@ void FTSResultsRequest::indexSearch( BtreeIndexing::BtreeIndex & ftsIndex,
     }
 
     vector< BtreeIndexing::WordArticleLink > links =
-      ftsIndex.findArticles( gd::toWString( word ), ignoreDiacritics );
+      ftsIndex.findArticles( gd::removeTrailingZero( word ), ignoreDiacritics );
     for( unsigned x = 0; x < links.size(); x++ )
     {
       if( Utils::AtomicInt::loadAcquire( isCancelled ) )
@@ -986,7 +986,7 @@ void FTSResultsRequest::combinedIndexSearch( BtreeIndexing::BtreeIndex & ftsInde
     auto fn_wordLink = [ & ](const QString & word )
     {
       QSet< uint32_t > tmp;
-      vector< BtreeIndexing::WordArticleLink > links = ftsIndex.findArticles( gd::toWString( word ) );
+      vector< BtreeIndexing::WordArticleLink > links = ftsIndex.findArticles( gd::removeTrailingZero( word ) );
       for( unsigned x = 0; x < links.size(); x++ )
       {
         if( Utils::AtomicInt::loadAcquire( isCancelled ) )

--- a/src/ftshelpers.hh
+++ b/src/ftshelpers.hh
@@ -135,7 +135,7 @@ public:
     wordsInIndex( 0 )
   {
     if( ignoreDiacritics_ )
-      searchString = gd::toQString( Folding::applyDiacriticsOnly( gd::toWString( searchString_ ) ) );
+      searchString = QString::fromStdU32String( Folding::applyDiacriticsOnly( gd::toWString( searchString_ ) ) );
 
     foundHeadwords = new QList< FTS::FtsHeadword >;
     results         = 0;

--- a/src/ftshelpers.hh
+++ b/src/ftshelpers.hh
@@ -135,7 +135,7 @@ public:
     wordsInIndex( 0 )
   {
     if( ignoreDiacritics_ )
-      searchString = QString::fromStdU32String( Folding::applyDiacriticsOnly( gd::toWString( searchString_ ) ) );
+      searchString = QString::fromStdU32String( Folding::applyDiacriticsOnly( gd::removeTrailingZero( searchString_ ) ) );
 
     foundHeadwords = new QList< FTS::FtsHeadword >;
     results         = 0;

--- a/src/headwordsmodel.cc
+++ b/src/headwordsmodel.cc
@@ -88,7 +88,7 @@ void HeadwordListModel::requestFinished()
       {
         auto allmatches = ( *i )->getAllMatches();
         for( auto & match : allmatches )
-          filterWords.append( gd::toQString( match.word ) );
+          filterWords.append( QString::fromStdU32String( match.word ) );
       }
       queuedRequests.erase( i++ );
     }

--- a/src/headwordsmodel.cc
+++ b/src/headwordsmodel.cc
@@ -41,7 +41,7 @@ void HeadwordListModel::setFilter( QRegularExpression reg )
   }
   filtering = true;
   filterWords.clear();
-  auto sr = _dict->prefixMatch( gd::toWString( reg.pattern() ), 500 );
+  auto sr = _dict->prefixMatch( gd::removeTrailingZero( reg.pattern() ), 500 );
   connect( sr.get(), &Dictionary::Request::finished, this, &HeadwordListModel::requestFinished, Qt::QueuedConnection );
   queuedRequests.push_back( sr );
 }

--- a/src/indexedzip.cc
+++ b/src/indexedzip.cc
@@ -235,7 +235,7 @@ bool IndexedZip::indexFile( BtreeIndexing::IndexedWords &zipFileNames, quint32 *
             wstring decoded = Iconv::toWstring( "CP866", entry.fileName.constData(),
                                                 entry.fileName.size() );
 
-            if( nameInSystemLocale.compare( decoded ) != 0 )
+            if( nameInSystemLocale != decoded )
             {
               zipFileNames.addSingleWord( decoded,
                                           entry.localHeaderOffset );
@@ -258,7 +258,7 @@ bool IndexedZip::indexFile( BtreeIndexing::IndexedWords &zipFileNames, quint32 *
             wstring decoded = Iconv::toWstring( "CP1251", entry.fileName.constData(),
                                                 entry.fileName.size() );
 
-            if( nameInSystemLocale.compare( decoded ) != 0 )
+            if( nameInSystemLocale != decoded )
             {
               zipFileNames.addSingleWord( decoded,
                                           entry.localHeaderOffset );

--- a/src/language.cc
+++ b/src/language.cc
@@ -410,7 +410,7 @@ BabylonLang getBabylonLangByIndex( int index )
 
 quint32 findBlgLangIDByEnglishName( gd::wstring const & lang )
 {
-  const QString enName = gd::toQString( lang );
+  QString enName = QString::fromStdU32String( lang );
   for ( const auto & idx : BabylonDb ) {
     if ( QString::compare( idx.englishName, enName, Qt::CaseInsensitive ) == 0 )
       return idx.id;

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -169,7 +169,7 @@ public:
       nextChar += consumed;
       left -= consumed;
     }
-    normalizedString = gd::toQString( normText );
+    normalizedString = QString::fromStdU32String( normText );
   }
 };
 /// End of DiacriticsHandler class
@@ -2450,7 +2450,7 @@ void ArticleView::highlightFTSResults()
       bool ignoreDiacritics = Utils::Url::hasQueryItem( url, "ignore_diacritics" );
 
       if( ignoreDiacritics )
-        regString = gd::toQString( Folding::applyDiacriticsOnly( gd::toWString( regString ) ) );
+        regString = QString::fromStdU32String( Folding::applyDiacriticsOnly( gd::toWString( regString ) ) );
       else
         regString = regString.remove( AccentMarkHandler::accentMark() );
 

--- a/src/wordfinder.cc
+++ b/src/wordfinder.cc
@@ -495,7 +495,7 @@ void WordFinder::updateResults()
     //GD_DPRINTF( "%d: %ls\n", i->second, i->first.c_str() );
 
     if ( searchResults.size() < maxSearchResults )
-      searchResults.push_back( std::pair< QString, bool >( gd::toQString( i->word ), i->wasSuggested ) );
+      searchResults.push_back( std::pair< QString, bool >( QString::fromStdU32String( i->word ), i->wasSuggested ) );
     else
       break;
   }


### PR DESCRIPTION
there are many string conversion in the system .some of them can be avoided .

- [x] pave the way to simplify string type conversion
- [x] remove unnecessary string type conversion , this seems a great amout of work,  should be commit with gradual commit
This seems too much work and can not figured out in one PR.

---------

method toWString
https://github.com/xiaoyifang/goldendict-ng/blob/3ff6b6a8eeda63a635d143ce7677f974708948c3/wstring_qt.cc#L11-L24

The above implementation was introduced in eaa62e69a0d579f968f355792477f708783642dd  to fix CJK character index issue.The fix is ok ,but as toWString() is used in too many places, the affected range is too wide. Actually only two parts of the code places need this fix.  
- when write word to index (index file is \0 sensitive , one more \0 character will make index can not work as expected)
- when query word from the index,the queryed word need this method.

All other places  can be simply replaced with toStd32String().More over,the `toWString()` will cause misunderstanding and confusion when compared to QString toStd32String . Make the further improvement difficult.


--------
