### PR TITLE
CMake: split windows & unix library finding & linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,11 @@ option(WITH_XAPIAN "enable Xapian support" ON)
 
 include(FeatureSummary)
 
-project(goldendict
-        VERSION 22.11.20
+project(goldendict-ng
+        VERSION 23.05.01
         LANGUAGES CXX C)
+
+set(GOLDENDICT "goldendict") # binary/executable name
 
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOMOC ON)
@@ -19,13 +21,6 @@ set(CMAKE_AUTORCC ON)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-if (APPLE)
-    if (WITH_EPWING_SUPPORT)
-        add_subdirectory(thirdparty/eb)
-    endif ()
-    include_directories(/usr/local/include /opt/homebrew/include)
-endif ()
 
 #### Importing Libraries
 
@@ -40,53 +35,6 @@ find_package(Qt6 REQUIRED COMPONENTS
         Xml
         TextToSpeech
         )
-
-
-if (APPLE)
-    find_library(CARBON_LIBRARY Carbon REQUIRED)
-endif ()
-
-if (UNIX)
-    # Provided by Cmake
-    find_package(ZLIB REQUIRED)
-    find_package(BZip2 REQUIRED)
-    find_package(Iconv REQUIRED)
-    if (WITH_XAPIAN)
-        find_package(Xapian REQUIRED) # https://github.com/xapian/xapian/tree/master/xapian-core/cmake
-    endif ()
-
-    # PkgConfig only packages
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(PKGCONFIG_DEPS IMPORTED_TARGET
-            hunspell
-            lzo2
-            opencc
-            vorbis # .ogg
-            vorbisfile
-            liblzma
-            libzstd
-            )
-    if (WITH_FFMPEG_PLAYER)
-        pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET
-                libavcodec
-                libavformat
-                libavutil
-                libswresample
-                )
-    endif ()
-endif ()
-
-if (LINUX)
-    find_package(X11 REQUIRED)
-    pkg_check_modules(LIBXTST IMPORTED_TARGET xtst)
-
-    if (WITH_EPWING_SUPPORT)
-        add_subdirectory(thirdparty/eb EXCLUDE_FROM_ALL)
-    endif ()
-    # add_library(libeb SHARED IMPORTED)
-    # set_target_properties(libeb PROPERTIES IMPORTED_LOCATION /usr/lib/libeb.so)
-    # set_target_properties(libeb PROPERTIES INCLUDE_DIRECTORIES /usr/include/)
-endif ()
 
 #### Compile time files and preprocessor flags
 
@@ -122,8 +70,9 @@ set(QSINGLEAPP_SOURCE_FILES
         thirdparty/qtsingleapplication/src/qtsingleapplication.h
         )
 
-qt_add_executable(${CMAKE_PROJECT_NAME}
-        MANUAL_FINALIZATION
+qt_add_executable(${GOLDENDICT} MANUAL_FINALIZATION)
+
+target_sources(${GOLDENDICT} PUBLIC
         icons/flags.qrc
         resources.qrc
         src/scripts/scripts.qrc
@@ -132,13 +81,12 @@ qt_add_executable(${CMAKE_PROJECT_NAME}
         ${MACOS_SOURCE_FILES}
         ${QSINGLEAPP_SOURCE_FILES})
 
-
 ### Common parts amount all platforms
 
-# hack -> this string will be compared with another string, thus having surrounding " "
+# Note: used as c++ string thus need surrounding " "
 add_compile_definitions(PROGRAM_VERSION="${PROJECT_VERSION}")
 
-target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+target_link_libraries(${GOLDENDICT} PRIVATE
         Qt6::Xml
         Qt6::Concurrent
         Qt6::Core5Compat
@@ -149,111 +97,53 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
         Qt6::TextToSpeech
         )
 
-target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC
-        CMAKE_USED_HACK  # temporal hack to avoid breaking qmake build
-        USE_ICONV
-        MAKE_ZIM_SUPPORT
-        MAKE_QTMULTIMEDIA_PLAYER
-        MAKE_CHINESE_CONVERSION_SUPPORT)
 
-target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC
+target_include_directories(${GOLDENDICT} PUBLIC
         ${PROJECT_SOURCE_DIR}/thirdparty/qtsingleapplication/src
         ${PROJECT_SOURCE_DIR}/src/
         ${PROJECT_SOURCE_DIR}/src/common
         ${PROJECT_SOURCE_DIR}/src/dict
         ${PROJECT_SOURCE_DIR}/src/ui
         ${PROJECT_SOURCE_DIR}/thirdparty/tomlplusplus
-)
+        )
 
