### PR TITLE
simplify fs::separator

### DIFF
--- a/src/common/utils.cc
+++ b/src/common/utils.cc
@@ -53,11 +53,6 @@ std::string Utils::Html::getHtmlCleaner()
 
 namespace Utils::Fs {
 
-char separator()
-{
-  return QDir::separator().toLatin1();
-}
-
 std::string basename( std::string const & str )
 {
   size_t x = str.rfind( separator() );

--- a/src/common/utils.hh
+++ b/src/common/utils.hh
@@ -333,8 +333,16 @@ namespace Fs {
 
 using std::string;
 
-/// Returns the filesystem separator (/ on Unix and clones, \ on Windows).
-char separator();
+/// Copied from Qt but with char as return type
+/// https://github.com/qt/qtbase/blob/6.5.0/src/corelib/io/qdir.h#L206-L213
+static char separator()
+{
+#if defined( Q_OS_WIN )
+  return u'\\';
+#else
+  return u'/';
+#endif
+};
 
 /// Returns the name part of the given filename.
 string basename( string const & );


### PR DESCRIPTION
QChar is utf16, this useless conversion has been there since the very beginning.

https://github.com/goldendict/goldendict/blame/845f5294a63f797165b1220f955274bc0b01526e/fsencoding.cc#L57-L60

Performance impact: <1ns (aka None :sweat_smile:)