### PR TITLE
opt: use QFontCombox instead

### DIFF
--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -59,7 +59,7 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   // Load values into form
 
   ui.interfaceLanguage->addItem( tr( "System default" ), QString() );
-//  ui.fontFamilies->insertItem(0, tr( "System default" ), QString() );
+  //  ui.fontFamilies->insertItem(0, tr( "System default" ), QString() );
 
   // See which other translations do we have
 
@@ -103,8 +103,8 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
 
   if(!p.webFontFamily.isEmpty())
     ui.fontFamilies->setCurrentText( p.webFontFamily );
-  else{
-    ui.fontFamilies->setCurrentFont(QApplication::font());
+  else {
+    ui.fontFamilies->setCurrentFont( QApplication::font() );
   }
 
   ui.displayStyle->addItem( QIcon( ":/icons/programicon_old.png" ), tr( "Default" ), QString() );

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -59,8 +59,6 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   // Load values into form
 
   ui.interfaceLanguage->addItem( tr( "System default" ), QString() );
-  //  ui.fontFamilies->insertItem(0, tr( "System default" ), QString() );
-
   // See which other translations do we have
 
   QStringList availLocs = QDir( Config::getLocDir() ).entryList( QStringList( "*.qm" ),

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -59,7 +59,7 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   // Load values into form
 
   ui.interfaceLanguage->addItem( tr( "System default" ), QString() );
-  ui.fontFamilies->addItem( tr( "System default" ), QString() );
+//  ui.fontFamilies->insertItem(0, tr( "System default" ), QString() );
 
   // See which other translations do we have
 
@@ -99,20 +99,13 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
     }
   }
 
-#if( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
-  const QStringList fontFamilies = QFontDatabase::families();
-#else
-  QFontDatabase fontDb;
-  const QStringList fontFamilies = fontDb.families();
-#endif
-  for( const QString & family : fontFamilies )
-  {
-    ui.fontFamilies->addItem( family );
-  }
   prevWebFontFamily = p.webFontFamily;
 
   if(!p.webFontFamily.isEmpty())
     ui.fontFamilies->setCurrentText( p.webFontFamily );
+  else{
+    ui.fontFamilies->setCurrentFont(QApplication::font());
+  }
 
   ui.displayStyle->addItem( QIcon( ":/icons/programicon_old.png" ), tr( "Default" ), QString() );
   ui.displayStyle->addItem( QIcon( ":/icons/programicon.png" ), tr( "Classic" ), QString( "classic" ) );
@@ -566,7 +559,7 @@ void Preferences::on_buttonBox_accepted()
     QMessageBox::information( this, tr( "Changing Language" ),
                               tr( "Restart the program to apply the language change." ) );
 
-  auto currentFontFamily = ui.fontFamilies->currentText();
+  auto currentFontFamily = ui.fontFamilies->currentFont().family();
   if( prevWebFontFamily != currentFontFamily )
   {
     //reset to default font .

--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -264,7 +264,7 @@ however, the article from the topmost dictionary is shown.</string>
         </widget>
        </item>
        <item row="8" column="0">
-        <widget class="QComboBox" name="fontFamilies">
+        <widget class="QFontComboBox" name="fontFamilies">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>


### PR DESCRIPTION
this feature actually has not take effect .
As the article-style.css has already appointed the font family.

maybe delete this part?