### PR TITLE
fix: macOS missing slot warning

### DIFF
--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -243,9 +243,9 @@ ScanPopup::ScanPopup( QWidget * parent,
 
 #ifdef Q_OS_MAC
   connect( &MouseOver::instance(),
-    SIGNAL( hovered( QString const &, bool ) ),
+    &MouseOver::hovered,
     this,
-    SLOT( handleInputWord( QString const &, bool ) ) );
+    &ScanPopup::handleInputWord);
 #endif
 
   hideTimer.setSingleShot( true );


### PR DESCRIPTION
https://github.com/xiaoyifang/goldendict-ng/issues/880