### PR TITLE
Convert navPronounce connect to new syntax

### DIFF
--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -233,8 +233,9 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   navPronounce->setEnabled( false );
   navToolbar->widgetForAction( navPronounce )->setObjectName( "soundButton" );
 
-  connect( navPronounce, SIGNAL( triggered() ),
-           this, SLOT( pronounce() ) );
+  connect( navPronounce, &QAction::triggered, [ this ]() {
+    getCurrentArticleView()->playSound();
+  } );
 
   // zooming
   // named separator (to be able to hide it via CSS)
@@ -1910,8 +1911,9 @@ void MainWindow::pageLoaded( ArticleView * view )
 
   updatePronounceAvailability();
 
-  if ( cfg.preferences.pronounceOnLoadMain )
-    pronounce( view );
+  if ( cfg.preferences.pronounceOnLoadMain && view != nullptr ) {
+    view->playSound();
+  }
 
   //updateFoundInDictsList();
 }
@@ -1968,14 +1970,6 @@ void MainWindow::dictionaryBarToggled( bool )
 
   updateDictionaryBar(); // Updates dictionary bar contents if it's shown
   applyMutedDictionariesState(); // Visibility change affects searches and results
-}
-
-void MainWindow::pronounce( ArticleView * view )
-{
-  if ( view )
-    view->playSound();
-  else
-    getCurrentArticleView()->playSound();
 }
 
 void MainWindow::showDictsPane( )

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -329,11 +329,6 @@ private slots:
 
   void dictionaryBarToggled( bool checked );
 
-  /// Pronounces the currently displayed word by playing its first audio
-  /// reference, if it has any.
-  /// If view is 0, the operation is done for the currently open tab.
-  void pronounce( ArticleView * view = 0 );
-
   void zoomin();
   void zoomout();
   void unzoom();


### PR DESCRIPTION
This is 5th PR that converts the remaining SIGNAL/SLOT to the new syntax.

They cannot be automatically converted mostly because of type mismatches.

![image](https://user-images.githubusercontent.com/20123683/235292014-dabfddfb-14d0-4f07-940c-928dd73e332f.png)
