### PR TITLE
fix global translateLineText not being updated 

### DIFF
--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -2347,10 +2347,13 @@ void MainWindow::setInputLineText( QString text, WildcardPolicy wildcardPolicy, 
   if ( wildcardPolicy == WildcardPolicy::EscapeWildcards )
     text = Folding::escapeWildcardSymbols( text );
 
-  if ( popupAction == NoPopupChange || cfg.preferences.searchInDock )
+  if ( popupAction == NoPopupChange || cfg.preferences.searchInDock ) {
     translateLine->setText( text );
-  else
+  }
+  else {
     translateBox->setText( text, popupAction == EnablePopup );
+  }
+  GlobalBroadcaster::instance()->translateLineText = text;
 }
 
 void MainWindow::handleEsc()


### PR DESCRIPTION
After [this commit](https://github.com/xiaoyifang/goldendict-ng/pull/808/files#diff-56c809abf8615ec9b8833e8e0ddc82d72ff689ed428040d4551b7cb2518b6a0fL630-R628) the global translateLineText doesn't update anymore. For example, when calling `goldendict <search>` from the terminal.
This PR ensures that when setInputLineText is called translateLineText is also updated.