### PR TITLE
fix: send to mainwindow got empty word

### DIFF
--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -494,7 +494,7 @@ void ScanPopup::engagePopup( bool forcePopup, bool giveFocus )
   if( cfg.preferences.scanToMainWindow && !forcePopup )
   {
     // Send translated word to main window istead of show popup
-    emit sendPhraseToMainWindow( definition->getWord() );
+    emit sendPhraseToMainWindow( pendingWord );
     return;
   }
 


### PR DESCRIPTION
regression from https://github.com/xiaoyifang/goldendict-ng/pull/736 due to Input Phase change: if the word is sent to mainwindow, then `definition->getWord()` would be empty

(unrelated: hopefully, the next release would be extremely perfect :sweat_smile: )