+#### Compile definitions
+
+target_compile_definitions(${GOLDENDICT} PUBLIC
+        CMAKE_USED_HACK  # temporal hack to avoid breaking qmake build
+        USE_ICONV
+        MAKE_ZIM_SUPPORT
+        MAKE_QTMULTIMEDIA_PLAYER
+        MAKE_CHINESE_CONVERSION_SUPPORT
+        )
 
 if (WITH_FFMPEG_PLAYER)
-    target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC MAKE_FFMPEG_PLAYER)
-    if (UNIX)
-        target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE PkgConfig::FFMPEG)
-    endif ()
+    target_compile_definitions(${GOLDENDICT} PUBLIC MAKE_FFMPEG_PLAYER)
 endif ()
 
 
 if (NOT WITH_EPWING_SUPPORT)
-    target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC NO_EPWING_SUPPORT)
+    target_compile_definitions(${GOLDENDICT} PUBLIC NO_EPWING_SUPPORT)
 endif ()
 
 
 if (WITH_XAPIAN)
-    target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC USE_XAPIAN)
-
-    if (UNIX)
-        target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE ${XAPIAN_LIBRARIES})
-    endif ()
+    target_compile_definitions(${GOLDENDICT} PUBLIC USE_XAPIAN)
 endif ()
 
+#### libraries linking && includes for Win or Unix
 
-### Parts where different platforms disagree
-
-if (LINUX)
-    target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC HAVE_X11)
-    target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE X11 PkgConfig::LIBXTST)
-
-    if (WITH_EPWING_SUPPORT)
-        target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE eb)
-    endif ()
-
+if (WIN32)
+    include(CMake_Win.cmake)
+else ()
+    include(CMake_Unix.cmake)
 endif ()
 
-if (MSVC)
-    target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC
-            __WIN32
-            NO_EPWING_SUPPORT
-            INCLUDE_LIBRARY_PATH
-            )
+#### add translations
 
