### PR TITLE
fix: selection triggered scanpopup too early

### DIFF
--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -286,7 +286,7 @@ ScanPopup::ScanPopup( QWidget * parent,
 
   // Use delay show to prevent multiple popups while selection in progress
   selectionDelayTimer.setSingleShot( true );
-  selectionDelayTimer.setInterval( 200 );
+  selectionDelayTimer.setInterval( 800 );
 
   connect( &selectionDelayTimer, &QTimer::timeout, this, &ScanPopup::translateWordFromSelection );
 #endif


### PR DESCRIPTION
on Ubuntu(Linux),the selection change event occured too often while the delayed time is a little small ,the result is that the popup will show up when users still selecting the text.  Increase the delayed time a little seems can solve this issue.

fix #629