### PR TITLE
fix: when input word in translateline and press Enter

### DIFF
--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -818,10 +818,10 @@ bool ArticleView::eventFilter( QObject * obj, QEvent * ev )
     if( handled )
     {
       if( result == Gestures::ZOOM_IN )
-        zoomIn();
+        emit zoomIn();
       else
       if( result == Gestures::ZOOM_OUT )
-        zoomOut();
+        emit zoomOut();
       else
       if( result == Gestures::SWIPE_LEFT )
         back();
@@ -881,7 +881,7 @@ bool ArticleView::eventFilter( QObject * obj, QEvent * ev )
       }
     }
     else
-    if ( ev->type() == QEvent::KeyPress || ev->type ()==QEvent::ShortcutOverride)
+    if ( ev->type() == QEvent::KeyPress )
     {
       QKeyEvent * keyEvent = static_cast< QKeyEvent * >( ev );
 


### PR DESCRIPTION
can not type word directly again.

fix:#185

the fix has a side-effect ,  for example, in the history panel , press `s` will be redirect to translateline inputbox.
should this be respected and navigate through the history panel.
Though the above side-effect can be fix,what's your opinion from user perspective @itkind