### PR TITLE
fix: define PROGRAM_DATA_DIR for cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,11 @@ endif ()
 # Note: used as c++ string thus need surrounding " "
 add_compile_definitions(PROGRAM_VERSION="${PROJECT_VERSION}")
 
+if (LINUX)
+    # see: config.cc -> getProgramDataDir
+    add_compile_definitions(PROGRAM_DATA_DIR="${CMAKE_INSTALL_PREFIX}/share/goldendict")
+endif ()
+
 target_link_libraries(${GOLDENDICT} PRIVATE
         Qt6::Xml
         Qt6::Concurrent

--- a/src/config.cc
+++ b/src/config.cc
@@ -2276,7 +2276,7 @@ QString getProgramDataDir() noexcept
 {
   if ( isPortableVersion() )
     return QCoreApplication::applicationDirPath();
-
+// TODO: rewrite this in QStandardPaths::AppDataLocation
   #ifdef PROGRAM_DATA_DIR
   return PROGRAM_DATA_DIR;
   #else


### PR DESCRIPTION
Fix the problem of https://github.com/xiaoyifang/goldendict-ng/issues/729#issuecomment-1574896207 reported by @aaly11

The resources path for Linux is hardcoded :sweat_smile: :sweat_smile:

This only affects Linux build 

https://github.com/xiaoyifang/goldendict-ng/blob/87e20912147fe660d458568d3bccbea6836545db/goldendict.pro#L221

![image](https://github.com/xiaoyifang/goldendict-ng/assets/20123683/aa2c8ee4-e8ad-4c12-9623-15638555af97)
