### PR TITLE
fix: access optional without checking the existence

### DIFF
--- a/src/dict/loaddictionaries.cc
+++ b/src/dict/loaddictionaries.cc
@@ -167,7 +167,7 @@ void LoadDictionaries::handlePath( Config::Path const & path )
     auto filePath = Utils::Path::combine( baseDir, "metadata.toml" );
 
     auto dictMetaData = Metadata::load( filePath.toStdString() );
-    if ( dictMetaData && !dictMetaData->name->empty() ) {
+    if ( dictMetaData && dictMetaData->name ) {
       dict->setName( dictMetaData->name.value() );
     }
   }


### PR DESCRIPTION
My bad, I didn't catch this problem in the review.

`dictMetaData->name` is optional with is similar to a pointer, pointing to a string.

`name->empty()` is std::string::empty.

If name doesn't exist, a`std::bad_optional_access` will be thrown.

Users who previously use metadata.toml that doesn't have the `name` field will be affected.

To reproduce:

create empty `metadata.toml` -> gd still starts (on windows), but without any dicts
```bash
# linux error msg
/usr/include/c++/13.1.1/optional:477: constexpr _Tp& std::_Optional_base_impl<_Tp, _Dp>::_M_get() [with _Tp = std::__cxx11::basic_string<char>; _Dp = std::_Optional_base<std::__cxx11::basic_string<char>, false, false>]: Assertion 'this->_M_is_engaged()' failed.
```

![image](https://github.com/xiaoyifang/goldendict-ng/assets/20123683/ef700100-77a3-4fad-97a3-afd7f4ca6a8c)
