### PR TITLE
clean: avoid include `<QtGUI>`

### DIFF
--- a/src/article_maker.cc
+++ b/src/article_maker.cc
@@ -11,9 +11,11 @@
 #include "langcoder.hh"
 #include "utils.hh"
 #include "wstring_qt.hh"
+#include <QDir>
 #include <QFile>
 #include <QTextDocumentFragment>
 #include <QUrl>
+
 #include "fmt/core.h"
 #include "fmt/compile.h"
 

--- a/src/audiooutput.cc
+++ b/src/audiooutput.cc
@@ -1,7 +1,6 @@
 #include "audiooutput.hh"
 
 #include <QAudioFormat>
-#include <QDebug>
 #include <QtConcurrent/qtconcurrentrun.h>
 #include <QFuture>
 #include <QWaitCondition>

--- a/src/btreeidx.hh
+++ b/src/btreeidx.hh
@@ -7,15 +7,17 @@
 #include "dict/dictionary.hh"
 #include "file.hh"
 
+#include <algorithm>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <algorithm>
-#include <QVector>
-#include <QSet>
-#include <QList>
 
-#include <stdint.h>
+#include <QFuture>
+#include <QList>
+#include <QSet>
+#include <QVector>
+
 
 /// A base for the dictionary which creates a btree index to look up
 /// the words.

--- a/src/common/utils.hh
+++ b/src/common/utils.hh
@@ -3,14 +3,14 @@
 #ifndef UTILS_HH
 #define UTILS_HH
 
-#include <QString>
 #include <QAtomicInt>
-#include <QTextDocument>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QKeyEvent>
+#include <QString>
+#include <QTextDocument>
 #include <QUrl>
 #include <QUrlQuery>
-#include <QJsonObject>
-#include <QJsonDocument>
 #include <QWidget>
 #include "filetype.hh"
 

--- a/src/dict/bgl.cc
+++ b/src/dict/bgl.cc
@@ -2,43 +2,41 @@
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
 #include "bgl.hh"
-#include "btreeidx.hh"
 #include "bgl_babylon.hh"
+#include "btreeidx.hh"
+#include "chunkedstorage.hh"
 #include "file.hh"
 #include "folding.hh"
-#include "utf8.hh"
-#include "chunkedstorage.hh"
+#include "ftshelpers.hh"
+#include "gddebug.hh"
+#include "htmlescape.hh"
 #include "langcoder.hh"
 #include "language.hh"
-#include "gddebug.hh"
+#include "utf8.hh"
+#include "utils.hh"
 
-#include "htmlescape.hh"
-#include "ftshelpers.hh"
-
+#include <ctype.h>
+#include <list>
 #include <map>
 #include <set>
-#include <list>
-#include <zlib.h>
-#include <ctype.h>
 #include <string.h>
+#include <zlib.h>
 
 #ifdef _MSC_VER
 #include <stub_msvc.h>
 #endif
 
+#include <QAtomicInt>
+#include <QPainter>
+#include <QRegularExpression>
 #include <QSemaphore>
 #include <QThreadPool>
-#include <QAtomicInt>
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6,0,0))
 #include <QtCore5Compat/QRegExp>
 #else
 #include <QRegExp>
 #endif
