### PR TITLE
two levels of group names for "Auto group by folder"

### DIFF
--- a/website/docs/manage_groups.md
+++ b/website/docs/manage_groups.md
@@ -36,3 +36,19 @@ For example, the structure below will be auto grouped into two groups:
         ├── Wikipedia_ru.slob
         └── Wikipedia.zim
 ```
+
+Note that if two groups share the same name but in different folder, then upper level's folder name will be prepended with group name. The Example below will be grouped into `epistularum/Japanese` and `Mastameta/Japanese`.
+
+More levels of folder nesting are not supported.
+
+```
+.
+├─epistularum
+│   └─Japanese   <- Group
+│       └─DictA  <- Dict Files's container folder
+|          └─ DictA Files
+├─Mastameta
+│   └─Japanese   <- Group
+|       └─DictB  <- Dict Files's container folder
+|          └─ DictB Files  
+```


### PR DESCRIPTION
fix https://forum.freemdict.com/t/topic/20678/7

New code will check if `container folder's dirname()` (aka groupName) has duplications. If yes, then set dirNeedPrepend to true.

When inserting paths to groupToDicts, two levels of names (like `epistularum/japanese`) will be inserted.

---

This structure will be grouped into `john/english` and `tomy/english` [test_autoFolderGrou.zip](https://github.com/xiaoyifang/goldendict-ng/files/11330251/test_autoFolderGrou.zip)
```
.
├── john
│   └── english
│       └── a&b
│           ├── a.dsl
│           └── b.dsl
└── tomy
    └── english
        └── c
            └── c.dsl
```

---

The code is not recursive, it does not work with more levels of nesting :sweat_smile:

I added a note that further nesting is not supported. Two levels should cover 99% of use cases.

