### PR TITLE
fix:startdict parse html incorrect

### DIFF
--- a/src/btreeidx.hh
+++ b/src/btreeidx.hh
@@ -238,7 +238,7 @@ public:
 
   virtual void findMatches();
 
-  void run(); // Run from another thread by BtreeWordSearchRunnable
+  void run();
 
   virtual void cancel()
   {

--- a/src/common/globalregex.hh
+++ b/src/common/globalregex.hh
@@ -59,6 +59,9 @@ namespace Html {
 const static QRegularExpression startDivTag( R"(<div[\s>])" );
 const static QRegularExpression htmlEntity( R"(&(?:#\d+|#[xX][\da-fA-F]+|[0-9a-zA-Z]+);)" );
 
+// exclude <br/> <hr/>
+const static QRegularExpression emptyXmlTag(R"(<(?!(br|hr)\b)([^/ >]*)\s*/>)");
+
 bool containHtmlEntity( std::string const & text );
 }
 

--- a/src/dict/aard.cc
+++ b/src/dict/aard.cc
@@ -663,7 +663,7 @@ public:
     } );
   }
 
-  void run(); // Run from another thread by DslArticleRequestRunnable
+  void run();
 
   void cancel() override
   {

--- a/src/dict/bgl.cc
+++ b/src/dict/bgl.cc
@@ -508,7 +508,7 @@ public:
     } );
   }
 
-  void run(); // Run from another thread by BglHeadwordsRequestRunnable
+  void run();
 
   void cancel() override
   {
@@ -631,7 +631,7 @@ public:
     } );
   }
 
-  void run(); // Run from another thread by BglArticleRequestRunnable
+  void run();
 
   void cancel() override
   {
@@ -902,7 +902,7 @@ public:
     } );
   }
 
-  void run(); // Run from another thread by BglResourceRequestRunnable
+  void run();
 
   void cancel() override
   {

--- a/src/dict/epwing.cc
+++ b/src/dict/epwing.cc
@@ -887,7 +887,7 @@ public:
     } );
   }
 
-  void run(); // Run from another thread by EpwingResourceRequestRunnable
+  void run();
 
   void cancel() override { isCancelled.ref(); }
 

--- a/src/dict/gls.cc
+++ b/src/dict/gls.cc
@@ -878,7 +878,7 @@ public:
     } );
   }
 
-  void run(); // Run from another thread by StardictHeadwordsRequestRunnable
+  void run();
 
   void cancel() override
   {
@@ -974,7 +974,7 @@ public:
     } );
   }
 
-  void run(); // Run from another thread by GlsArticleRequestRunnable
+  void run();
 
   void cancel() override
   {
@@ -1126,7 +1126,7 @@ public:
     } );
   }
 
-  void run(); // Run from another thread by GlsResourceRequestRunnable
+  void run();
 
   void cancel() override
   {

--- a/src/dict/hunspell.cc
+++ b/src/dict/hunspell.cc
@@ -204,7 +204,7 @@ public:
     } );
   }
 
-  void run(); // Run from another thread by HunspellArticleRequestRunnable
+  void run();
 
   void cancel() override
   {
@@ -343,7 +343,7 @@ public:
 
   }
 
-  void run(); // Run from another thread by HunspellHeadwordsRequestRunnable
+  void run();
 
   void cancel() override
   {
@@ -492,7 +492,7 @@ public:
     } );
   }
 
-  void run(); // Run from another thread by HunspellPrefixMatchRequestRunnable
+  void run();
 
   void cancel() override
   {

--- a/src/dict/sdict.cc
+++ b/src/dict/sdict.cc
@@ -504,7 +504,7 @@ public:
 
   }
 
-  void run(); // Run from another thread by DslArticleRequestRunnable
+  void run();
 
   void cancel() override
   {

--- a/src/dict/slob.cc
+++ b/src/dict/slob.cc
@@ -1329,7 +1329,7 @@ public:
     } );
   }
 
-  void run(); // Run from another thread by DslArticleRequestRunnable
+  void run();
 
   void cancel() override
   {
@@ -1491,7 +1491,7 @@ public:
       } );
   }
 
-  void run(); // Run from another thread by ZimResourceRequestRunnable
+  void run();
 
   void cancel() override
   {

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -1232,7 +1232,7 @@ public:
     } );
   }
 
-  void run(); // Run from another thread by StardictHeadwordsRequestRunnable
+  void run();
 
   void cancel() override
   {
@@ -1594,7 +1594,7 @@ public:
     } );
   }
 
-  void run(); // Run from another thread by StardictResourceRequestRunnable
+  void run();
 
   void cancel() override
   {

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -22,10 +22,8 @@
 #include <map>
 #include <set>
 #include <string>
-// msvc defines _WIN32 https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170
-// gcc also defines __WIN32, _WIN32, __WIN32__
-// todo: unify how windows are detected on headers
-#ifndef _WIN32
+
+#ifndef Q_OS_WIN
 #include <arpa/inet.h>
 #else
 #include <winsock.h>
@@ -94,7 +92,7 @@ struct Ifo
   string sametypesequence, dicttype, description;
   string copyright, author, email, website, date;
 
-  Ifo( File::Class & );
+  explicit Ifo( File::Class & );
 };
 
 enum
