### PR TITLE
opt: mdx fulltext lock seperated with normal search

### DIFF
--- a/src/common/globalbroadcaster.hh
+++ b/src/common/globalbroadcaster.hh
@@ -34,7 +34,7 @@ public:
   unsigned currentGroupId;
   QString translateLineText{};
   //hold the dictionary id;
-  QSet<QString> collapsedDicts;
+  QSet< QString > collapsedDicts;
   QMap< QString, QSet< QString > > folderFavoritesMap;
   QMap< unsigned, QString > groupFolderMap;
 
@@ -42,6 +42,8 @@ public:
 signals:
   void dictionaryChanges( ActiveDictIds ad );
   void dictionaryClear( ActiveDictIds ad );
+
+  void indexingDictionary( QString );
 };
 
 #endif // GLOBAL_GLOBALBROADCASTER_H

--- a/src/dict/dictionary.hh
+++ b/src/dict/dictionary.hh
@@ -351,8 +351,8 @@ public:
     auto newProgress = getIndexingFtsProgress();
     if ( newProgress != lastProgress ) {
       lastProgress = newProgress;
-      emit GlobalBroadcaster::instance()->indexingDictionary( QString::fromStdString( getName() )
-                                                              + QString( "......%1%2" ).arg( "%" ).arg( newProgress ) );
+      emit GlobalBroadcaster::instance()->indexingDictionary(
+        QString( "%1......%%2" ).arg( QString::fromStdString( getName() ) ).arg( newProgress ) );
     }
   }
 

--- a/src/dict/dictionary.hh
+++ b/src/dict/dictionary.hh
@@ -17,6 +17,7 @@
 #include "config.hh"
 #include "utils.hh"
 #include <QString>
+#include "globalbroadcaster.hh"
 
 /// Abstract dictionary-related stuff
 namespace Dictionary {
@@ -261,11 +262,15 @@ Q_DECLARE_FLAGS( Features, Feature )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Features )
 
 /// A dictionary. Can be used to query words.
