### PR TITLE
Revise how word is getting passed

### DIFF
--- a/src/article_maker.cc
+++ b/src/article_maker.cc
@@ -242,7 +242,7 @@ std::string ArticleMaker::makeNotFoundBody( QString const & word,
 }
 
 sptr< Dictionary::DataRequest > ArticleMaker::makeDefinitionFor(
-  Config::InputPhrase const & phrase, unsigned groupId,
+  QString const & word, unsigned groupId,
   QMap< QString, QString > const & contexts,
   QSet< QString > const & mutedDicts,
   QStringList const & dictIDs , bool ignoreDiacritics ) const
@@ -268,9 +268,9 @@ sptr< Dictionary::DataRequest > ArticleMaker::makeDefinitionFor(
         break;
     }
 
-    string header = makeHtmlHeader( phrase.phrase, QString(), true );
+    string header = makeHtmlHeader( word, QString(), true );
 
-    return std::make_shared<ArticleRequest>( phrase, Instances::Group{groupId,""},
+    return std::make_shared<ArticleRequest>( word, Instances::Group{groupId,""},
                                contexts, ftsDicts, header,
                                -1, true );
   }
@@ -278,9 +278,9 @@ sptr< Dictionary::DataRequest > ArticleMaker::makeDefinitionFor(
   if ( groupId == Instances::Group::HelpGroupId )
   {
     // This is a special group containing internal welcome/help pages
-    string result = makeHtmlHeader( phrase.phrase, QString(), cfg.alwaysExpandOptionalParts);
+    string result = makeHtmlHeader( word, QString(), cfg.alwaysExpandOptionalParts);
 
-    if ( phrase.phrase == tr( "Welcome!" ) )
+    if ( word == tr( "Welcome!" ) )
     {
       result += tr(
 "<h3 align=\"center\">Welcome to <b>GoldenDict</b>!</h3>"
@@ -298,7 +298,7 @@ sptr< Dictionary::DataRequest > ArticleMaker::makeDefinitionFor(
         ).toUtf8().data();
     }
     else
-    if ( phrase.phrase == tr( "Working with popup" ) )
+    if ( word == tr( "Working with popup" ) )
     {
       result += ( tr( "<h3 align=\"center\">Working with the popup</h3>"
 
@@ -319,7 +319,7 @@ sptr< Dictionary::DataRequest > ArticleMaker::makeDefinitionFor(
     else
     {
       // Not found
-      return makeNotFoundTextFor( phrase.phrase, "help" );
+      return makeNotFoundTextFor( word, "help" );
     }
 
     result += "</body></html>";
@@ -346,7 +346,7 @@ sptr< Dictionary::DataRequest > ArticleMaker::makeDefinitionFor(
   std::vector< sptr< Dictionary::Class > > const & activeDicts =
     activeGroup ? activeGroup->dictionaries : dictionaries;
 
-  string header = makeHtmlHeader( phrase.phrase,
+  string header = makeHtmlHeader( word,
                                   activeGroup && activeGroup->icon.size() ?
                                     activeGroup->icon : QString(),
                                   cfg.alwaysExpandOptionalParts );
@@ -362,13 +362,13 @@ sptr< Dictionary::DataRequest > ArticleMaker::makeDefinitionFor(
               QString::fromStdString( activeDicts[ x ]->getId() ) ) )
         unmutedDicts.push_back( activeDicts[ x ] );
 
-    return  std::make_shared<ArticleRequest>( phrase, Instances::Group{ activeGroup ? activeGroup->id:0, activeGroup ? activeGroup->name : ""},
+    return  std::make_shared<ArticleRequest>( word, Instances::Group{ activeGroup ? activeGroup->id:0, activeGroup ? activeGroup->name : ""},
                                contexts, unmutedDicts, header,
                                cfg.collapseBigArticles ? cfg.articleSizeLimit : -1,
                                cfg.alwaysExpandOptionalParts, ignoreDiacritics );
   }
   else
-    return std::make_shared<ArticleRequest>( phrase, Instances::Group{ activeGroup ? activeGroup->id:0, activeGroup ? activeGroup->name : ""},
+    return std::make_shared<ArticleRequest>( word, Instances::Group{ activeGroup ? activeGroup->id:0, activeGroup ? activeGroup->name : ""},
                                contexts, activeDicts, header,
                                cfg.collapseBigArticles ? cfg.articleSizeLimit : -1,
                                cfg.alwaysExpandOptionalParts, ignoreDiacritics );
@@ -432,7 +432,7 @@ bool ArticleMaker::adjustFilePath( QString & fileName )
 
 //////// ArticleRequest
 
-ArticleRequest::ArticleRequest( Config::InputPhrase const & phrase,
+ArticleRequest::ArticleRequest( QString const & word,
                                 Instances::Group const & group_,
                                 QMap< QString, QString > const & contexts_,
                                 vector< sptr< Dictionary::Class > > const & activeDicts_,
@@ -440,7 +440,7 @@ ArticleRequest::ArticleRequest( Config::InputPhrase const & phrase,
                                 int sizeLimit,
                                 bool needExpandOptionalParts_,
                                 bool ignoreDiacritics_ ):
-  word( phrase.phrase ),
+  word( word ),
   group( group_ ),
   contexts( contexts_ ),
   activeDicts( activeDicts_ ),
@@ -448,9 +448,6 @@ ArticleRequest::ArticleRequest( Config::InputPhrase const & phrase,
   needExpandOptionalParts( needExpandOptionalParts_ ),
   ignoreDiacritics( ignoreDiacritics_ )
 {
-  if ( !phrase.punctuationSuffix.isEmpty() )
-    alts.insert( gd::toWString( phrase.phraseWithSuffix() ) );
-
   // No need to lock dataMutex on construction
 
   hasAnyData = true;

--- a/src/article_maker.hh
+++ b/src/article_maker.hh
@@ -41,7 +41,7 @@ public:
   /// the keys are dictionary ids.
   /// If mutedDicts is not empty, the search would be limited only to those
   /// dictionaries in group which aren't listed there.
-  sptr< Dictionary::DataRequest > makeDefinitionFor( Config::InputPhrase const & phrase, unsigned groupId,
+  sptr< Dictionary::DataRequest > makeDefinitionFor( QString const & word, unsigned groupId,
                                                      QMap< QString, QString > const & contexts,
                                                      QSet< QString > const & mutedDicts =
                                                        QSet< QString >(),
@@ -116,7 +116,7 @@ class ArticleRequest: public Dictionary::DataRequest
 
 public:
 
-  ArticleRequest( Config::InputPhrase const & phrase, Instances::Group const & group,
+  ArticleRequest( QString const & phrase, Instances::Group const & group,
                   QMap< QString, QString > const & contexts,
                   std::vector< sptr< Dictionary::Class > > const & activeDicts,
                   std::string const & header,

--- a/src/article_netmgr.cc
+++ b/src/article_netmgr.cc
@@ -276,8 +276,7 @@ sptr< Dictionary::DataRequest > ArticleNetworkAccessManager::getResource(
     if ( Utils::Url::queryItemValue( url, "blank" ) == "1" )
       return articleMaker.makeEmptyPage();
 
-    Config::InputPhrase phrase ( Utils::Url::queryItemValue( url, "word" ).trimmed(),
-                                 Utils::Url::queryItemValue( url, "punctuation_suffix" ) );
+    QString word =  Utils::Url::queryItemValue( url, "word" ).trimmed();
 
     bool groupIsValid = false;
     unsigned group = Utils::Url::queryItemValue( url, "group" ).toUInt( &groupIsValid );
@@ -287,7 +286,7 @@ sptr< Dictionary::DataRequest > ArticleNetworkAccessManager::getResource(
     {
       // Individual dictionaries set from full-text search
       QStringList dictIDList = dictIDs.split( "," );
-      return articleMaker.makeDefinitionFor( phrase, group, QMap< QString, QString >(), QSet< QString >(), dictIDList );
+      return articleMaker.makeDefinitionFor( word, group, QMap< QString, QString >(), QSet< QString >(), dictIDList );
     }
 
     // See if we have some dictionaries muted
@@ -318,8 +317,8 @@ sptr< Dictionary::DataRequest > ArticleNetworkAccessManager::getResource(
 
     bool ignoreDiacritics = Utils::Url::queryItemValue( url, "ignore_diacritics" ) == "1";
 
-    if ( groupIsValid && phrase.isValid() ) // Require group and phrase to be passed
-      return articleMaker.makeDefinitionFor( phrase, group, contexts, mutedDicts, QStringList(), ignoreDiacritics );
+    if ( groupIsValid && !word.isEmpty() ) // Require group and phrase to be passed
+      return articleMaker.makeDefinitionFor( word, group, contexts, mutedDicts, QStringList(), ignoreDiacritics );
   }
 
   if ( ( url.scheme() == "bres" || url.scheme() == "gdau" || url.scheme() == "gdvideo" || url.scheme() == "gico" ) &&

--- a/src/config.cc
+++ b/src/config.cc
@@ -185,7 +185,6 @@ ScanPopupWindowFlags spwfFromInt( int id )
 
 QString Preferences::sanitizeInputPhrase( QString const & inputWord ) const
 {
-
   QString result = inputWord;
   if ( stripClipboard ) {
     auto parts = inputWord.split( QChar::LineFeed, Qt::SkipEmptyParts );
@@ -202,7 +201,7 @@ QString Preferences::sanitizeInputPhrase( QString const & inputWord ) const
   }
 
   // Simplify whitespaces and remove soft hyphens (0xAD);
-  return result.simplified();
+  return Folding::trimWhitespaceOrPunct(  result.simplified() );
 }
 
 Preferences::Preferences():

--- a/src/config.cc
+++ b/src/config.cc
@@ -183,41 +183,26 @@ ScanPopupWindowFlags spwfFromInt( int id )
   return SPWF_default;
 }
 
-InputPhrase Preferences::sanitizeInputPhrase( QString const & inputPhrase ) const
+QString Preferences::sanitizeInputPhrase( QString const & inputWord ) const
 {
-  InputPhrase result;
 
-  QString _phase = inputPhrase;
-  if( stripClipboard )
-  {
-    auto parts = inputPhrase.split( QChar::LineFeed, Qt::SkipEmptyParts );
-    if( !parts.empty() )
-    {
-      _phase = parts[ 0 ];
+  QString result = inputWord;
+  if ( stripClipboard ) {
+    auto parts = inputWord.split( QChar::LineFeed, Qt::SkipEmptyParts );
+    if ( !parts.empty() ) {
+      result = parts[ 0 ];
     }
   }
 
-  if( limitInputPhraseLength && _phase.size() > inputPhraseLengthLimit )
-  {
+  if ( limitInputPhraseLength && result.size() > inputPhraseLengthLimit ) {
     gdDebug( "Ignoring an input phrase %lld symbols long. The configured maximum input phrase length is %d symbols.",
-             _phase.size(), inputPhraseLengthLimit );
-    return result;
+             result.size(),
+             inputPhraseLengthLimit );
+    return {};
   }
 
-  const QString withPunct = _phase.simplified().remove( QChar( 0xAD ) ); // Simplify whitespaces and remove soft hyphens;
-  result.phrase = Folding::trimWhitespaceOrPunct(  withPunct );
-  if ( !result.isValid() )
-    return result; // The suffix of an invalid input phrase must be empty.
-
-  const int prefixSize = withPunct.indexOf( result.phrase.at(0) );
-  const int suffixSize = withPunct.size() - prefixSize - result.phrase.size();
-  Q_ASSERT( suffixSize >= 0 );
-  Q_ASSERT( withPunct.size() - suffixSize - 1
-            == withPunct.lastIndexOf( result.phrase.at( result.phrase.size() - 1 ) ) );
-  if ( suffixSize != 0 )
-    result.punctuationSuffix = withPunct.right( suffixSize );
-
-  return result;
+  // Simplify whitespaces and remove soft hyphens (0xAD);
+  return result.simplified();
 }
 
 Preferences::Preferences():
@@ -250,7 +235,7 @@ Preferences::Preferences():
   ignoreOwnClipboardChanges( false ),
   scanToMainWindow( false ),
   ignoreDiacritics( false ),
-  ignorePunctuation( false ),
+  ignorePunctuation( true ),
 #ifdef HAVE_X11
   // Enable both Clipboard and Selection by default so that X users can enjoy full
   // power and disable optionally.

--- a/src/config.cc
+++ b/src/config.cc
@@ -201,7 +201,7 @@ QString Preferences::sanitizeInputPhrase( QString const & inputWord ) const
   }
 
   // Simplify whitespaces and remove soft hyphens (0xAD);
-  return Folding::trimWhitespaceOrPunct(  result.simplified() );
+  return Folding::trimWhitespace(  result.simplified() );
 }
 
 Preferences::Preferences():

--- a/src/config.hh
+++ b/src/config.hh
@@ -249,38 +249,6 @@ enum ScanPopupWindowFlags
 };
 ScanPopupWindowFlags spwfFromInt( int id );
 
-struct InputPhrase
-{
-  InputPhrase()
-  {}
-
-  InputPhrase( QString const & _phrase, QString const & _suffix ) :
-    phrase( _phrase ),
-    punctuationSuffix( _suffix )
-  {}
-
-  static InputPhrase fromPhrase( QString const & phrase )
-  {
-    return InputPhrase( phrase, QString() );
-  }
-
-  bool isValid() const { return !phrase.isEmpty(); }
-
-  QString phraseWithSuffix() const { return phrase + punctuationSuffix; }
-
-  QString phrase;
-  QString punctuationSuffix;
-};
-
-inline bool operator == ( InputPhrase const & a, InputPhrase const & b )
-{
-  return a.phrase == b.phrase && a.punctuationSuffix == b.punctuationSuffix;
-}
-inline bool operator != ( InputPhrase const & a, InputPhrase const & b )
-{
-  return !( a == b );
-}
-
 /// Various user preferences
 struct Preferences
 {
@@ -361,7 +329,7 @@ struct Preferences
 
   bool limitInputPhraseLength;
   int inputPhraseLengthLimit;
-  InputPhrase sanitizeInputPhrase( QString const & inputPhrase ) const;
+  QString sanitizeInputPhrase( QString const & inputWord ) const;
 
   unsigned short maxDictionaryRefsInContextMenu;
 
@@ -881,7 +849,5 @@ QString getStylesDir();
 QString getCacheDir() noexcept;
 
 }
-
-Q_DECLARE_METATYPE( Config::InputPhrase )
 
 #endif

--- a/src/ui/articleview.hh
+++ b/src/ui/articleview.hh
@@ -135,10 +135,6 @@ public:
   /// contexts is an optional map of context values to be passed for dictionaries.
   /// The only values to pass here are ones obtained from showDefinitionInNewTab()
   /// signal or none at all.
-  void showDefinition( Config::InputPhrase const & phrase, unsigned group,
-                       QString const & scrollTo = QString(),
-                       Contexts const & contexts = Contexts() );
-
   void showDefinition( QString const & word, unsigned group,
                        QString const & scrollTo = QString(),
                        Contexts const & contexts = Contexts() );
@@ -232,7 +228,7 @@ public:
   QString getTitle();
 
   /// Returns the phrase translated by the current article.
-  Config::InputPhrase getPhrase() const;
+ QString getWord() const;
 
   /// Prints current article
   void print( QPrinter * ) const;

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -4054,9 +4054,9 @@ void MainWindow::focusWordList()
 
 void MainWindow::addWordToHistory( const QString & word )
 {
+//    skip epwing reference link. epwing reference link has the pattern of r%dAt%d
     if(QRegularExpressionMatch m = RX::Epwing::refWord.match( word ); m.hasMatch() )
         return;
-    qDebug()<<"WHATISTHIS" << word;
     history.addItem( History::Item( 1, word.trimmed() ) );
 }
 

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -60,12 +60,11 @@ public:
   /// Set group for main/popup window
   void setGroupByName( QString const & name, bool main_window );
 
-  enum WildcardPolicy { EscapeWildcards, WildcardsAreAlreadyEscaped };
+  enum class WildcardPolicy { EscapeWildcards, WildcardsAreAlreadyEscaped };
 public slots:
 
   void messageFromAnotherInstanceReceived( QString const & );
   void showStatusBarMessage ( QString const &, int, QPixmap const & );
-  void phraseReceived( Config::InputPhrase const &, WildcardPolicy );
   void wordReceived( QString const & );
   void headwordReceived( QString const &, QString const & );
   void headwordFromFavorites( QString const &, QString const & );
@@ -144,7 +143,6 @@ private:
 
   WordList * wordList;
   QLineEdit * translateLine;
-  QString translateBoxSuffix; ///< A punctuation suffix that corresponds to translateLine's text.
 
   WordFinder wordFinder;
 
@@ -244,17 +242,17 @@ private:
 
   QString unescapeTabHeader( QString const & header );
 
-  void respondToTranslationRequest( Config::InputPhrase const & phrase,
+  void respondToTranslationRequest( QString const & word,
                                     bool checkModifiers, QString const & scrollTo = QString() );
 
   void updateSuggestionList();
   void updateSuggestionList( QString const & text );
 
   enum TranslateBoxPopup { NoPopupChange, EnablePopup, DisablePopup };
-  void setTranslateBoxTextAndKeepSuffix( QString text, WildcardPolicy wildcardPolicy,
-                                         TranslateBoxPopup popupAction );
-  void setTranslateBoxTextAndClearSuffix( QString const & text, WildcardPolicy wildcardPolicy,
-                                          TranslateBoxPopup popupAction );
+
+  /// Change the text of translateLine (Input line in the dock) or TranslateBox (Input line in toolbar)
+  void setInputLineText( QString text, WildcardPolicy wildcardPolicy, TranslateBoxPopup popupAction );
+
   void changeWebEngineViewFont();
   bool isWordPresentedInFavorites( QString const & word, unsigned groupId );
 private slots:
@@ -382,11 +380,10 @@ private slots:
 
   void mutedDictionariesChanged();
 
-  void showTranslationFor( Config::InputPhrase const &, unsigned inGroup = 0,
+  void showTranslationFor(QString const &, unsigned inGroup = 0,
                            QString const & scrollTo = QString() );
-  void showTranslationFor( QString const & );
 
-  void showTranslationFor( QString const &, QStringList const & dictIDs,
+  void showTranslationForDicts( QString const &, QStringList const & dictIDs,
                            QRegExp const & searchRegExp, bool ignoreDiacritics );
 
   void showHistoryItem( QString const & );

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -672,7 +672,7 @@ void ScanPopup::showTranslationFor( QString const & word )
   ui.pronounceButton->setDisabled( true );
 
   unsigned groupId = ui.groupList->getCurrentGroup();
-  definition->showDefinition( word, groupId = groupId );
+  definition->showDefinition( word, groupId );
   definition->focus();
 }
 

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -256,7 +256,7 @@ ScanPopup::ScanPopup( QWidget * parent,
   connect( &MouseOver::instance(),
     SIGNAL( hovered( QString const &, bool ) ),
     this,
-    SLOT( mouseHovered( QString const &, bool ) ) );
+    SLOT( handleInputWord( QString const &, bool ) ) );
 #endif
 
   hideTimer.setSingleShot( true );
@@ -463,6 +463,30 @@ void ScanPopup::showEngagePopup()
   engagePopup(false);
 }
 #endif
+
+[[deprecated]]
+void ScanPopup::handleInputWord( QString const & str, bool forcePopup )
+{
+  auto sanitizedPhrase = cfg.preferences.sanitizeInputPhrase( str );
+
+  if ( isVisible() && sanitizedPhrase == pendingWord )
+  {
+    // Attempt to translate the same word we already have shown in scan popup.
+    // Ignore it, as it is probably a spurious mouseover event.
+    return;
+  }
+
+  pendingWord = sanitizedPhrase;
+
+#ifdef HAVE_X11
+  if ( cfg.preferences.showScanFlag ) {
+    emit showScanFlag();
+    return;
+  }
+#endif
+
+  engagePopup( forcePopup );
+}
 
 void ScanPopup::engagePopup( bool forcePopup, bool giveFocus )
 {

--- a/src/ui/scanpopup.hh
+++ b/src/ui/scanpopup.hh
@@ -64,7 +64,7 @@ signals:
   /// Forwarded from the dictionary bar, so that main window could act on this.
   void editGroupRequested( unsigned id );
   /// Send word to main window
-  void sendPhraseToMainWindow( Config::InputPhrase const & phrase );
+  void sendPhraseToMainWindow( QString const & word );
   /// Close opened menus when window hide
   void closeMenu();
 
@@ -132,8 +132,7 @@ private:
   ArticleView * definition;
   QAction escapeAction, switchExpandModeAction, focusTranslateLineAction;
   QAction openSearchAction;
-  Config::InputPhrase pendingInputPhrase, inputPhrase;
-  QString translateBoxSuffix; ///< A punctuation suffix that corresponds to translateBox's text.
+  QString pendingWord; // Word that is going to be translated
   WordFinder wordFinder;
   Config::Events configEvents;
   DictionaryBar dictionaryBar;
@@ -189,12 +188,11 @@ private:
 
   void updateBackForwardButtons();
 
-  void showTranslationFor( Config::InputPhrase const & inputPhrase );
+  void showTranslationFor( QString const & inputPhrase );
 
   void updateSuggestionList();
   void updateSuggestionList( QString const & text );
 private slots:
-  void mouseHovered( QString const & , bool forcePopup);
   void currentGroupChanged( int );
   void prefixMatchFinished();
   void on_pronounceButton_clicked();

--- a/src/ui/translatebox.hh
+++ b/src/ui/translatebox.hh
@@ -41,7 +41,6 @@ class TranslateBox : public QWidget
 
 public:
   explicit TranslateBox(QWidget * parent = 0);
-  void setPlaceholderText(const QString &text);
   QLineEdit * translateLine();
   WordList * wordList();
   void setText(QString text, bool showPopup=true);


### PR DESCRIPTION
Same thing but with less than half of the code :sweat_smile: 

fix https://github.com/xiaoyifang/goldendict-ng/issues/726

Only 2 cases call `sanitizeInputPhrase`

1. ScanPopup Clipboard
1. Ctrl+V on ArticleView (ArticleView::PasteTriggered)

The old code is passing a phrase::suffix around for this and only this moment.

https://github.com/goldendict/goldendict/commit/60bc05218f0036b361f07e3fc4343103343bd618#diff-2f0f60eeecbf581d1ccc00ea91a53402edc308f7f5210db294df826ec949ae23R483-R484

![image](https://github.com/xiaoyifang/goldendict-ng/assets/20123683/5fbf4ebd-06ed-4bfd-b497-156d3f277271)

In old code, when searching via clipboard for words like `Assoc.` results from both `Assoc` and `Assoc.` will show.

If we turn on `ignorePunctuation` by default and get rid of the entire InputPhrase thing,
only the edge case will be changed -> in mainwindow -> Search `Assoc....` will yield both `Assoc` & `Assoc.`


https://github.com/xiaoyifang/goldendict-ng/commit/5a0a6c649169ce9ad7858375a38b97a6f4cf9dde



