### PR TITLE
add vcpkg support on Windows

### DIFF
--- a/.github/workflows/windows-6.x-xapian.yml
+++ b/.github/workflows/windows-6.x-xapian.yml
@@ -82,6 +82,21 @@ jobs:
           echo "$previousTag">version.txt
           cat version.txt
 
+      - name: vcpkg install
+        shell: powershell
+        run: |   
+          git clone --depth 1 https://github.com/microsoft/vcpkg.git
+          .\vcpkg\bootstrap-vcpkg.bat
+          # .\vcpkg\vcpkg.exe install  ffmpeg[core,avcodec,avformat,mp3lame,opus,speex,swresample,vorbis,fdk-aac,gpl]  --triplet=x64-windows-release
+          .\vcpkg\vcpkg.exe install speex  zlib libiconv  xapian hunspell liblzma openssl lzo cryptopp opencc libvorbis zstd bzip2 --triplet=x64-windows-release
+
+      - name: copy vcpkg packages into winlibs
+        shell: bash
+        run: |   
+          ls -al vcpkg/installed/x64-windows-release/
+          cp -R vcpkg/installed/x64-windows-release/*  winlibs
+          ls -al winlibs/lib
+
       # # msvc编译
       - uses: ilammy/msvc-dev-cmd@v1
       #   with:
@@ -90,7 +105,7 @@ jobs:
         id: build
         shell: cmd
         run: |
-          qmake "CONFIG+=zim_support" CONFIG+=release CONFIG+=use_xapian CONFIG+=use_iconv
+          qmake "CONFIG+=zim_support" CONFIG+=release CONFIG+=use_xapian CONFIG+=use_iconv CONFIG+=no_epwing_support CONFIG+=no_ffmpeg_player
           nmake
 
           echo winSdkDir=%WindowsSdkDir% >> %GITHUB_ENV%

--- a/goldendict.pro
+++ b/goldendict.pro
@@ -126,7 +126,8 @@ win32 {
         contains(QMAKE_TARGET.arch, x86_64) {
             DEFINES += NOMINMAX __WIN64
         }
-        LIBS += -L$${PWD}/winlibs/lib/msvc
+        #LIBS += -L$${PWD}/winlibs/lib/msvc
+        LIBS += -L$${PWD}/winlibs/lib
         # silence the warning C4290: C++ exception specification ignored
         QMAKE_CXXFLAGS += /wd4290 /Zc:__cplusplus /std:c++17 /permissive- 
         # QMAKE_LFLAGS_RELEASE += /OPT:REF /OPT:ICF


### PR DESCRIPTION
possible solution:
1. add vcpkg as a submodule 
this will make the library path easy to include in the qmake 
2. remove packages from winlib/msvc