### PR TITLE
`metadata.cc` & `metadata.hh`

### DIFF
--- a/goldendict.pro
+++ b/goldendict.pro
@@ -363,6 +363,7 @@ HEADERS += \
     src/keyboardstate.hh \
     src/langcoder.hh \
     src/language.hh \
+    src/metadata.hh \
     src/multimediaaudioplayer.hh \
     src/parsecmdline.hh \
     src/resourceschemehandler.hh \
@@ -485,6 +486,7 @@ SOURCES += \
     src/langcoder.cc \
     src/language.cc \
     src/main.cc \
+    src/metadata.cc \
     src/multimediaaudioplayer.cc \
     src/parsecmdline.cc \
     src/resourceschemehandler.cc \

--- a/src/metadata.cc
+++ b/src/metadata.cc
@@ -1,0 +1,33 @@
+#include "metadata.hh"
+#include "toml.hpp"
+#include <QDebug>
+
+std::optional< Metadata::result > Metadata::load( std::string_view filepath )
+{
+  // by default, the optional will be initialized as std::nullopt
+  Metadata::result result{};
+  toml::table tbl;
+
+  try {
+    tbl = toml::parse_file( filepath );
+  }
+  catch ( toml::parse_error & e ) {
+    qWarning()<< "Failed to load metadata: " << QString::fromUtf8(filepath.data(),filepath.size())
+              << "Reason:" << e.what();
+
+    return std::nullopt;
+  }
+
+  if ( toml::array * categories = tbl.get_as< toml::array >( "categories" ) ) {
+    // result.categories is an optional, it exists, but the vector does not, so we have to create one here
+    result.categories.emplace();
+    for ( auto & el : *categories ) {
+      if ( el.is_string() ) {
+        result.categories.value().emplace_back( std::move( *el.value_exact< std::string >() ) );
+      }
+    }
+  }
+
+  result.name = tbl[ "metadata" ][ "name" ].value_exact< std::string >();
+  return result;
+}

--- a/src/metadata.hh
+++ b/src/metadata.hh
@@ -1,0 +1,19 @@
+#pragma once
+#include <QStringView>
+#include <optional>
+#include <vector>
+
+namespace Metadata {
+
+/**
+ * Represent the metadata.toml beside the dictionary files
+ */
+struct result
+{
+  std::optional< std::vector< std::string > > categories;
+  std::optional< std::string > name;
+};
+
+[[nodiscard]] std::optional< Metadata::result > load( std::string_view filepath );
+
+} // namespace Metadata

--- a/website/docs/manage_groups.md
+++ b/website/docs/manage_groups.md
@@ -80,7 +80,7 @@ The `metadata.toml` should be placed beside dictionary files. One `metadata.toml
 The metadata file uses [TOML](https://toml.io) format.
 
 ```toml
-category = [ "English", "Russian", "Chinese" ]
+categories = [ "English", "Russian", "Chinese" ]
 
 # the following fields have not supported yet.
 [metadata]
@@ -108,12 +108,12 @@ For example,
 
 The content of the metadata `(A)` is
 ```toml
-category = ["en-zh", "汉英词典"]
+categories = ["en-zh", "汉英词典"]
 ```
 
 The content of the metadata `(B)` is
 ```toml
-category = ["图片词典", "en-zh", "汉英词典"]
+categories = ["图片词典", "en-zh", "汉英词典"]
 ```
 
 The structure above will be auto grouped into three groups:


### PR DESCRIPTION
The `struct metadata` itself and all its members are defined with `std::optinoal`.

To check their existence, we can just `if(metadata)`/`if(metadata->name)` or `metadata.has_value()`

---

`toml.hpp` is used with discipline to avoid compile time increases: Use it only in `metadata.cc` as an implementation detail and does not include it in `metadata.hh`.

---

`category` is changed to `categories` because a plural seems more natural here:

![image](https://user-images.githubusercontent.com/20123683/235322393-b3c6a726-c958-4b2e-b8ef-61771596d3dd.png)
https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/#build-time-dependencies

---

It also includes getting the name from
```
categories = ["1", "2"]

[metadata]
name = "new name"
```