### PR TITLE
opt: add command line option --no-tts

### DIFF
--- a/src/config.hh
+++ b/src/config.hh
@@ -760,14 +760,21 @@ struct Class
 
   QString editDictionaryCommandLine; // Command line to call external editor for dictionary
 
-  Class(): lastMainGroupId( 0 ), lastPopupGroupId( 0 ),
-           pinPopupWindow( false ), showingDictBarNames( false ),
-           usingSmallIconsInToolbars( false ),
-           maxPictureWidth( 0 ), maxHeadwordSize ( 256U ),
-           maxHeadwordsToExpand( 0 )
-  {}
+  Class():
+    lastMainGroupId( 0 ),
+    lastPopupGroupId( 0 ),
+    pinPopupWindow( false ),
+    showingDictBarNames( false ),
+    usingSmallIconsInToolbars( false ),
+    maxPictureWidth( 0 ),
+    maxHeadwordSize( 256U ),
+    maxHeadwordsToExpand( 0 )
+  {
+  }
   Group * getGroup( unsigned id );
   Group const * getGroup( unsigned id ) const;
+  //disable tts dictionary. does not need to save to persistent file
+  bool notts = false;
 };
 
 #ifdef Q_OS_WIN

--- a/src/dict/sources.cc
+++ b/src/dict/sources.cc
@@ -116,19 +116,20 @@ Sources::Sources( QWidget * parent, Config::Class const & cfg):
   ui.enableCustomTransliteration->setChecked( trs.customTrans.enable );
   ui.customTransliteration->setPlainText( trs.customTrans.context );
 
-  ui.linguaEnabled->setChecked(lingua.enable);
-  ui.linguaLangCode->setText(lingua.languageCodes);
+  ui.linguaEnabled->setChecked( lingua.enable );
+  ui.linguaLangCode->setText( lingua.languageCodes );
 
   ui.forvoEnabled->setChecked( forvo.enable );
   ui.forvoApiKey->setText( forvo.apiKey );
   ui.forvoLanguageCodes->setText( forvo.languageCodes );
 
   // Text to speech
-  textToSpeechSource = new TextToSpeechSource( this, cfg.voiceEngines );
-  ui.tabWidget->addTab( textToSpeechSource, QIcon(":/icons/text2speech.svg"), tr( "Text to Speech" ) );
+  if ( !cfg.notts ) {
+    textToSpeechSource = new TextToSpeechSource( this, cfg.voiceEngines );
+    ui.tabWidget->addTab( textToSpeechSource, QIcon( ":/icons/text2speech.svg" ), tr( "Text to Speech" ) );
+  }
 
-  if ( Config::isPortableVersion() )
-  {
+  if ( Config::isPortableVersion() ) {
     // Paths
 
     ui.paths->setEnabled( false );

--- a/src/main.cc
+++ b/src/main.cc
@@ -142,6 +142,7 @@ struct GDOptions
 
   inline bool needTogglePopup() const
   { return togglePopup; }
+  bool notts;
 };
 
 void processCommandLine( QCoreApplication * app, GDOptions * result)
@@ -156,6 +157,8 @@ void processCommandLine( QCoreApplication * app, GDOptions * result)
   QCommandLineOption logFileOption( QStringList() << "l"
                                                   << "log-to-file",
                                     QObject::tr( "Save debug messages to gd_log.txt in the config folder." ) );
+
+  QCommandLineOption notts( "no-tts", QObject::tr( "Disable tts." ) );
 
   QCommandLineOption groupNameOption( QStringList() << "g"
                                                     << "group-name",
@@ -174,6 +177,7 @@ void processCommandLine( QCoreApplication * app, GDOptions * result)
   qcmd.addOption( groupNameOption );
   qcmd.addOption( popupGroupNameOption );
   qcmd.addOption( togglePopupOption );
+  qcmd.addOption( notts );
 
   QCommandLineOption doNothingOption( "disable-web-security" ); // ignore the --disable-web-security
   doNothingOption.setFlags( QCommandLineOption::HiddenFromHelp );
@@ -195,6 +199,10 @@ void processCommandLine( QCoreApplication * app, GDOptions * result)
 
   if ( qcmd.isSet( togglePopupOption ) ) {
     result->togglePopup = true;
+  }
+
+  if ( qcmd.isSet( notts ) ) {
+    result->notts = true;
   }
 
   const QStringList posArgs = qcmd.positionalArguments();
@@ -377,7 +385,7 @@ int main( int argc, char ** argv )
                       QHotkeyApplication::translate( "Main", "Error in configuration file. Continue with default settings?" ),
                       QMessageBox::Yes | QMessageBox::No );
       mb.exec();
-      if( mb.result() != QMessageBox::Yes )
+      if ( mb.result() != QMessageBox::Yes )
         return -1;
 
       QString configFile = Config::getConfigFileName();
@@ -387,8 +395,11 @@ int main( int argc, char ** argv )
     break;
   }
 
-  if( gdcl.needLogFile() )
-  {
+  if ( gdcl.notts ) {
+    cfg.notts = true;
+  }
+
+  if ( gdcl.needLogFile() ) {
     // Open log file
     logFilePtr->setFileName( Config::getConfigDir() + "gd_log.txt" );
     logFilePtr->remove();


### PR DESCRIPTION
when start goldendict
append the option `--no-tts` will disable the tts loading.

such as 
```
goldendict.exe --no-tts
```

on Windows,  you can append the option to the shortcut of GoldenDict.exe or just start the application in the cmd console.
