### PR TITLE
Add `dict://` handler to linux

### DIFF
--- a/redist/org.goldendict.GoldenDict.desktop
+++ b/redist/org.goldendict.GoldenDict.desktop
@@ -7,4 +7,4 @@ GenericName=Multiformat Dictionary
 Comment=A feature-rich dictionary lookup program
 Icon=goldendict
 Exec=goldendict %u
-MimeType=x-scheme-handler/goldendict
+MimeType=x-scheme-handler/goldendict;x-scheme-handler/dict;

--- a/src/main.cc
+++ b/src/main.cc
@@ -175,8 +175,8 @@ void processCommandLine( QCoreApplication * app, GDOptions * result)
     result->word = posArgs.at( 0 );
 
 #if defined( Q_OS_LINUX ) || defined( Q_OS_WIN )
-    // handle url scheme like "goldendict://" on windows
-    result->word.remove( "goldendict://" );
+    // handle url scheme like "goldendict://" or "dict://" on windows/linux
+    result->word.remove( 0, result->word.indexOf( "://" ) + 3 );
     // In microsoft Words, the / will be automatically appended
     if ( result->word.endsWith( "/" ) ) {
       result->word.chop( 1 );


### PR DESCRIPTION
fix https://github.com/goldendict/goldendict/pull/1624#issuecomment-1525586803

macOS' built-in dictionary app can handle `dict://`, a lot of scripts/apps just use it.

By adding this, those scripts will be reusable without trouble.

# test

Install, then `sudo update-desktop-database` -> `xdg-open dict://word` 