### PR TITLE
fix: fulltext remove query word size check

### DIFF
--- a/src/ftshelpers.cc
+++ b/src/ftshelpers.cc
@@ -115,8 +115,7 @@ void tokenizeCJK( QStringList & indexWords, QRegularExpression wordRegExp, QStri
     bool parsed = false;
     QString hieroglyph;
     for( int x = 0; x < word.size(); x++ )
-      if ( Utils::isCJKChar( word.at( x ).unicode() ) )
-      {
+      if ( Utils::isCJKChar( word.at( x ).unicode() ) ) {
         parsed = true;
         hieroglyph.append( word[ x ] );
 
@@ -144,8 +143,7 @@ bool containCJK( QString const & str)
 {
   bool hasCJK = false;
   for(auto x : str)
-    if ( Utils::isCJKChar( x.unicode() ) )
-    {
+    if ( Utils::isCJKChar( x.unicode() ) ) {
       hasCJK = true;
       break;
     }

--- a/src/ftshelpers.cc
+++ b/src/ftshelpers.cc
@@ -115,7 +115,7 @@ void tokenizeCJK( QStringList & indexWords, QRegularExpression wordRegExp, QStri
     bool parsed = false;
     QString hieroglyph;
     for( int x = 0; x < word.size(); x++ )
-      if( isCJKChar( word.at( x ).unicode() ) )
+      if ( Utils::isCJKChar( word.at( x ).unicode() ) )
       {
         parsed = true;
         hieroglyph.append( word[ x ] );
@@ -144,92 +144,12 @@ bool containCJK( QString const & str)
 {
   bool hasCJK = false;
   for(auto x : str)
-    if( isCJKChar( x.unicode() ) )
+    if ( Utils::isCJKChar( x.unicode() ) )
     {
       hasCJK = true;
       break;
     }
   return hasCJK;
-}
-
-bool parseSearchString( QString const & str, QStringList & indexWords,
-                        QStringList & searchWords,
-                        QRegExp & searchRegExp, int searchMode,
-                        bool matchCase,
-                        int distanceBetweenWords,
-                        bool & hasCJK,
-                        bool ignoreWordsOrder )
-{
-  searchWords.clear();
-  indexWords.clear();
-  // QRegularExpression spacesRegExp( "\\W+", QRegularExpression::UseUnicodePropertiesOption );
-  // QRegularExpression wordRegExp( QString( "\\w{" ) + QString::number( FTS::MinimumWordSize ) + ",}", QRegularExpression::UseUnicodePropertiesOption );
-  // QRegularExpression setsRegExp( "\\[[^\\]]+\\]", QRegularExpression::CaseInsensitiveOption );
-  // QRegularExpression regexRegExp( "\\\\[afnrtvdDwWsSbB]|\\\\x([0-9A-Fa-f]{4})|\\\\0([0-7]{3})", QRegularExpression::CaseInsensitiveOption);
-
-  hasCJK = containCJK( str );
-
-  if( searchMode == FTS::WholeWords || searchMode == FTS::PlainText )
-  {
-    // Make words list for search in article text
-    searchWords = str.normalized( QString::NormalizationForm_C ).split( RX::Ftx::spacesRegExp, Qt::SkipEmptyParts );
-    // Make words list for index search
-    QStringList list =
-      str.normalized( QString::NormalizationForm_C ).toLower().split( RX::Ftx::spacesRegExp, Qt::SkipEmptyParts );
-
-    QString searchString;
-    if( hasCJK )
-    {
-      tokenizeCJK( indexWords, RX::Ftx::wordRegExp, list );
-      // QStringList allWords = str.split( spacesRegExp, Qt::SkipEmptyParts );
-      searchString         = makeHiliteRegExpString( list, searchMode, distanceBetweenWords, hasCJK , ignoreWordsOrder);
-    }
-    else
-    {
-      indexWords = list.filter( RX::Ftx::wordRegExp );
-      indexWords.removeDuplicates();
-
-      // Make regexp for results hilite
-
-      QStringList allWords = str.split( RX::Ftx::spacesRegExp, Qt::SkipEmptyParts );
-      searchString = makeHiliteRegExpString( allWords, searchMode, distanceBetweenWords,false, ignoreWordsOrder );
-    }
-    searchRegExp = QRegExp( searchString, matchCase ? Qt::CaseSensitive : Qt::CaseInsensitive, QRegExp::RegExp2 );
-    searchRegExp.setMinimal( true );
-    return !indexWords.isEmpty();
-  }
-  else
-  {
-    // Make words list for index search
-
-    QString tmp = str;
-
-    // Remove RegExp commands
-    if( searchMode == FTS::RegExp )
-      tmp.replace( RX::Ftx::regexRegExp, " " );
-
-    // Remove all symbol sets
-    tmp.replace( RX::Ftx::setsRegExp, " " );
-
-    QStringList const list =
-      tmp.normalized( QString::NormalizationForm_C ).toLower().split( RX::Ftx::spacesRegExp, Qt::SkipEmptyParts );
-
-    if( hasCJK )
-    {
-      tokenizeCJK( indexWords, RX::Ftx::wordRegExp, list );
-    }
-    else
-    {
-      indexWords = list.filter( RX::Ftx::wordRegExp );
-      indexWords.removeDuplicates();
-    }
-
-    searchRegExp = QRegExp( str, matchCase ? Qt::CaseSensitive : Qt::CaseInsensitive,
-                            searchMode == FTS::Wildcards ? QRegExp::WildcardUnix : QRegExp::RegExp2 );
-    searchRegExp.setMinimal( true );
-  }
-
-  return true;
 }
 
 void makeFTSIndex( BtreeIndexing::BtreeDictionary * dict, QAtomicInt & isCancelled )
@@ -343,11 +263,6 @@ void makeFTSIndex( BtreeIndexing::BtreeDictionary * dict, QAtomicInt & isCancell
   catch ( Xapian::Error & e ) {
     qWarning() << "create xapian index:" << QString::fromStdString( e.get_description() );
   }
-}
-
-bool isCJKChar( ushort ch )
-{
-  return Utils::isCJKChar(ch);
 }
 
 void FTSResultsRequest::run()

--- a/src/ftshelpers.hh
+++ b/src/ftshelpers.hh
@@ -16,23 +16,12 @@
 #include "folding.hh"
 #include "wstring_qt.hh"
 
-#include <string>
-
 namespace FtsHelpers
 {
 
 bool ftsIndexIsOldOrBad( BtreeIndexing::BtreeDictionary * dict );
 
-bool parseSearchString( QString const & str, QStringList & IndexWords,
-                        QStringList & searchWords,
-                        QRegExp & searchRegExp, int searchMode,
-                        bool matchCase,
-                        int distanceBetweenWords,
-                        bool & hasCJK,
-                        bool ignoreWordsOrder = false );
-
 void makeFTSIndex( BtreeIndexing::BtreeDictionary * dict, QAtomicInt & isCancelled );
-bool isCJKChar( ushort ch );
 
 class FTSResultsRequest : public Dictionary::DataRequest
 {

--- a/src/fulltextsearch.cc
+++ b/src/fulltextsearch.cc
@@ -327,27 +327,16 @@ void FullTextSearchDialog::setNewIndexingName( QString name )
 
 void FullTextSearchDialog::accept()
 {
-  QStringList list1, list2;
-  int mode = ui.searchMode->itemData( ui.searchMode->currentIndex() ).toInt();
+  const int mode = ui.searchMode->itemData( ui.searchMode->currentIndex() ).toInt();
 
   model->clear();
   matchedCount=0;
   ui.articlesFoundLabel->setText( tr( "Articles found: " ) + QString::number( results.size() ) );
 
-  bool hasCJK;
-  if ( !FtsHelpers::parseSearchString( ui.searchLine->text(),
-                                       list1,
-                                       list2,
-                                       searchRegExp,
-                                       mode,
-                                       false,
-                                       0,
-                                       hasCJK,
-                                       false ) ) {
+  if ( ui.searchLine->text().isEmpty() ) {
     QMessageBox message( QMessageBox::Warning,
                          "GoldenDict",
-                         tr( "The search line must contains at least one word containing " )
-                           + QString::number( MinimumWordSize ) + tr( " or more symbols" ),
+                         tr( "The querying word can not be empty." ),
                          QMessageBox::Ok,
                          this );
     message.exec();
@@ -369,11 +358,8 @@ void FullTextSearchDialog::accept()
   ui.searchProgressBar->show();
 
   // Make search requests
-
-  for( unsigned x = 0; x < activeDicts.size(); ++x )
-  {
-    if( !activeDicts[ x ] ->haveFTSIndex())
-    {
+  for ( unsigned x = 0; x < activeDicts.size(); ++x ) {
+    if ( !activeDicts[ x ]->haveFTSIndex() ) {
       continue;
     }
     //max results=100


### PR DESCRIPTION
Before:

the searching word must has more than 4 letters.  limited with the original fulltext index engine.
![image](https://github.com/xiaoyifang/goldendict-ng/assets/105986/561e3ddb-28af-424f-bab2-242824b962ad)


After:


![image](https://github.com/xiaoyifang/goldendict-ng/assets/105986/5d3e2038-5b1c-4386-8c0d-afa9764e82b6)
