### PR TITLE
fix: windows, change package name with xapian

### DIFF
--- a/.github/workflows/windows-6.x-xapian.yml
+++ b/.github/workflows/windows-6.x-xapian.yml
@@ -203,7 +203,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ steps.package.outputs.packageName }}/GoldenDict-ng-v23-Installer.exe
-          asset_name: ${{ matrix.qt_ver }}-GoldenDict-ng-Installer.exe
+          asset_name: ${{ matrix.qt_ver }}-GoldenDict-ng-xapian-Installer.exe
           tag: v${{env.version}}-${{env.version-suffix}}.${{ steps.vars.outputs.release_hm }}.${{ steps.vars.outputs.sha_short }}
           overwrite: true 
           release_name: GoldenDict-ng-v${{env.version}}-${{env.version-suffix}}.${{ steps.vars.outputs.release_hm }}.${{ steps.vars.outputs.sha_short }}


### PR DESCRIPTION
https://github.com/xiaoyifang/goldendict-ng/issues/701#event-9274858282

`xapian` seems to have been overdeleted last time.

