### PR TITLE
Preserve old group selection after editDictionaries

### DIFF
--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -307,9 +307,15 @@ void ScanPopup::refresh() {
   // it, we disconnect it while we're clearing and filling back groups.
   disconnect( ui.groupList, &GroupComboBox::currentIndexChanged,
     this, &ScanPopup::currentGroupChanged );
+
+  auto OldGroupID = ui.groupList->getCurrentGroup();
+
+  // repopulate
   ui.groupList->clear();
-  ui.groupList->fill(groups);
-  ui.groupList->setCurrentGroup(0); // user edited group list, force reset to default
+  ui.groupList->fill( groups );
+
+  ui.groupList->setCurrentGroup( OldGroupID ); // This does nothing if OldGroupID doesn't exist;
+
   ui.groupList->setVisible(!cfg.groups.empty());
 
   updateDictionaryBar();


### PR DESCRIPTION
fix: https://forum.freemdict.com/t/topic/11495/2272

The `ui.groupList->getCurrentGroup()` will obtain group's id
The `setCurrentGroup` will loop through groups and compare that id.

### Tests

* have some groups, open editDictioanries dialog -> add a new group -> close -> scanpoup's group selection isn't changed
* have some groups -> select one -> open editDictioanries -> delete the selected group -> close -> program won't crash, and it will up to Qt decide which one will be selected (not superisingly, the first one :sweat_smile: )
* open editDictiaonries -> delete all groups
* open editDictionaries -> rename group -> still the same one selected even after rename