### PR TITLE
fix: modern style's .gddictname

### DIFF
--- a/src/stylesheets/article-style-st-modern.css
+++ b/src/stylesheets/article-style-st-modern.css
@@ -60,9 +60,9 @@ a:hover
   font-size: 12px;
   font-weight: normal;
   float: right;
-  border: 0px;
-  border-top-right-radius: 8px;
-  border-bottom-left-radius: 6px;
+  border: 0;
+  border-bottom-right-radius: 8px;
+  border-bottom-left-radius: 8px;
   margin: -6px;
   margin-bottom: 5px;
   margin-left: 2px;


### PR DESCRIPTION
Fix the consequence of adding paddings to the body. https://github.com/xiaoyifang/goldendict-ng/pull/650

|Before | After |
| -- | -- |
| ![image](https://github.com/xiaoyifang/goldendict-ng/assets/20123683/5b30559e-c1c6-421b-b8ee-188d8642c0b9) | ![image](https://github.com/xiaoyifang/goldendict-ng/assets/20123683/4cc9916e-0b03-4f5d-aa18-1dad10966d45)|
