### PR TITLE
Reduce include dependency on `mainwindow.hh`

### DIFF
--- a/src/fulltextsearch.cc
+++ b/src/fulltextsearch.cc
@@ -4,11 +4,9 @@
 #include "fulltextsearch.hh"
 #include "ftshelpers.hh"
 #include "gddebug.hh"
-#include "mainwindow.hh"
 #include "utils.hh"
 
 #include <QThreadPool>
-#include <QIntValidator>
 #include <QMessageBox>
 #include <qalgorithms.h>
 
@@ -334,8 +332,12 @@ FullTextSearchDialog::FullTextSearchDialog( QWidget * parent,
   if( delegate )
     ui.headwordsView->setItemDelegate( delegate );
 
-  ui.searchLine->setText( static_cast< MainWindow * >( parent )->getTranslateLineText() );
   ui.searchLine->selectAll();
+}
+
+void FullTextSearchDialog::setSearchText( const QString & text )
+{
+  ui.searchLine->setText( text );
 }
 
 FullTextSearchDialog::~FullTextSearchDialog()

--- a/src/fulltextsearch.hh
+++ b/src/fulltextsearch.hh
@@ -213,6 +213,8 @@ public:
                         FtsIndexing & ftsidx );
   virtual ~FullTextSearchDialog();
 
+  void setSearchText( const QString & text );
+
   void setCurrentGroup( unsigned group_ )
   { group = group_; updateDictionaries(); }
 

--- a/src/ui/dictheadwords.cc
+++ b/src/ui/dictheadwords.cc
@@ -3,7 +3,6 @@
 
 #include "dictheadwords.hh"
 #include "gddebug.hh"
-#include "mainwindow.hh"
 
 #include <QRegExp>
 #if (QT_VERSION >= QT_VERSION_CHECK(6,0,0))

--- a/src/ui/editdictionaries.cc
+++ b/src/ui/editdictionaries.cc
@@ -4,7 +4,6 @@
 #include "editdictionaries.hh"
 #include "dict/loaddictionaries.hh"
 #include "dictinfo.hh"
-#include "mainwindow.hh"
 #include "utils.hh"
 #include <QMessageBox>
 

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -4398,6 +4398,8 @@ void MainWindow::showFullTextSearchDialog()
   if( !ftsDlg )
   {
     ftsDlg = new FTS::FullTextSearchDialog( this, cfg, dictionaries, groupInstances, ftsIndexing );
+    ftsDlg->setSearchText( translateLine->text() );
+
     addGlobalActionsToDialog( ftsDlg );
     addGroupComboBoxActionsToDialog( ftsDlg, groupList );
 

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -57,9 +57,6 @@ public:
 
   virtual void commitData( QSessionManager & );
 
-  QString getTranslateLineText() const
-  { return translateLine->text(); }
-
   /// Set group for main/popup window
   void setGroupByName( QString const & name, bool main_window );
 


### PR DESCRIPTION
Reduce compile time,

`editdictionaries.cc` and `dictheadwords.cc` doesn't need it

`fulltextsearch.cc` has a useless `static_cast<Mainwindow*>`

# test

Type a word on search box -> Open Full text search dialog, the word is automatically on the dialog's search box.