### PR TITLE
clean: convert Scanpopup edictGroupRequested to new syntax

### DIFF
--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -741,11 +741,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   scanPopup->setStyleSheet( styleSheet() );
 
-  connect( scanPopup,
-           SIGNAL( editGroupRequested( unsigned ) ),
-           this,
-           SLOT( editDictionaries( unsigned ) ),
-           Qt::QueuedConnection );
+  connect( scanPopup, &ScanPopup::editGroupRequest, this, &MainWindow::editDictionaries, Qt::QueuedConnection );
 
   connect( scanPopup, &ScanPopup::sendPhraseToMainWindow, this, [ this ]( QString const & word ) {
     wordReceived( word );

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -149,8 +149,7 @@ ScanPopup::ScanPopup( QWidget * parent,
 
   addToolBar( Qt::RightToolBarArea, &dictionaryBar );
 
-  connect( &dictionaryBar, SIGNAL(editGroupRequested()),
-           this, SLOT(editGroupRequested()) );
+  connect( &dictionaryBar, &DictionaryBar::editGroupRequested, this, &ScanPopup::editGroupRequested );
   connect( this, &ScanPopup::closeMenu, &dictionaryBar, &DictionaryBar::closePopupMenu );
   connect( &dictionaryBar, &DictionaryBar::showDictionaryInfo, this, &ScanPopup::showDictionaryInfo );
   connect( &dictionaryBar, &DictionaryBar::openDictionaryFolder, this, &ScanPopup::openDictionaryFolder );
@@ -415,7 +414,7 @@ void ScanPopup::translateWordFromSelection()
 
 void ScanPopup::editGroupRequested()
 {
-  emit editGroupRequested( ui.groupList->getCurrentGroup() );
+  emit editGroupRequest( ui.groupList->getCurrentGroup() );
 }
 
 void ScanPopup::translateWordFromClipboard(QClipboard::Mode m)

--- a/src/ui/scanpopup.hh
+++ b/src/ui/scanpopup.hh
@@ -62,7 +62,7 @@ public:
 signals:
 
   /// Forwarded from the dictionary bar, so that main window could act on this.
-  void editGroupRequested( unsigned id );
+  void editGroupRequest( unsigned id );
   /// Send word to main window
   void sendPhraseToMainWindow( QString const & word );
   /// Close opened menus when window hide


### PR DESCRIPTION
Small change, to test, -> scanpopup -> right click dictioanryBar -> editDictioanries (if has group, jump to that group's edit page)

* old code has a SIGNAL and a SLOT both named editGroupRequested'
* rename the SIGNAL to editGroupRequest to avoid this ambiguity