### PR TITLE
clean: convert `MainWindow::addGlobalAction` SLOT to new syntax

### DIFF
--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -382,21 +382,31 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   trayIconMenu.addSeparator();
   connect( trayIconMenu.addAction( tr( "&Quit" ) ), &QAction::triggered, this, &MainWindow::quitApp );
 
-  addGlobalAction( &escAction, SLOT( handleEsc() ) );
+  addGlobalAction( &escAction, [ this ]() {
+    handleEsc();
+  } );
   escAction.setShortcut( QKeySequence( "Esc" ) );
 
-  addGlobalAction( &focusTranslateLineAction, SLOT( focusTranslateLine() ) );
+  addGlobalAction( &focusTranslateLineAction, [ this ]() {
+    focusTranslateLine();
+  } );
   focusTranslateLineAction.setShortcuts( QList< QKeySequence >() <<
                                          QKeySequence( "Alt+D" ) <<
                                          QKeySequence( "Ctrl+L" ) );
 
-  addGlobalAction( &focusHeadwordsDlgAction, SLOT( focusHeadwordsDialog() ) );
+  addGlobalAction( &focusHeadwordsDlgAction, [ this ]() {
+    focusHeadwordsDialog();
+  } );
   focusHeadwordsDlgAction.setShortcut( QKeySequence( "Ctrl+D" ) );
 
-  addGlobalAction( &focusArticleViewAction, SLOT( focusArticleView() ) );
+  addGlobalAction( &focusArticleViewAction, [ this ]() {
+    focusArticleView();
+  } );
   focusArticleViewAction.setShortcut( QKeySequence( "Ctrl+N" ) );
 
-  addGlobalAction( ui.fullTextSearchAction, SLOT( showFullTextSearchDialog() ) );
+  addGlobalAction( ui.fullTextSearchAction, [ this ]() {
+    showFullTextSearchDialog();
+  } );
 
   addTabAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
   addTabAction.setShortcut( QKeySequence( "Ctrl+T" ) );
@@ -1122,10 +1132,10 @@ MainWindow::~MainWindow()
 #endif
 }
 
-void MainWindow::addGlobalAction( QAction * action, const char * slot )
+void MainWindow::addGlobalAction( QAction * action, const std::function< void() > & slotFunc )
 {
   action->setShortcutContext( Qt::WidgetWithChildrenShortcut );
-  connect( action, SIGNAL( triggered() ), this, slot );
+  connect( action, &QAction::triggered, this, slotFunc );
 
   ui.centralWidget->addAction( action );
   ui.dictsPane->addAction( action );

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -10,6 +10,7 @@
 #include <QSystemTrayIcon>
 #include <QNetworkAccessManager>
 #include <QProgressDialog>
+#include <functional>
 #include "ui_mainwindow.h"
 #include "config.hh"
 #include "dict/dictionary.hh"
@@ -68,7 +69,7 @@ public slots:
   void quitApp();
 
 private:
-  void addGlobalAction( QAction * action, const char * slot );
+  void addGlobalAction( QAction * action, const std::function< void() > & slotFunc );
   void addGlobalActionsToDialog( QDialog * dialog );
   void addGroupComboBoxActionsToDialog( QDialog * dialog, GroupComboBox * pGroupComboBox );
   void removeGroupComboBoxActionsFromDialog( QDialog * dialog, GroupComboBox * pGroupComboBox );


### PR DESCRIPTION
Stop the madness of passing `char *` as a function.

Changed code was invented at https://github.com/goldendict/goldendict/pull/482/files which fix ShortCut sometimes doesn't work when focusing on side panels.

#### To test

Focus one of the side panels, press `Esc` `Alt+D` ......

#### Unrelated details

```
  addGlobalAction( &escAction, [ this ]() {
    handleEsc();
  } );
```

Can be alternatively written as below for C++11

```
  addGlobalAction( &escAction, std::bind(&MainWindow::handleEsc, this));
```

which means passing the member function `MainWindow::handleEsc` instanced as `this` to `addGlobalAction`.

`std::bind` is obsoleted by passing lambda with `this` captured after C++14. https://clang.llvm.org/extra/clang-tidy/checks/modernize/avoid-bind.html

Mandatry godblot: https://godbolt.org/z/fx4x7W3jd