@@ -799,7 +797,7 @@ void StardictDictionary::pangoToHtml( QString & text )
           else if( style.compare( "font_style", Qt::CaseInsensitive ) == 0
                    || style.compare( "style", Qt::CaseInsensitive ) == 0)
             newSpan += QString( "font-style:" ) + styleRegex.cap( 2 ) + ";";
-          else if( style.compare( "weight", Qt::CaseInsensitive ) == 0
+          else if( style.compare( "font_weight", Qt::CaseInsensitive ) == 0
                    || style.compare( "weight", Qt::CaseInsensitive ) == 0)
           {
             QString str = styleRegex.cap( 2 );

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -16,7 +16,6 @@
 #include "indexedzip.hh"
 #include "tiff.hh"
 #include "ftshelpers.hh"
-#include "wstring_qt.hh"
 #include "audiolink.hh"
 
 #include <zlib.h>
@@ -176,17 +175,12 @@ public:
   inline quint32 getLangTo() const override
   { return idxHeader.langTo; }
 
-  sptr< Dictionary::WordSearchRequest > findHeadwordsForSynonym( wstring const & ) override
-    ;
+  sptr< Dictionary::WordSearchRequest > findHeadwordsForSynonym( wstring const & ) override;
 
-  sptr< Dictionary::DataRequest > getArticle( wstring const &,
-                                                      vector< wstring > const & alts,
-                                                      wstring const &,
-                                                      bool ignoreDiacritics ) override
-    ;
+  sptr< Dictionary::DataRequest >
+  getArticle( wstring const &, vector< wstring > const & alts, wstring const &, bool ignoreDiacritics ) override;
 
-  sptr< Dictionary::DataRequest > getResource( string const & name ) override
-    ;
+  sptr< Dictionary::DataRequest > getResource( string const & name ) override;
 
   QString const& getDescription() override;
 
@@ -953,7 +947,7 @@ void StardictDictionary::loadArticle( uint32_t address,
 
   char * ptr = articleBody;
 
-  if ( sameTypeSequence.size() )
+  if ( !sameTypeSequence.empty() )
   {
     /// The sequence is known, it's not stored in the article itself
     for( unsigned seq = 0; seq < sameTypeSequence.size(); ++seq )
@@ -1339,7 +1333,7 @@ public:
     } );
   }
 
-  void run(); // Run from another thread by StardictArticleRequestRunnable
+  void run();
 
   void cancel() override
   {

--- a/src/dict/xdxf.cc
+++ b/src/dict/xdxf.cc
@@ -467,7 +467,7 @@ public:
     } );
   }
 
-  void run(); // Run from another thread by XdxfArticleRequestRunnable
+  void run();
 
   void cancel() override
   {
@@ -963,7 +963,7 @@ public:
     } );
   }
 
-  void run(); // Run from another thread by XdxfResourceRequestRunnable
+  void run();
 
   void cancel() override
   {

--- a/src/dict/xdxf2html.cc
+++ b/src/dict/xdxf2html.cc
@@ -17,6 +17,8 @@
 
 #include <QRegularExpression>
 
+#include "globalregex.hh"
+
 namespace Xdxf2Html {
 
 static void fixLink( QDomElement & el, string const & dictId, const char *attrName )
@@ -69,8 +71,6 @@ string convert( string const & in, DICT_TYPE type, map < string, string > const 
                 Dictionary::Class *dictPtr,  IndexedZip * resourceZip,
                 bool isLogicalFormat, unsigned revisionNumber, QString * headword )
 {
-//  GD_DPRINTF( "Source>>>>>>>>>>: %s\n\n\n", in.c_str() );
-
   // Convert spaces after each end of line to &nbsp;s, and then each end of
   // line to a <br>
 
@@ -107,11 +107,6 @@ string convert( string const & in, DICT_TYPE type, map < string, string > const 
         afterEol = false;
     }
   }
-
-  // Strip "<nu />" tags - QDomDocument don't handle it correctly
-  string::size_type n;
-  while( ( n = inConverted.find( "<nu />" ) ) != string::npos )
-      inConverted.erase( n, 6 );
 
   // We build a dom representation of the given xml, then do some transforms
   QDomDocument dd;
@@ -703,9 +698,8 @@ string convert( string const & in, DICT_TYPE type, map < string, string > const 
     el.setAttribute( "class", "xdxf_rref" );
   }
 
-//  GD_DPRINTF( "Result>>>>>>>>>>: %s\n\n\n", dd.toByteArray( 0 ).data() );
-
-  return dd.toString( 1 ).remove('\n').remove( QRegularExpression( "<(b|i)/>" ) ).toUtf8().data();
+  //workaround,  the xml is not very suitable to process the html content.  such as <blockquote/> is valid in xml ,while invalid in html.
+  return dd.toString().remove( RX::Html::emptyXmlTag ).toUtf8().data();
 }
 
 }


### PR DESCRIPTION
related with #657 
fix https://github.com/goldendict/goldendict/issues/1634

This is a workaround (I just comment the workaround in detail 😄 )

Maybe in the future , this whole parse implementation can be replaced with some stream-based-token-process logic
or with a real html parser.