### PR TITLE
fix: possible crash

### DIFF
--- a/.github/workflows/macos-homebrew-xapian.yml
+++ b/.github/workflows/macos-homebrew-xapian.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-11,macos-12]
-        qt_ver: [6.4.3]
+        qt_ver: [ 6.5.1 ]
         qt_arch: [clang_64]
     env:
       targetName: GoldenDict

--- a/.github/workflows/ubuntu-6.2-xapian.yml
+++ b/.github/workflows/ubuntu-6.2-xapian.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        qt_ver: [6.4.3]
+        qt_ver: [ 6.5.1 ]
         qt_arch: [gcc_64]
     env:
       version: 23.06.02

--- a/.github/workflows/windows-6.x-xapian.yml
+++ b/.github/workflows/windows-6.x-xapian.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-2019]
-        qt_ver: [6.4.3]
+        qt_ver: [6.5.1]
         qt_arch: [win64_msvc2019_64]
     env:
       targetName: GoldenDict.exe

--- a/src/ui/mainstatusbar.cc
+++ b/src/ui/mainstatusbar.cc
@@ -85,9 +85,12 @@ void MainStatusBar::showMessage(const QString & str, int timeout, const QPixmap 
   {
     timer->start( timeout );
   }
-  raise();
-  show();
-  move( QPoint( 0, parentWidget()->height() - height() ) );
+  if ( parentWidget() && parentWidget()->isVisible() ) {
+    raise();
+
+    show();
+    move( QPoint( 0, parentWidget()->height() - height() ) );
+  }
 }
 
 void MainStatusBar::mousePressEvent ( QMouseEvent * )

--- a/src/ui/mainstatusbar.cc
+++ b/src/ui/mainstatusbar.cc
@@ -87,7 +87,6 @@ void MainStatusBar::showMessage(const QString & str, int timeout, const QPixmap 
   }
   if ( parentWidget() && parentWidget()->isVisible() ) {
     raise();
-
     show();
     move( QPoint( 0, parentWidget()->height() - height() ) );
   }


### PR DESCRIPTION
Currently : this crash is only found when used with Qt6.5.1

details check #823 


------
Gussed Reason:

  StatusBar's parent widget is MainWindow.
  When Mainwindows invoke restoreState()  ,,   somehow the StatusBar's show method got affected and caused an access voilation.