### PR TITLE
fix: phrase send from scanpopup should not escape again

### DIFF
--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -748,9 +748,9 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
     this, SLOT(editDictionaries(unsigned)),
     Qt::QueuedConnection);
 
-  connect( scanPopup, &ScanPopup::sendPhraseToMainWindow,
-    this,&MainWindow::phraseReceived,
-    Qt::QueuedConnection);
+  connect( scanPopup, &ScanPopup::sendPhraseToMainWindow, this, [ this ]( Config::InputPhrase const & phrase ) {
+    phraseReceived( phrase, WildcardsAreAlreadyEscaped );
+  } );
 
   connect( scanPopup, &ScanPopup::inspectSignal,this,&MainWindow::inspectElement );
   connect( scanPopup, &ScanPopup::forceAddWordToHistory, this, &MainWindow::forceAddWordToHistory );
@@ -3728,17 +3728,17 @@ ArticleView * MainWindow::getCurrentArticleView()
   return 0;
 }
 
-void MainWindow::phraseReceived( Config::InputPhrase const & phrase )
+void MainWindow::phraseReceived( Config::InputPhrase const & phrase, WildcardPolicy wildcardPolicy )
 {
   toggleMainWindow( true );
-  setTranslateBoxTextAndKeepSuffix( phrase.phrase, EscapeWildcards, NoPopupChange );
+  setTranslateBoxTextAndKeepSuffix( phrase.phrase, wildcardPolicy, NoPopupChange );
   translateBoxSuffix = phrase.punctuationSuffix;
   respondToTranslationRequest( phrase, false );
 }
 
 void MainWindow::wordReceived( const QString & word)
 {
-  phraseReceived( Config::InputPhrase::fromPhrase( word ) );
+  phraseReceived( Config::InputPhrase::fromPhrase( word ), EscapeWildcards );
 }
 
 void MainWindow::headwordReceived( const QString & word, const QString & ID )

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -60,11 +60,12 @@ public:
   /// Set group for main/popup window
   void setGroupByName( QString const & name, bool main_window );
 
+  enum WildcardPolicy { EscapeWildcards, WildcardsAreAlreadyEscaped };
 public slots:
 
   void messageFromAnotherInstanceReceived( QString const & );
   void showStatusBarMessage ( QString const &, int, QPixmap const & );
-  void phraseReceived( Config::InputPhrase const & );
+  void phraseReceived( Config::InputPhrase const &, WildcardPolicy );
   void wordReceived( QString const & );
   void headwordReceived( QString const &, QString const & );
   void headwordFromFavorites( QString const &, QString const & );
@@ -252,7 +253,6 @@ private:
   void updateSuggestionList();
   void updateSuggestionList( QString const & text );
 
-  enum WildcardPolicy { EscapeWildcards, WildcardsAreAlreadyEscaped };
   enum TranslateBoxPopup { NoPopupChange, EnablePopup, DisablePopup };
   void setTranslateBoxTextAndKeepSuffix( QString text, WildcardPolicy wildcardPolicy,
                                          TranslateBoxPopup popupAction );


### PR DESCRIPTION
fix #626