### PR TITLE
opt: redirect the log to the current console

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -77,10 +77,10 @@ IndentCaseBlocks: false
 IndentGotoLabels: true
 IndentPPDirectives: BeforeHash
 IndentExternBlock: AfterExternBlock
-IndentRequiresClause: true
+# IndentRequiresClause: true
 IndentWidth: 2
 IndentWrappedFunctionNames: false
-InsertBraces: false
+# InsertBraces: false
 InsertTrailingCommas: None
 KeepEmptyLinesAtTheStartOfBlocks: true
 LambdaBodyIndentation: Signature
@@ -104,7 +104,7 @@ PPIndentWidth:   -1
 ReferenceAlignment: Pointer
 ReflowComments: false
 SortIncludes: Never
-RequiresClausePosition: OwnLine
+# RequiresClausePosition: OwnLine
 RemoveBracesLLVM: false
 SeparateDefinitionBlocks: Leave
 ShortNamespaceLines: 1

--- a/src/main.cc
+++ b/src/main.cc
@@ -17,7 +17,7 @@
 
 #ifdef Q_OS_WIN32
 #include <QtCore/qt_windows.h>
-#include <windows.h>
+  #include <windows.h>
 #endif
 
 #include "termination.hh"
@@ -234,10 +234,10 @@ int main( int argc, char ** argv )
 
 #ifdef Q_OS_WIN32
   // attach the new console to this application's process
-  if ( AttachConsole( GetCurrentProcessId() ) ) {
+  if ( AttachConsole( ATTACH_PARENT_PROCESS ) ) {
     // reopen the std I/O streams to redirect I/O to the new console
     freopen( "CON", "w", stdout );
-     freopen( "CON", "w", stderr );
+    freopen( "CON", "w", stderr );
   }
 
 #endif
@@ -256,7 +256,7 @@ int main( int argc, char ** argv )
   int newArgc                     = argc + 1 + 1;
   char ** newArgv                 = new char *[ newArgc ];
   for ( int i = 0; i < argc; i++ ) {
-        newArgv[ i ] = argv[ i ];
+    newArgv[ i ] = argv[ i ];
   }
   newArgv[ argc ]     = ARG_DISABLE_WEB_SECURITY;
   newArgv[ argc + 1 ] = nullptr;
@@ -273,9 +273,8 @@ int main( int argc, char ** argv )
   QString appDirPath = QCoreApplication::applicationDirPath() + "/crash";
 
   QDir dir;
-  if (!dir.exists(appDirPath)) {
-        bool res = dir.mkpath(appDirPath);
-        qDebug() << "New mkdir " << appDirPath << " " << res;
+  if ( !dir.exists( appDirPath ) ) {
+    dir.mkpath( appDirPath );
   }
 
   google_breakpad::ExceptionHandler eh(

--- a/src/main.cc
+++ b/src/main.cc
@@ -17,6 +17,7 @@
 
 #ifdef Q_OS_WIN32
 #include <QtCore/qt_windows.h>
+#include <windows.h>
 #endif
 
 #include "termination.hh"
@@ -217,18 +218,27 @@ void processCommandLine( QCoreApplication * app, GDOptions * result)
 int main( int argc, char ** argv )
 {
 #ifdef Q_OS_UNIX
-    // GoldenDict use lots of X11 functions and it currently cannot work
-    // natively on Wayland. This workaround will force GoldenDict to use
-    // XWayland.
-    char * xdg_envc = getenv("XDG_SESSION_TYPE");
-    QString xdg_session = xdg_envc ? QString::fromLatin1(xdg_envc) : QString();
-    if (!QString::compare(xdg_session, QString("wayland"), Qt::CaseInsensitive))
-    {
-        setenv("QT_QPA_PLATFORM", "xcb", 1);
-    }
+  // GoldenDict use lots of X11 functions and it currently cannot work
+  // natively on Wayland. This workaround will force GoldenDict to use
+  // XWayland.
+  char * xdg_envc     = getenv( "XDG_SESSION_TYPE" );
+  QString xdg_session = xdg_envc ? QString::fromLatin1( xdg_envc ) : QString();
+  if ( !QString::compare( xdg_session, QString( "wayland" ), Qt::CaseInsensitive ) ) {
+    setenv( "QT_QPA_PLATFORM", "xcb", 1 );
+  }
 #endif
+
 #ifdef Q_OS_MAC
-    setenv("LANG", "en_US.UTF-8", 1);
+  setenv( "LANG", "en_US.UTF-8", 1 );
+#endif
+
+#ifdef Q_OS_WIN32
+  // attach the new console to this application's process
+  if ( AttachConsole( GetCurrentProcessId() ) ) {
+    // reopen the std I/O streams to redirect I/O to the new console
+    freopen( "CON", "w", stdout );
+     freopen( "CON", "w", stderr );
+  }
 
 #endif
 


### PR DESCRIPTION
This is the result on Windows,
If start goldendict from a console ,the console will be used as output.


![image](https://github.com/xiaoyifang/goldendict-ng/assets/105986/a2b619be-6b3a-4eb4-a8a4-6ad05c638a68)
