### PR TITLE
clean up mainwindow::translateInputFinished 

### DIFF
--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -641,10 +641,12 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   connect( translateBox->translateLine(), &QLineEdit::textChanged, this, &MainWindow::translateInputChanged );
 
-  connect( ui.translateLine, SIGNAL( returnPressed() ), this, SLOT( translateInputFinished() ) );
-
-  connect( translateBox->translateLine(), SIGNAL( returnPressed() ),
-           this, SLOT( translateInputFinished() ) );
+  connect( ui.translateLine, &QLineEdit::returnPressed, [ this ]() {
+    translateInputFinished( true );
+  } );
+  connect( translateBox->translateLine(), &QLineEdit::returnPressed, [ this ]() {
+    translateInputFinished( true );
+  } );
 
   connect( ui.wordList, &QListWidget::itemSelectionChanged, this, &MainWindow::wordListSelectionChanged );
 

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -2598,17 +2598,11 @@ bool MainWindow::eventFilter( QObject * obj, QEvent * ev )
 
 void MainWindow::wordListItemActivated( QListWidgetItem * item )
 {
-  if( wordListSelChanged )
+  if ( wordListSelChanged ) {
     wordListSelChanged = false;
+  }
   else {
-    // TODO: code duplication with translateInputFinished!
-
-    Qt::KeyboardModifiers mods = QApplication::keyboardModifiers();
-    if ( mods & (Qt::ControlModifier | Qt::ShiftModifier) )
-      addNewTab();
-
-    showTranslationFor( item->text() );
-    getCurrentArticleView()->focus();
+    respondToTranslationRequest( item->text(), true );
   }
 }
 

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -345,7 +345,7 @@ private slots:
 
   void currentGroupChanged( int );
   void translateInputChanged( QString const & );
-  void translateInputFinished( bool checkModifiers = true );
+  void translateInputFinished( bool checkModifiers );
 
   /// Closes any opened search in the article view, and focuses the translateLine/close main window to tray.
   void handleEsc();


### PR DESCRIPTION
* convert its SLOT usage to new syntax (there are only a few old SIGNAL/SLOT to be removed)
* slash a TODO from 2012

Interaction to test: Hold Ctrl or Shift, click a word from dropdown -> open in new tab

![image](https://github.com/xiaoyifang/goldendict-ng/assets/20123683/adde0a35-ad7c-4744-9868-232e5d76d69a)
