### PR TITLE
opt: iconv remove unused parameter

### DIFF
--- a/src/common/iconv.cc
+++ b/src/common/iconv.cc
@@ -13,10 +13,11 @@ char const * const Iconv::Utf8 = "UTF-8";
 
 using gd::wchar;
 
-Iconv::Iconv( char const * to, char const * from )
+Iconv::Iconv( char const * from )
 #ifdef USE_ICONV
-// the to encoding must be UTF8
-    :state( iconv_open( Utf8, from ) )
+  // the to encoding must be UTF8
+  :
+  state( iconv_open( Utf8, from ) )
 #endif
 {
 #ifdef USE_ICONV
@@ -116,7 +117,7 @@ gd::wstring Iconv::toWstring( char const * fromEncoding, void const * fromData,
   if ( !dataSize )
     return {};
 
-  Iconv ic( Utf8, fromEncoding );
+  Iconv ic( fromEncoding );
 
   QString outStr = ic.convert(fromData, dataSize);
   return gd::toWString(outStr);
@@ -131,7 +132,7 @@ std::string Iconv::toUtf8( char const * fromEncoding, void const * fromData,
   if ( !dataSize )
     return {};
 
-  Iconv ic( Utf8, fromEncoding );
+  Iconv ic( fromEncoding );
 
   const QString outStr = ic.convert(fromData, dataSize);
   return outStr.toStdString();

--- a/src/common/iconv.hh
+++ b/src/common/iconv.hh
@@ -34,7 +34,7 @@ public:
   static char const * const Utf16Le;
   static char const * const Utf8;
 
-  Iconv( char const * to, char const * from );
+  Iconv( char const * from );
 
   ~Iconv();
 

--- a/src/dict/bgl_babylon.cc
+++ b/src/dict/bgl_babylon.cc
@@ -760,7 +760,7 @@ void Babylon::convertToUtf8( std::string &s, unsigned int type )
   if( charset == "UTF-8" )
     return;
 
-  Iconv conv_("UTF-8", charset.c_str());
+  Iconv conv_( charset.c_str() );
 
   size_t inbufbytes = s.size();
 

--- a/src/dict/hunspell.cc
+++ b/src/dict/hunspell.cc
@@ -645,7 +645,7 @@ void getSuggestionsForExpression( wstring const & expression,
 
 string encodeToHunspell( Hunspell & hunspell, wstring const & str )
 {
-  Iconv conv( hunspell.get_dic_encoding(), Iconv::GdWchar );
+  Iconv conv( Iconv::GdWchar );
 
   void const * in = str.data();
   size_t inLeft = str.size() * sizeof( wchar );
@@ -663,7 +663,7 @@ string encodeToHunspell( Hunspell & hunspell, wstring const & str )
 
 wstring decodeFromHunspell( Hunspell & hunspell, char const * str )
 {
-  Iconv conv( Iconv::GdWchar, hunspell.get_dic_encoding() );
+  Iconv conv( hunspell.get_dic_encoding() );
 
   void const * in = str;
   size_t inLeft = strlen( str );


### PR DESCRIPTION
In GoldenDict, the application uses utf-8 as the default encoding. There should be no other use.