-
-#include <QRegularExpression>
-
-#include "utils.hh"
 
 namespace Bgl {
 

--- a/src/dict/bgl_babylon.cc
+++ b/src/dict/bgl_babylon.cc
@@ -22,18 +22,20 @@
  * program. */
 
 #include "bgl_babylon.hh"
+#include "dictionary.hh"
+#include "gddebug.hh"
+#include "globalregex.hh"
+#include "htmlescape.hh"
+#include "iconv.hh"
+#include "ufile.hh"
+
 #include <algorithm>
-#include <cerrno>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
-#include "gddebug.hh"
-#include "ufile.hh"
-#include "iconv.hh"
-#include "htmlescape.hh"
+
 #include <QString>
-#include "dictionary.hh"
-#include "globalregex.hh"
+#include <QtEndian>
 
 #ifdef _WIN32
 #include <io.h>

--- a/src/dict/chinese.cc
+++ b/src/dict/chinese.cc
@@ -7,7 +7,6 @@
 // #ifdef Q_OS_MAC
 #include <opencc/opencc.h>
 // #endif
-#include <opencc/Export.hpp>
 // #include <opencc/SimpleConverter.hpp>
 #include "folding.hh"
 #include "gddebug.hh"

--- a/src/dict/customtransliteration.cc
+++ b/src/dict/customtransliteration.cc
@@ -1,5 +1,6 @@
 #include "customtransliteration.hh"
 #include "dictionary.hh"
+#include <QCoreApplication>
 
 namespace CustomTranslit {
 

--- a/src/dict/dictionary.hh
+++ b/src/dict/dictionary.hh
@@ -4,20 +4,22 @@
 #ifndef __DICTIONARY_HH_INCLUDED__
 #define __DICTIONARY_HH_INCLUDED__
 
-#include <vector>
-#include <string>
 #include <map>
-#include <QObject>
-#include <QWaitCondition>
-#include "sptr.hh"
-#include "ex.hh"
+#include <string>
+#include <vector>
 
-#include "wstring.hh"
-#include "langcoder.hh"
-#include "config.hh"
-#include "utils.hh"
+#include <QMutex>
+#include <QObject>
 #include <QString>
+#include <QWaitCondition>
+
+#include "config.hh"
+#include "ex.hh"
 #include "globalbroadcaster.hh"
+#include "langcoder.hh"
+#include "sptr.hh"
+#include "utils.hh"
+#include "wstring.hh"
 
 /// Abstract dictionary-related stuff
 namespace Dictionary {

--- a/src/dict/dsl.cc
+++ b/src/dict/dsl.cc
@@ -15,15 +15,11 @@
 #include "audiolink.hh"
 #include "langcoder.hh"
 #include "wstring_qt.hh"
-#include "zipfile.hh"
 #include "indexedzip.hh"
 #include "gddebug.hh"
 #include "tiff.hh"
-#include "fulltextsearch.hh"
 #include "ftshelpers.hh"
-#include "language.hh"
 
-#include <zlib.h>
 #include <map>
 #include <set>
 #include <string>
@@ -43,7 +39,6 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QPainter>
-#include <QMap>
 #include <QStringList>
 
 #include <QRegularExpression>

--- a/src/dict/epwing_book.hh
+++ b/src/dict/epwing_book.hh
@@ -1,15 +1,20 @@
 #ifndef __EPWING_BOOK_HH_INCLUDED__
 #define __EPWING_BOOK_HH_INCLUDED__
 
-#include <qglobal.h>
+#include "dict/dictionary.hh"
+#include "ex.hh"
+
+#include <QMap>
+#include <QStack>
+#include <QVector>
+#include <QtGlobal>
+
+#include <string>
+#include <vector>
 
 #if defined( Q_OS_WIN32 ) || defined( Q_OS_MAC )
 #define _FILE_OFFSET_BITS 64
 #endif
-
-#include "dict/dictionary.hh"
-#include "ex.hh"
-
 
 #include <QString>
 #if (QT_VERSION >= QT_VERSION_CHECK(6,0,0))
@@ -17,10 +22,7 @@
 #else
 #include <QTextCodec>
 #endif
-#include <QMap>
-#include <QVector>
-#include <vector>
-#include <string>
+
 
 #ifdef _MSC_VER
 #include <stub_msvc.h>

--- a/src/dict/lingualibre.cc
+++ b/src/dict/lingualibre.cc
@@ -1,8 +1,11 @@
 #include "lingualibre.hh"
 #include "utf8.hh"
 #include "audiolink.hh"
-#include <string>
+
+#include <QJsonArray>
 #include <QJsonDocument>
+
+#include <string>
 #include <utility>
 
 namespace Lingua {

--- a/src/dict/sdict.cc
+++ b/src/dict/sdict.cc
@@ -12,7 +12,6 @@
 #include "decompress.hh"
 #include "htmlescape.hh"
 #include "ftshelpers.hh"
-#include "wstring_qt.hh"
 
 #include <map>
 #include <set>
@@ -24,15 +23,12 @@
 
 #include <QString>
 #include <QSemaphore>
-#include <QThreadPool>
 #include <QAtomicInt>
-#include <QRegExp>
 #if (QT_VERSION >= QT_VERSION_CHECK(6,0,0))
 #include <QtCore5Compat>
 #endif
 #include <QRegularExpression>
 
-#include "ufile.hh"
 #include "utils.hh"
 
 namespace Sdict {

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -36,7 +36,6 @@
 
 #include <QString>
 #include <QSemaphore>
-#include <QThreadPool>
 #include <QAtomicInt>
 #if (QT_VERSION >= QT_VERSION_CHECK(6,0,0))
 #include <QtCore5Compat/QRegExp>
@@ -45,7 +44,6 @@
 #endif
 #include <QStringList>
 #include <QDomDocument>
-#include <QDomNode>
 #include "ufile.hh"
 #include "utils.hh"
 

--- a/src/fulltextsearch.hh
+++ b/src/fulltextsearch.hh
@@ -1,16 +1,20 @@
 #ifndef __FULLTEXTSEARCH_HH_INCLUDED__
 #define __FULLTEXTSEARCH_HH_INCLUDED__
 
+#include <QAbstractListModel>
+#include <QAction>
+#include <QList>
+#include <QTimer>
+#include <QThread>
+#include <QRunnable>
 #include <QSemaphore>
 #include <QStringList>
+
 #if (QT_VERSION >= QT_VERSION_CHECK(6,0,0))
 #include <QtCore5Compat/QRegExp>
 #else
 #include <QRegExp>
 #endif
-#include <QAbstractListModel>
-#include <QList>
-#include <QAction>
 
 #include "dict/dictionary.hh"
 #include "ui_fulltextsearch.h"

--- a/src/hotkeywrapper.cc
+++ b/src/hotkeywrapper.cc
@@ -6,8 +6,9 @@
 #include "hotkeywrapper.hh"
 #include "gddebug.hh"
 
+#include <QSessionManager>
+#include <QTimer>
 #include <QWidget>
-#include <QMainWindow>
 
 #ifdef Q_OS_WIN
 #include "mainwindow.hh"

--- a/src/hotkeywrapper.hh
+++ b/src/hotkeywrapper.hh
@@ -1,36 +1,39 @@
 #ifndef HOTKEYWRAPPER_H
 #define HOTKEYWRAPPER_H
 
-#include <QtGui>
+#include <QGuiApplication>
+#include <QThread>
+
+#include "config.hh"
+#include "ex.hh"
+#include "qtsingleapplication.h"
+#include "utils.hh"
 
 #ifdef HAVE_X11
 
-#include <set>
+  #include <set>
 
-#include <X11/Xlib.h>
-#include <X11/extensions/record.h>
-#if (QT_VERSION >= QT_VERSION_CHECK(6,0,0))
-#include <QGuiApplication>
-#else
-#include <QX11Info>
+  #include <X11/Xlib.h>
+  #include <X11/extensions/record.h>
+  #if ( QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 ) )
+    #include <QX11Info>
+  #endif
+  #include <X11/Xlibint.h>
+
+  #undef Bool
+  #undef min
+  #undef max
+
 #endif
-#include <X11/Xlibint.h>
 
-#undef Bool
-#undef min
-#undef max
-
+#ifdef Q_OS_WIN
+  #include <QAbstractNativeEventFilter>
 #endif
 
 #ifdef Q_OS_MAC
 #define __SECURITYHI__
 #include <Carbon/Carbon.h>
 #endif
-
-#include "ex.hh"
-#include "qtsingleapplication.h"
-#include "utils.hh"
-#include "config.hh"
 
 //////////////////////////////////////////////////////////////////////////
 

--- a/src/langcoder.cc
+++ b/src/langcoder.cc
@@ -5,13 +5,15 @@
 #include "language.hh"
 #include "utf8.hh"
 
+#include <QFileInfo>
+#include <QLocale>
+
 #ifdef _MSC_VER
 #include <stub_msvc.h>
 #endif
 #if (QT_VERSION >= QT_VERSION_CHECK(6,0,0))
 #include <QtCore5Compat/QRegExp>
 #endif
-#include <QLocale>
 
 // Language codes
 

--- a/src/langcoder.hh
+++ b/src/langcoder.hh
@@ -1,7 +1,8 @@
 #ifndef LANGCODER_H
 #define LANGCODER_H
 
-#include <QtGui>
+#include <QString>
+#include <QIcon>
 #include "wstring.hh"
 
 struct GDLangCode

--- a/src/language.cc
+++ b/src/language.cc
@@ -1,10 +1,8 @@
 #include "language.hh"
 #include "langcoder.hh"
 #include <map>
+#include <QMap>
 #include <QCoreApplication>
-
-#include <stdint.h>
-#include <QObject>
 
 namespace Language {
 

--- a/src/macos/machotkeywrapper.mm
+++ b/src/macos/machotkeywrapper.mm
@@ -2,6 +2,7 @@
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
 #include "hotkeywrapper.hh"
+#include <QTimer>
 #include <ApplicationServices/ApplicationServices.h>
 
 namespace MacKeyMapping

--- a/src/main.cc
+++ b/src/main.cc
@@ -16,7 +16,6 @@
 #endif
 
 #ifdef Q_OS_WIN32
-#include <QtCore/qt_windows.h>
   #include <windows.h>
 #endif
 
@@ -30,7 +29,6 @@
 #include <QtWebEngineCore/QWebEngineUrlScheme>
 
 #include "gddebug.hh"
-#include <QMutexLocker>
 #include <QMutex>
 
 #if defined(USE_BREAKPAD)

--- a/src/ui/about.cc
+++ b/src/ui/about.cc
@@ -2,11 +2,12 @@
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
 #include "about.hh"
-#include <QPushButton>
-#include <QtGui>
-#include <QSysInfo>
-
 #include "utils.hh"
+
+#include <QClipboard>
+#include <QFile>
+#include <QPushButton>
+#include <QSysInfo>
 
 About::About( QWidget * parent, std::vector< sptr< Dictionary::Class > > * dictonaries ): QDialog( parent )
 {

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -2,15 +2,19 @@
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
 #include "articleview.hh"
+#include "dict/programs.hh"
 #include "folding.hh"
 #include "fulltextsearch.hh"
 #include "gddebug.hh"
 #include "gestures.hh"
-#include "dict/programs.hh"
+#include "globalbroadcaster.hh"
+#include "speechclient.hh"
 #include "utils.hh"
 #include "webmultimediadownload.hh"
 #include "wildcard.hh"
 #include "wstring_qt.hh"
+#include <QBuffer>
+#include <QClipboard>
 #include <QCryptographicHash>
 #include <QDebug>
 #include <QDesktopServices>
@@ -25,8 +29,8 @@
 #include <QWebEngineScript>
 #include <QWebEngineScriptCollection>
 #include <QWebEngineSettings>
-#include <assert.h>
 #include <map>
+
 #if (QT_VERSION >= QT_VERSION_CHECK(5,0,0) && QT_VERSION < QT_VERSION_CHECK(6,0,0))
 #include <QWebEngineContextMenuData>
 #endif
@@ -40,11 +44,6 @@
 #include <QPainter>
 #endif
 
-#include <QBuffer>
-
-#include "speechclient.hh"
-
-#include "globalbroadcaster.hh"
 using std::map;
 using std::list;
 

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -4,7 +4,6 @@
 #include <QMenu>
 #include <QContextMenuEvent>
 #include <QProcess>
-#include "gddebug.hh"
 
 
 using std::vector;

--- a/src/ui/editdictionaries.hh
+++ b/src/ui/editdictionaries.hh
@@ -4,15 +4,16 @@
 #ifndef __EDITDICTIONARIES_HH_INCLUDED__
 #define __EDITDICTIONARIES_HH_INCLUDED__
 
-#include "dict/dictionary.hh"
 #include "config.hh"
-#include "ui_editdictionaries.h"
+#include "dict/dictionary.hh"
 #include "dict/sources.hh"
-#include "orderandprops.hh"
 #include "groups.hh"
 #include "instances.hh"
-#include <QNetworkAccessManager>
+#include "orderandprops.hh"
+#include "ui_editdictionaries.h"
 #include <QAction>
+#include <QNetworkAccessManager>
+#include <QPointer>
 
 class EditDictionaries: public QDialog
 {

--- a/src/ui/groups_widgets.cc
+++ b/src/ui/groups_widgets.cc
@@ -9,16 +9,16 @@
 #include "language.hh"
 #include "metadata.hh"
 
-//#include "initializing.hh"
-
-#include <QMenu>
 #include <QDir>
-#include <QIcon>
-#include <QMap>
-#include <QVector>
-#include <QFileInfo>
 #include <QFileDialog>
+#include <QFileInfo>
+#include <QIcon>
+#include <QImageReader>
+#include <QMap>
+#include <QMenu>
 #include <QMessageBox>
+#include <QTimer>
+#include <QVector>
 
 using std::vector;
 

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -43,7 +43,6 @@
 #include "historypanewidget.hh"
 #include "utils.hh"
 #include "help.hh"
-#include <qscreen.h>
 #include "ui_authentication.h"
 #include "resourceschemehandler.hh"
 
@@ -60,7 +59,6 @@
 #endif
 
 #include <QWebEngineSettings>
-#include <QWebEngineProfile>
 #include <QProxyStyle>
 
 #ifdef HAVE_X11

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -1,9 +1,11 @@
-#include "globalbroadcaster.hh"
 #include "keyboardstate.hh"
-#include "langcoder.hh"
 #include "language.hh"
 #include "preferences.hh"
 #include "help.hh"
+
+#include <QDebug>
+#include <QDir>
+#include <QFontDatabase>
 #include <QMessageBox>
 #include <QWebEngineProfile>
 #include <QWebEngineSettings>

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -10,6 +10,7 @@
 #include <QMouseEvent>
 #if (QT_VERSION < QT_VERSION_CHECK(6,0,0))
 #include <QDesktopWidget>
+#include <QScreen>
 #include <QStringList>
 #endif
 #include "gddebug.hh"


### PR DESCRIPTION
This is year 2023, and C/C++ will read every included header and then ignores most lines.

`<QtGUI>` includes every Qt header (a few hundreds) transitively.

This PR removes 3 `<QtGUI>` which are all got introduced before 2010.

(And fix every other header that depends on this "Include *EVERYTHING*" header)
