### PR TITLE
clean: remove duplicated exCantReadFile definitions

### DIFF
--- a/src/dict/aard.cc
+++ b/src/dict/aard.cc
@@ -47,7 +47,6 @@ using BtreeIndexing::IndexInfo;
 namespace {
 
 DEF_EX_STR( exNotAardFile, "Not an AARD file", Dictionary::Ex )
-DEF_EX_STR( exCantReadFile, "Can't read file", Dictionary::Ex )
 DEF_EX_STR( exWordIsTooLarge, "Enountered a word that is too large:", Dictionary::Ex )
 DEF_EX_STR( exSuddenEndOfFile, "Sudden end of file", Dictionary::Ex )
 

--- a/src/dict/bgl_babylon.cc
+++ b/src/dict/bgl_babylon.cc
@@ -47,7 +47,6 @@
 
 using std::string;
 
-DEF_EX_STR( exCantReadFile, "Can't read file", Dictionary::Ex )
 DEF_EX( exUserAbort, "User abort", Dictionary::Ex )
 DEF_EX( exIconv, "Iconv library error", Dictionary::Ex )
 DEF_EX( exAllocation, "Error memory allocation", Dictionary::Ex )

--- a/src/dict/dictdfiles.cc
+++ b/src/dict/dictdfiles.cc
@@ -44,7 +44,7 @@ using BtreeIndexing::IndexInfo;
 
 namespace {
 
-DEF_EX_STR( exCantReadFile, "Can't read file", Dictionary::Ex )
+using Dictionary::exCantReadFile;
 DEF_EX( exFailedToReadLineFromIndex, "Failed to read line from index file", Dictionary::Ex )
 DEF_EX( exMalformedIndexFileLine, "Malformed index file line encountered", Dictionary::Ex )
 DEF_EX( exInvalidBase64, "Invalid base64 sequence encountered", Dictionary::Ex )

--- a/src/dict/dictionary.hh
+++ b/src/dict/dictionary.hh
@@ -42,6 +42,8 @@ DEF_EX( exIndexOutOfRange, "The supplied index is out of range", Ex )
 DEF_EX( exSliceOutOfRange, "The requested data slice is out of range", Ex )
 DEF_EX( exRequestUnfinished, "The request hasn't yet finished", Ex )
 
+DEF_EX_STR( exCantReadFile, "Can't read file", Dictionary::Ex )
+
 /// When you request a search to be performed in a dictionary, you get
 /// this structure in return. It accumulates search results over time.
 /// The finished() signal is emitted when the search has finished and there's

--- a/src/dict/dsl.cc
+++ b/src/dict/dsl.cc
@@ -76,7 +76,6 @@ using BtreeIndexing::IndexInfo;
 
 namespace {
 
-DEF_EX_STR( exCantReadFile, "Can't read file", Dictionary::Ex )
 DEF_EX( exUserAbort, "User abort", Dictionary::Ex )
 DEF_EX_STR( exDictzipError, "DICTZIP error", Dictionary::Ex )
 

--- a/src/dict/gls.cc
+++ b/src/dict/gls.cc
@@ -302,7 +302,7 @@ namespace {
 
 ////////////////// GLS Dictionary
 
-DEF_EX_STR( exCantReadFile, "Can't read file", Dictionary::Ex )
+using Dictionary::exCantReadFile;
 DEF_EX( exUserAbort, "User abort", Dictionary::Ex )
 DEF_EX_STR( exDictzipError, "DICTZIP error", Dictionary::Ex )
 

--- a/src/dict/sdict.cc
+++ b/src/dict/sdict.cc
@@ -47,7 +47,7 @@ using BtreeIndexing::IndexInfo;
 namespace {
 
 DEF_EX_STR( exNotDctFile, "Not an Sdictionary file", Dictionary::Ex )
-DEF_EX_STR( exCantReadFile, "Can't read file", Dictionary::Ex )
+using Dictionary::exCantReadFile;
 DEF_EX_STR( exWordIsTooLarge, "Enountered a word that is too large:", Dictionary::Ex )
 DEF_EX_STR( exSuddenEndOfFile, "Sudden end of file", Dictionary::Ex )
 

--- a/src/dict/slob.cc
+++ b/src/dict/slob.cc
@@ -61,7 +61,7 @@ using BtreeIndexing::IndexedWords;
 using BtreeIndexing::IndexInfo;
 
 DEF_EX_STR( exNotSlobFile, "Not an Slob file", Dictionary::Ex )
-DEF_EX_STR( exCantReadFile, "Can't read file", Dictionary::Ex )
+using Dictionary::exCantReadFile;
 DEF_EX_STR( exCantDecodeFile, "Can't decode file", Dictionary::Ex )
 DEF_EX_STR( exNoCodecFound, "No text codec found", Dictionary::Ex )
 DEF_EX( exUserAbort, "User abort", Dictionary::Ex )

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -74,7 +74,7 @@ DEF_EX_STR( exNoSynFile, "No corresponding .syn file was found for", Dictionary:
 DEF_EX( ex64BitsNotSupported, "64-bit indices are not presently supported, sorry", Dictionary::Ex )
 DEF_EX( exDicttypeNotSupported, "Dictionaries with dicttypes are not supported, sorry", Dictionary::Ex )
 
-DEF_EX_STR( exCantReadFile, "Can't read file", Dictionary::Ex )
+using Dictionary::exCantReadFile;
 DEF_EX_STR( exWordIsTooLarge, "Enountered a word that is too large:", Dictionary::Ex )
 DEF_EX_STR( exSuddenEndOfFile, "Sudden end of file", Dictionary::Ex )
 DEF_EX_STR( exDictzipError, "DICTZIP error", Dictionary::Ex )

--- a/src/dict/xdxf.cc
+++ b/src/dict/xdxf.cc
@@ -81,7 +81,7 @@ quint32 getLanguageId( const QString & lang )
 
 namespace {
 
-DEF_EX_STR( exCantReadFile, "Can't read file", Dictionary::Ex )
+using Dictionary::exCantReadFile;
 DEF_EX_STR( exNotXdxfFile, "The file is not an XDXF file:", Dictionary::Ex )
 DEF_EX( exCorruptedIndex, "The index file is corrupted", Dictionary::Ex )
 DEF_EX_STR( exDictzipError, "DICTZIP error", Dictionary::Ex )

--- a/src/dict/zim.cc
+++ b/src/dict/zim.cc
@@ -58,7 +58,7 @@ using BtreeIndexing::IndexedWords;
 using BtreeIndexing::IndexInfo;
 
 DEF_EX_STR( exNotZimFile, "Not an Zim file", Dictionary::Ex )
-DEF_EX_STR( exCantReadFile, "Can't read file", Dictionary::Ex )
+using Dictionary::exCantReadFile;
 DEF_EX_STR( exInvalidZimHeader, "Invalid Zim header", Dictionary::Ex )
 DEF_EX( exUserAbort, "User abort", Dictionary::Ex )
 


### PR DESCRIPTION
Obviously, it is a result of copy-paste programming