-class Class
+class Class: public QObject
 {
+  Q_OBJECT
+
   string id;
   vector< string > dictionaryFiles;
   long indexedFtsDoc;
+
+  long lastProgress = 0;
 
 protected:
   QString dictionaryDescription;
@@ -339,8 +344,16 @@ public:
   /// Returns the number of articles in the dictionary.
   virtual unsigned long getArticleCount() noexcept=0;
 
-  void setIndexedFtsDoc(long _indexedFtsDoc){
+  void setIndexedFtsDoc(long _indexedFtsDoc)
+  {
     indexedFtsDoc = _indexedFtsDoc;
+
+    auto newProgress = getIndexingFtsProgress();
+    if ( newProgress != lastProgress ) {
+      lastProgress = newProgress;
+      emit GlobalBroadcaster::instance()->indexingDictionary( QString::fromStdString( getName() )
+                                                              + QString( "......%1%2" ).arg( "%" ).arg( newProgress ) );
+    }
   }
 
   int getIndexingFtsProgress(){

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -197,7 +197,7 @@ public:
 
 };
 
-class MdxDictionary: public QObject, public BtreeIndexing::BtreeDictionary
+class MdxDictionary: public BtreeIndexing::BtreeDictionary
 {
   Mutex idxMutex;
   File::Class idx;
@@ -305,17 +305,15 @@ private:
 
   void removeDirectory( QString const & directory );
 
-  friend class MdxHeadwordsRequest;
   friend class MdxArticleRequest;
   friend class MddResourceRequest;
   void loadResourceFile( const wstring & resourceName, vector< char > & data );
 };
 
-MdxDictionary::MdxDictionary( string const & id, string const & indexFile,
-                              vector<string> const & dictionaryFiles ):
+MdxDictionary::MdxDictionary( string const & id, string const & indexFile, vector< string > const & dictionaryFiles ):
   BtreeDictionary( id, dictionaryFiles ),
-  idxFile(indexFile),
   idx( indexFile, "rb" ),
+  idxFile( indexFile ),
   idxHeader( idx.read< IdxHeader >() ),
   chunks( idx, idxHeader.chunksOffset ),
   deferredInitRunnableStarted( false )

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -1472,20 +1472,20 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
       // Save dictionary stylesheets
       {
         MdictParser::StyleSheets const & styleSheets = parser.styleSheets();
-        idxHeader.styleSheetAddress = idx.tell();
-        idxHeader.styleSheetCount = styleSheets.size();
+        idxHeader.styleSheetAddress                  = idx.tell();
+        idxHeader.styleSheetCount                    = styleSheets.size();
 
-        for ( auto iter = styleSheets.begin(); iter != styleSheets.end(); ++iter ) {
-          string styleBegin( iter->second.first.toStdString() );
-          string styleEnd( iter->second.second.toStdString() );
+        for ( auto const & [ key, value ] : styleSheets ) {
+          string const styleBegin( value.first.toStdString() );
+          string const styleEnd( value.second.toStdString() );
 
           // key
-          idx.write< qint32 >( iter->first );
+          idx.write< qint32 >( key );
           // styleBegin
           idx.write< quint32 >( (quint32)styleBegin.size() + 1 );
           idx.write( styleBegin.c_str(), styleBegin.size() + 1 );
           // styleEnd
-          idx.write<quint32>( ( quint32 )styleEnd.size() + 1 );
+          idx.write< quint32 >( (quint32)styleEnd.size() + 1 );
           idx.write( styleEnd.c_str(), styleEnd.size() + 1 );
         }
       }

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -23,11 +23,10 @@
 #include <map>
 #include <set>
 #include <list>
-#include <ctype.h>
-#include <stdlib.h>
-
+#include <cctype>
+#include <cstdlib>
 #ifdef _MSC_VER
-#include <stub_msvc.h>
+  #include <stub_msvc.h>
 #endif
 
 #include "globalregex.hh"
@@ -232,7 +231,7 @@ public:
 
   map< Dictionary::Property, string > getProperties() noexcept override
   {
-    return map< Dictionary::Property, string >();
+    return {};
   }
 
   unsigned long getArticleCount() noexcept override
@@ -274,7 +273,7 @@ public:
 
   void setFTSParameters( Config::FullTextSearch const & fts ) override
   {
-    if( ensureInitDone().size() )
+    if ( !ensureInitDone().empty() )
       return;
 
     can_FTS = fts.enabled
@@ -1478,16 +1477,14 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
         idxHeader.styleSheetAddress = idx.tell();
         idxHeader.styleSheetCount = styleSheets.size();
 
-        for ( MdictParser::StyleSheets::const_iterator iter = styleSheets.begin();
-              iter != styleSheets.end(); ++iter )
-        {
-          string styleBegin(iter->second.first.toStdString());
+        for ( auto iter = styleSheets.begin(); iter != styleSheets.end(); ++iter ) {
+          string styleBegin( iter->second.first.toStdString() );
           string styleEnd( iter->second.second.toStdString() );
 
           // key
-          idx.write<qint32>( iter->first );
+          idx.write< qint32 >( iter->first );
           // styleBegin
-          idx.write<quint32>( ( quint32 )styleBegin.size() + 1 );
+          idx.write< quint32 >( (quint32)styleBegin.size() + 1 );
           idx.write( styleBegin.c_str(), styleBegin.size() + 1 );
           // styleEnd
           idx.write<quint32>( ( quint32 )styleEnd.size() + 1 );

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -201,7 +201,7 @@ class MdxDictionary: public BtreeIndexing::BtreeDictionary
 {
   Mutex idxMutex;
   File::Class idx;
-  string idxFile;
+  string idxFileName;
   IdxHeader idxHeader;
   string encoding;
   ChunkedStorage::Reader chunks;
@@ -313,7 +313,7 @@ private:
 MdxDictionary::MdxDictionary( string const & id, string const & indexFile, vector< string > const & dictionaryFiles ):
   BtreeDictionary( id, dictionaryFiles ),
   idx( indexFile, "rb" ),
-  idxFile( indexFile ),
+  idxFileName( indexFile ),
   idxHeader( idx.read< IdxHeader >() ),
   chunks( idx, idxHeader.chunksOffset ),
   deferredInitRunnableStarted( false )
@@ -489,7 +489,7 @@ void MdxDictionary::makeFTSIndex( QAtomicInt & isCancelled, bool firstIteration 
 
   try
   {
-    auto _dict = std::make_shared<MdxDictionary>( this->getId(),idxFile,this->getDictionaryFilenames());
+    auto _dict = std::make_shared< MdxDictionary >( this->getId(), idxFileName, this->getDictionaryFilenames() );
     if( !_dict->ensureInitDone().empty() )
       return;
     FtsHelpers::makeFTSIndex( _dict.get(), isCancelled );

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -216,7 +216,7 @@ public:
 
   MdxDictionary( string const & id, string const & indexFile, vector<string> const & dictionaryFiles );
 
-  ~MdxDictionary();
+  ~MdxDictionary() override;
 
   void deferredInit() override;
 
@@ -557,7 +557,7 @@ public:
     isCancelled.ref();
   }
 
-  ~MdxArticleRequest()
+  ~MdxArticleRequest() override
   {
     isCancelled.ref();
     f.waitForFinished();

--- a/src/dict/zim.cc
+++ b/src/dict/zim.cc
@@ -495,7 +495,7 @@ void ZimDictionary::makeFTSIndex( QAtomicInt & isCancelled, bool firstIteration 
            getName().c_str() );
   try
   {
-    return FtsHelpers::makeFTSIndexXapian(this,isCancelled);
+    return FtsHelpers::makeFTSIndex(this,isCancelled);
   }
   catch( std::exception &ex )
   {

--- a/src/ftshelpers.cc
+++ b/src/ftshelpers.cc
@@ -559,9 +559,9 @@ void FTSResultsRequest::checkSingleArticle( uint32_t  offset,
       if( Utils::AtomicInt::loadAcquire( isCancelled ) )
         return;
 
-      if( ignoreWordsOrder ) {
+      if ( ignoreWordsOrder ) {
         for ( auto & [ fst, snd ] : wordsList )
-        snd = true;
+          snd = true;
       }
 
       dict.getArticleText( offset, headword, articleText );

--- a/src/ftshelpers.cc
+++ b/src/ftshelpers.cc
@@ -351,6 +351,10 @@ void makeFTSIndex( BtreeIndexing::BtreeDictionary * dict, QAtomicInt & isCancell
 {
   Mutex::Lock _( dict->getFtsMutex() );
 
+  //check the index again.
+  if ( dict->haveFTSIndex() )
+    return;
+
   try {
     if ( Utils::AtomicInt::loadAcquire( isCancelled ) )
       throw exUserAbort();

--- a/src/ftshelpers.cc
+++ b/src/ftshelpers.cc
@@ -559,10 +559,9 @@ void FTSResultsRequest::checkSingleArticle( uint32_t  offset,
       if( Utils::AtomicInt::loadAcquire( isCancelled ) )
         return;
 
-      if( ignoreWordsOrder )
-      {
-        for(auto & i : wordsList)
-          i.second = true;
+      if( ignoreWordsOrder ) {
+        for ( auto & [ fst, snd ] : wordsList )
+        snd = true;
       }
 
       dict.getArticleText( offset, headword, articleText );

--- a/src/ftshelpers.cc
+++ b/src/ftshelpers.cc
@@ -291,8 +291,8 @@ void parseArticleForFts( uint32_t articleAddress, QString & articleText,
         QStringList list;
 
         QStringList oldVariant = word.split( RX::Ftx::regSplit, Qt::SkipEmptyParts );
-        for(auto & it : oldVariant)
-          if( it.size() >= FTS::MinimumWordSize && !list.contains( it ) )
+        for ( auto const & it : oldVariant )
+          if ( it.size() >= FTS::MinimumWordSize && !list.contains( it ) )
             list.append( it );
 
         QRegularExpressionMatch match = RX::Ftx::regBrackets.match( word );
@@ -317,8 +317,7 @@ void parseArticleForFts( uint32_t articleAddress, QString & articleText,
             list.append( parsedWord );
         }
 
-        for(auto & it : list)
-        {
+        for ( auto const & it : list ) {
           //if( !setOfWords.contains( *it ) )
           {
             setOfWords.push_back( it );
@@ -415,7 +414,7 @@ void makeFTSIndex( BtreeIndexing::BtreeDictionary * dict, QAtomicInt & isCancell
 
     long indexedDoc = 0L;
 
-    for ( auto & address : offsets ) {
+    for ( auto const & address : offsets ) {
       indexedDoc++;
 
       if ( address > lastAddress && skip ) {
@@ -710,10 +709,8 @@ void FTSResultsRequest::indexSearch( BtreeIndexing::BtreeIndex & ftsIndex,
 
     vector< BtreeIndexing::WordArticleLink > links =
       ftsIndex.findArticles( gd::removeTrailingZero( word ), ignoreDiacritics );
-    for(auto & link : links)
-    {
-      if( Utils::AtomicInt::loadAcquire( isCancelled ) )
-      {
+    for ( auto const & link : links ) {
+      if ( Utils::AtomicInt::loadAcquire( isCancelled ) ) {
         addressLists << tmp;
         return;
       }
@@ -831,10 +828,8 @@ void FTSResultsRequest::combinedIndexSearch( BtreeIndexing::BtreeIndex & ftsInde
     {
       QSet< uint32_t > tmp;
       vector< BtreeIndexing::WordArticleLink > links = ftsIndex.findArticles( gd::removeTrailingZero( word ) );
-      for(auto & link : links)
-      {
-        if( Utils::AtomicInt::loadAcquire( isCancelled ) )
-        {
+      for ( auto const & link : links ) {
+        if ( Utils::AtomicInt::loadAcquire( isCancelled ) ) {
           Mutex::Lock _( dataMutex );
           sets << tmp;
           return;

--- a/src/ftshelpers.hh
+++ b/src/ftshelpers.hh
@@ -64,7 +64,6 @@ void parseArticleForFts( uint32_t articleAddress, QString & articleText,
                          bool handleRoundBrackets = false );
 
 void makeFTSIndex( BtreeIndexing::BtreeDictionary * dict, QAtomicInt & isCancelled );
-void makeFTSIndexXapian( BtreeIndexing::BtreeDictionary * dict, QAtomicInt & isCancelled );
 bool isCJKChar( ushort ch );
 
 class FTSResultsRequest : public Dictionary::DataRequest
@@ -91,7 +90,7 @@ class FTSResultsRequest : public Dictionary::DataRequest
   void checkArticles( QVector< uint32_t > const & offsets,
                       QStringList const & words,
                       QRegExp const & searchRegexp = QRegExp() );
-  QRegularExpression createMatchRegex( QRegExp const & searchRegexp );
+  QRegularExpression createMatchRegex( QRegExp const & searchRegexp ) const;
 
   void checkSingleArticle( uint32_t offset,
                            QStringList const & words,

--- a/src/fulltextsearch.cc
+++ b/src/fulltextsearch.cc
@@ -67,10 +67,10 @@ void Indexing::timeout()
     if ( Utils::AtomicInt::loadAcquire( isCancelled ) )
       break;
 
-    auto progress = dictionary->getIndexingFtsProgress();
-    if ( progress > 0 && progress < 100 ) {
-      emit sendNowIndexingName( QString::fromUtf8( dictionary->getName().c_str() )
-                                + QString( "......%1%2" ).arg( "%" ).arg( progress ) );
+    auto newProgress = dictionary->getIndexingFtsProgress();
+    if ( newProgress > 0 && newProgress < 100 ) {
+      emit sendNowIndexingName(
+        QString( "%1......%%2" ).arg( QString::fromStdString( dictionary->getName() ) ).arg( newProgress ) );
     }
   }
 }

--- a/src/fulltextsearch.cc
+++ b/src/fulltextsearch.cc
@@ -235,6 +235,10 @@ FullTextSearchDialog::FullTextSearchDialog( QWidget * parent,
   setNewIndexingName( ftsIdx.nowIndexingName() );
 
   connect( &ftsIdx, &FtsIndexing::newIndexingName, this, &FullTextSearchDialog::setNewIndexingName );
+  connect( GlobalBroadcaster::instance(),
+           &GlobalBroadcaster::indexingDictionary,
+           this,
+           &FullTextSearchDialog::setNewIndexingName );
 
   ui.searchMode->addItem( tr( "Whole words" ), WholeWords );
   ui.searchMode->addItem( tr( "Plain text"), PlainText );

--- a/src/fulltextsearch.hh
+++ b/src/fulltextsearch.hh
@@ -97,8 +97,6 @@ public:
 
   ~Indexing()
   {
-
-
     emit sendNowIndexingName( QString() );
     hasExited.release();
   }

--- a/src/fulltextsearch.hh
+++ b/src/fulltextsearch.hh
@@ -144,7 +144,7 @@ protected:
   Mutex nameMutex;
 
 private slots:
-  void setNowIndexedName( QString name );
+  void setNowIndexedName( const QString & name );
 
 signals:
   void newIndexingName( QString name );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -691,6 +691,10 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   groupListInToolbar->installEventFilter( this );
 
   connect( &ftsIndexing, &FTS::FtsIndexing::newIndexingName, this, &MainWindow::showFTSIndexingName );
+  connect( GlobalBroadcaster::instance(),
+           &GlobalBroadcaster::indexingDictionary,
+           this,
+           &MainWindow::showFTSIndexingName );
 
   applyProxySettings();
 


### PR DESCRIPTION
mdx's fulltext creation use the same dictionary object which handle the normal search .
When created the fulltext, `loadArticle` has to be locked by `fulltext` and `normal search`

Which means when creating mdx fulltext ,  the normal search will be affected.

Other dictionaries should face the same dilemma.  In this PR ,  use mdx as an experimental solution.