-    target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC
-            ${CMAKE_SOURCE_DIR}/winlibs/include/
-            )
-
-    set_property(TARGET ${CMAKE_PROJECT_NAME} PROPERTY
-            MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
-
-    file(GLOB WINLIBS_FILES "${CMAKE_SOURCE_DIR}/winlibs/lib/msvc/*.lib")
-    foreach (A_WIN_LIB ${WINLIBS_FILES})
-        target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE ${A_WIN_LIB})
-    endforeach ()
-
-endif ()
-
-
-if (APPLE)
-    target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE ${CARBON_LIBRARY})
-
-    if (WITH_EPWING_SUPPORT)
-        target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE eb)
-    endif ()
-endif ()
-
-if (UNIX)
-    target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
-            ${PROJECT_SOURCE_DIR}/thirdparty)
-
-    target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
-            # pkg-config packages need manually link
-            PkgConfig::PKGCONFIG_DEPS
-            BZip2::BZip2
-            ZLIB::ZLIB #hidden requirement of dsl_details.cc and more?
-            Iconv::Iconv
-            )
-endif ()
-
-set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
-        MACOSX_BUNDLE_GUI_IDENTIFIER my.example.com
-        MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
-        MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
-        MACOSX_BUNDLE TRUE
-        # WIN32_EXECUTABLE TRUE # TODO: this will prevent any qDebug() from showing up.
-        )
-
-install(TARGETS ${CMAKE_PROJECT_NAME}
+install(TARGETS ${GOLDENDICT}
         BUNDLE DESTINATION .
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/${GOLDENDICT})
 
 # include all *ts files under locale
 file(GLOB TRANS_FILES "locale/*.ts")
@@ -263,12 +153,21 @@ set_source_files_properties(${TRANS_FILES}
         PROPERTIES OUTPUT_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/locale")
 
 # a wrapper over qt_add_lupdate and  qt_add_lrelease
-qt_add_translations(${CMAKE_PROJECT_NAME} TS_FILES ${TRANS_FILES}
+qt_add_translations(${GOLDENDICT} TS_FILES ${TRANS_FILES}
         QM_FILES_OUTPUT_VARIABLE qm_files)
 
-qt_finalize_target(${CMAKE_PROJECT_NAME})
+#### installation
 
-if (LINUX)
+if (APPLE)
+    set_target_properties(${GOLDENDICT} PROPERTIES
+            MACOSX_BUNDLE_GUI_IDENTIFIER my.example.com
+            MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
+            MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+            MACOSX_BUNDLE TRUE
+            )
+endif ()
+
+if (LINUX OR BSD)
     install(FILES ${CMAKE_SOURCE_DIR}/redist/org.goldendict.GoldenDict.desktop DESTINATION share/applications)
     install(FILES ${CMAKE_SOURCE_DIR}/redist/org.goldendict.GoldenDict.metainfo.xml DESTINATION share/metainfo)
 
@@ -277,13 +176,6 @@ if (LINUX)
     install(FILES ${qm_files} DESTINATION share/goldendict/locale)
 endif ()
 
-# Copy .dlls to output dir
-if (MSVC)
-    file(GLOB DLL_FILES LIST_DIRECTORIES false "${CMAKE_SOURCE_DIR}/winlibs/lib/msvc/*.dll")
-    foreach (A_DLL_FILE ${DLL_FILES})
-        get_filename_component(TEMP_VAR_HOLDING_DLL_FILENAME ${A_DLL_FILE} NAME)
-        configure_file("${A_DLL_FILE}" "${CMAKE_BINARY_DIR}/${TEMP_VAR_HOLDING_DLL_FILENAME}" COPYONLY)
-    endforeach ()
-endif ()
+qt_finalize_target(${GOLDENDICT})
 
 feature_summary(WHAT ALL DESCRIPTION "Build configuration:")

--- a/CMake_Unix.cmake
+++ b/CMake_Unix.cmake
@@ -1,0 +1,73 @@
+#### Include Paths
+
+if (APPLE)
+    # old & new homebrew's include paths
+    target_include_directories(${GOLDENDICT} PRIVATE /usr/local/include /opt/homebrew/include)
+endif ()
+
+target_include_directories(${GOLDENDICT} PRIVATE
+        ${PROJECT_SOURCE_DIR}/thirdparty)
+
+#### Special Platform supporting libraries
+
+if (LINUX OR BSD)
+    find_package(X11 REQUIRED)
+    pkg_check_modules(LIBXTST IMPORTED_TARGET xtst)
+    target_compile_definitions(${GOLDENDICT} PUBLIC HAVE_X11)
+    target_link_libraries(${GOLDENDICT} PRIVATE X11 PkgConfig::LIBXTST)
+endif ()
+
+if (APPLE)
+    find_library(CARBON_LIBRARY Carbon REQUIRED)
+    target_link_libraries(${GOLDENDICT} PRIVATE ${CARBON_LIBRARY})
+endif ()
+
+##### Finding packages from package manager
+
+
+find_package(PkgConfig REQUIRED)
+# Provided by Cmake
+find_package(ZLIB REQUIRED)
+find_package(BZip2 REQUIRED)
+find_package(Iconv REQUIRED)
+
+
+# Consider all PkgConfig dependencies as one
+pkg_check_modules(PKGCONFIG_DEPS IMPORTED_TARGET
+        hunspell
+        lzo2
+        opencc
+        vorbis # .ogg
+        vorbisfile
+        liblzma
+        libzstd
+        )
+
+target_link_libraries(${GOLDENDICT} PRIVATE
+        # pkg-config packages need manually link
+        PkgConfig::PKGCONFIG_DEPS
+        BZip2::BZip2
+        ZLIB::ZLIB #hidden requirement of dsl_details.cc and more?
+        Iconv::Iconv
+        )
+
+if (WITH_FFMPEG_PLAYER)
+    pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET
+            libavcodec
+            libavformat
+            libavutil
+            libswresample
+            )
+    target_link_libraries(${GOLDENDICT} PRIVATE PkgConfig::FFMPEG)
+endif ()
+
+if (WITH_XAPIAN)
+    find_package(Xapian REQUIRED) # https://github.com/xapian/xapian/tree/master/xapian-core/cmake
+    target_link_libraries(${GOLDENDICT} PRIVATE ${XAPIAN_LIBRARIES})
+endif ()
+
+if (WITH_EPWING_SUPPORT)
+    add_subdirectory(thirdparty/eb)
+    target_link_libraries(${GOLDENDICT} PRIVATE eb)
+endif ()
+

--- a/CMake_Win.cmake
+++ b/CMake_Win.cmake
@@ -1,0 +1,26 @@
+target_compile_definitions(${GOLDENDICT} PUBLIC
+        __WIN32
+        INCLUDE_LIBRARY_PATH # temporal hack to let singleapplication compile
+        )
+
+target_include_directories(${GOLDENDICT} PUBLIC
+        ${CMAKE_SOURCE_DIR}/winlibs/include/
+        )
+
+set_property(TARGET ${BIN_NAME} PROPERTY
+        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+
+file(GLOB WINLIBS_FILES "${CMAKE_SOURCE_DIR}/winlibs/lib/msvc/*.lib")
+foreach (A_WIN_LIB ${WINLIBS_FILES})
+    target_link_libraries(${GOLDENDICT} PRIVATE ${A_WIN_LIB})
+endforeach ()
+
+# Copy .dlls to output dir
+
+file(GLOB DLL_FILES LIST_DIRECTORIES false "${CMAKE_SOURCE_DIR}/winlibs/lib/msvc/*.dll")
+foreach (A_DLL_FILE ${DLL_FILES})
+    get_filename_component(TEMP_VAR_HOLDING_DLL_FILENAME ${A_DLL_FILE} NAME)
+    configure_file("${A_DLL_FILE}" "${CMAKE_BINARY_DIR}/${TEMP_VAR_HOLDING_DLL_FILENAME}" COPYONLY)
+endforeach ()
+
+


### PR DESCRIPTION
They have almost nothing in common, split win & unix make the build much more cleaner.

The Linux also switched to `thirdparty/eb`, which will generate a `libeb.so` in the output directory.

The linkage is 

```
~/src/goldendict/cmake-build-debug  
> ldd ./goldendict
        libeb.so => /home/slbtty/src/goldendict/cmake-build-debug/thirdparty/eb/libeb.so (0x00007f7f7e0df000)
```

As described here 

https://github.com/xiaoyifang/simple-eb/blob/221bc9c831066bf82710be296f28ffaf0ecd360d/CMakeLists.txt#L88
![image](https://user-images.githubusercontent.com/20123683/236447923-9c85d132-1156-4263-84b5-12759d73b075.png)

The `libeb.so` will be installed to `/usr/lib/libeb.so`

---

I think we should just mark `eb` as a static library so that we don't need to care about how to install this extra `.so`.
