### PR TITLE
Refactor DataRequest Experiment 1

### DIFF
--- a/src/article_maker.hh
+++ b/src/article_maker.hh
@@ -34,14 +34,14 @@ public:
 
   /// Looks up the given phrase within the given group, and creates a full html
   /// page text containing its definition.
-  /// The result is returned as Dictionary::DataRequest just like dictionaries
+  /// The result is returned as Request::Data just like dictionaries
   /// themselves do. The difference is that the result is a complete html page
   /// with all definitions from all the relevant dictionaries.
   /// Contexts is a map of context values to be passed to each dictionary, where
   /// the keys are dictionary ids.
   /// If mutedDicts is not empty, the search would be limited only to those
   /// dictionaries in group which aren't listed there.
-  sptr< Dictionary::DataRequest > makeDefinitionFor( QString const & word, unsigned groupId,
+  sptr< Request::Dict > makeDefinitionFor( QString const & word, unsigned groupId,
                                                      QMap< QString, QString > const & contexts,
                                                      QSet< QString > const & mutedDicts =
                                                        QSet< QString >(),
@@ -51,13 +51,13 @@ public:
   /// Makes up a text which states that no translation for the given word
   /// was found. Sometimes it's better to call this directly when it's already
   /// known that there's no translation.
-  sptr< Dictionary::DataRequest > makeNotFoundTextFor( QString const & word, QString const & group ) const;
+  sptr< Request::Dict > makeNotFoundTextFor( QString const & word, QString const & group ) const;
 
   /// Creates an 'untitled' page. The result is guaranteed to be instant.
-  sptr< Dictionary::DataRequest > makeEmptyPage() const;
+  sptr< Request::Dict > makeEmptyPage() const;
 
   /// Create page with one picture
-  sptr< Dictionary::DataRequest > makePicturePage( std::string const & url ) const;
+  sptr< Request::Dict > makePicturePage( std::string const & url ) const;
 
   /// Add base path to file path if it's relative and file not found
   /// Return true if path successfully adjusted
@@ -77,7 +77,7 @@ private:
 
 /// The request specific to article maker. This should really be private,
 /// but we need it to be handled by moc.
-class ArticleRequest: public Dictionary::DataRequest
+class ArticleRequest: public Request::Article
 {
   Q_OBJECT
 
@@ -87,8 +87,8 @@ class ArticleRequest: public Dictionary::DataRequest
   std::vector< sptr< Dictionary::Class > > activeDicts;
   
   std::set< gd::wstring, std::less<> > alts; // Accumulated main forms
-  std::list< sptr< Dictionary::WordSearchRequest > > altSearches;
-  std::list< sptr< Dictionary::DataRequest > > bodyRequests;
+  std::list< sptr< Request::WordSearch > > altSearches;
+  std::list< sptr< Request::Article > > bodyRequests;
   bool altsDone{ false };
   bool bodyDone{ false };
   bool foundAnyDefinitions{ false };
@@ -135,8 +135,6 @@ private slots:
 
 private:
   int htmlTextSize( QString html );
-  /// Appends the given string to 'data', with locking its mutex.
-  void appendToData( std::string const & );
 
   /// Uses stemmedWordFinder to perform the next step of looking up word
   /// combinations.
@@ -153,7 +151,7 @@ private:
 
   /// Find end of corresponding </div> tag
   int findEndOfCloseDiv( QString const &, int pos );
-  bool isCollapsable( Dictionary::DataRequest & req,QString const & dictId );
+  bool isCollapsable( Request::Article & req,QString const & dictId );
 };
 
 

--- a/src/article_netmgr.hh
+++ b/src/article_netmgr.hh
@@ -120,7 +120,7 @@ public:
   /// If it succeeds, the result is a dictionary request object. Otherwise, an
   /// empty pointer is returned.
   /// The function can optionally set the Content-Type header correspondingly.
-  sptr< Dictionary::DataRequest > getResource( QUrl const & url,
+  sptr< Request::Dict > getResource( QUrl const & url,
                                                QString & contentType );
 
   virtual QNetworkReply * getArticleReply( QNetworkRequest const & req );
@@ -131,7 +131,7 @@ class ArticleResourceReply: public QNetworkReply
 {
   Q_OBJECT
 
-  sptr< Dictionary::DataRequest > req;
+  sptr< Request::Dict > req;
   qint64 alreadyRead;
 
   QAtomicInt finishSignalSent;
@@ -140,7 +140,7 @@ public:
 
   ArticleResourceReply( QObject * parent,
                         QNetworkRequest const &,
-                        sptr< Dictionary::DataRequest > const &,
+                        sptr< Request::Dict > const &,
                         QString const & contentType );
 
   ~ArticleResourceReply();

--- a/src/btreeidx.cc
+++ b/src/btreeidx.cc
@@ -420,14 +420,14 @@ BtreeWordSearchRequest::~BtreeWordSearchRequest()
   f.waitForFinished();
 }
 
-sptr< Dictionary::WordSearchRequest > BtreeDictionary::prefixMatch(
+sptr< Request::WordSearch > BtreeDictionary::prefixMatch(
   wstring const & str, unsigned long maxResults )
   
 {
   return std::make_shared<BtreeWordSearchRequest>( *this, str, 0, -1, true, maxResults );
 }
 
-sptr< Dictionary::WordSearchRequest > BtreeDictionary::stemmedMatch(
+sptr< Request::WordSearch > BtreeDictionary::stemmedMatch(
   wstring const & str, unsigned minLength, unsigned maxSuffixVariation,
   unsigned long maxResults )
   

--- a/src/btreeidx.hh
+++ b/src/btreeidx.hh
@@ -167,11 +167,11 @@ public:
 
   /// This function does the search using the btree index. Derivatives usually
   /// need not to implement this function.
-  virtual sptr< Dictionary::WordSearchRequest > prefixMatch( wstring const &,
+  virtual sptr< Request::WordSearch > prefixMatch( wstring const &,
                                                              unsigned long )
     ;
 
-  virtual sptr< Dictionary::WordSearchRequest > stemmedMatch( wstring const &,
+  virtual sptr< Request::WordSearch > stemmedMatch( wstring const &,
                                                               unsigned minLength,
                                                               unsigned maxSuffixVariation,
                                                               unsigned long maxResults )
@@ -218,7 +218,7 @@ protected:
   friend class FTSResultsRequest;
 };
 
-class BtreeWordSearchRequest: public Dictionary::WordSearchRequest
+class BtreeWordSearchRequest: public Request::WordSearch
 {
 protected:
   BtreeDictionary & dict;

--- a/src/dict/aard.cc
+++ b/src/dict/aard.cc
@@ -250,7 +250,7 @@ class AardDictionary: public BtreeIndexing::BtreeDictionary
     inline quint32 getLangTo() const override
     { return idxHeader.langTo; }
 
-    sptr< Dictionary::DataRequest > getArticle( wstring const &,
+    sptr< Request::Article > getArticle( wstring const &,
                                                         vector< wstring > const & alts,
                                                         wstring const &,
                                                         bool ignoreDiacritics ) override
@@ -258,7 +258,7 @@ class AardDictionary: public BtreeIndexing::BtreeDictionary
 
     QString const& getDescription() override;
 
-    sptr< Dictionary::DataRequest >
+    sptr< Request::Blob >
     getSearchResults( QString const & searchString, int searchMode, bool matchCase, bool ignoreDiacritics ) override;
     void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
@@ -618,7 +618,7 @@ void AardDictionary::getArticleText( uint32_t articleAddress, QString & headword
   }
 }
 
-sptr< Dictionary::DataRequest >
+sptr< Request::Blob >
 AardDictionary::getSearchResults( QString const & searchString, int searchMode, bool matchCase, bool ignoreDiacritics )
 {
   return std::make_shared< FtsHelpers::FTSResultsRequest >( *this,
@@ -630,7 +630,7 @@ AardDictionary::getSearchResults( QString const & searchString, int searchMode, 
 
 /// AardDictionary::getArticle()
 
-class AardArticleRequest: public Dictionary::DataRequest
+class AardArticleRequest: public Request::Article
 {
   wstring word;
   vector< wstring > alts;
@@ -778,7 +778,7 @@ void AardArticleRequest::run()
   finish();
 }
 
-sptr< Dictionary::DataRequest > AardDictionary::getArticle( wstring const & word,
+sptr< Request::Article > AardDictionary::getArticle( wstring const & word,
                                                             vector< wstring > const & alts,
                                                             wstring const &,
                                                             bool ignoreDiacritics )

--- a/src/dict/bgl.cc
+++ b/src/dict/bgl.cc
@@ -209,19 +209,19 @@ namespace
     inline quint32 getLangTo() const override
     { return idxHeader.langTo; }
 
-    sptr< Dictionary::WordSearchRequest > findHeadwordsForSynonym( wstring const & ) override
+    sptr< Request::WordSearch > findHeadwordsForSynonym( wstring const & ) override
       ;
 
-    sptr< Dictionary::DataRequest > getArticle( wstring const &,
+    sptr< Request::Article > getArticle( wstring const &,
                                                         vector< wstring > const & alts,
                                                         wstring const &,
                                                         bool ignoreDiacritics ) override
       ;
 
-    sptr< Dictionary::DataRequest > getResource( string const & name ) override
+    sptr< Request::Blob > getResource( string const & name ) override
       ;
 
-    sptr< Dictionary::DataRequest >
+    sptr< Request::Blob >
     getSearchResults( QString const & searchString, int searchMode, bool matchCase, bool ignoreDiacritics ) override;
     QString const& getDescription() override;
 
@@ -475,7 +475,7 @@ namespace
 
 /// BglDictionary::findHeadwordsForSynonym()
 
-class BglHeadwordsRequest: public Dictionary::WordSearchRequest
+class BglHeadwordsRequest: public Request::WordSearch
 {
   wstring str;
   BglDictionary & dict;
@@ -556,7 +556,7 @@ void BglHeadwordsRequest::run()
   finish();
 }
 
-sptr< Dictionary::WordSearchRequest >
+sptr< Request::WordSearch >
   BglDictionary::findHeadwordsForSynonym( wstring const & word )
   
 {
@@ -596,7 +596,7 @@ string postfixToSuperscript( string const & in )
 /// BglDictionary::getArticle()
 
 
-class BglArticleRequest: public Dictionary::DataRequest
+class BglArticleRequest: public Request::Article
 {
   wstring word;
   vector< wstring > alts;
@@ -848,7 +848,7 @@ void BglArticleRequest::run()
   finish();
 }
 
-sptr< Dictionary::DataRequest > BglDictionary::getArticle( wstring const & word,
+sptr< Request::Article > BglDictionary::getArticle( wstring const & word,
                                                            vector< wstring > const & alts,
                                                            wstring const &,
                                                            bool ignoreDiacritics )
@@ -860,7 +860,7 @@ sptr< Dictionary::DataRequest > BglDictionary::getArticle( wstring const & word,
 
 //// BglDictionary::getResource()
 
-class BglResourceRequest: public Dictionary::DataRequest
+class BglResourceRequest: public Request::Blob
 {
 
   QMutex & idxMutex;
@@ -968,7 +968,7 @@ void BglResourceRequest::run()
   finish();
 }
 
-sptr< Dictionary::DataRequest > BglDictionary::getResource( string const & name )
+sptr< Request::Blob > BglDictionary::getResource( string const & name )
   
 {
   return std::shared_ptr<BglResourceRequest>(new BglResourceRequest(idxMutex, idx, idxHeader.resourceListOffset,
@@ -1055,7 +1055,7 @@ sptr< Dictionary::DataRequest > BglDictionary::getResource( string const & name 
   }
 }
 
-sptr< Dictionary::DataRequest > BglDictionary::getSearchResults( QString const & searchString,
+sptr< Request::Blob > BglDictionary::getSearchResults( QString const & searchString,
                                                                  int searchMode,
                                                                  bool matchCase,
 

--- a/src/dict/dictdfiles.cc
+++ b/src/dict/dictdfiles.cc
@@ -118,7 +118,7 @@ public:
   inline quint32 getLangTo() const override
   { return idxHeader.langTo; }
 
-  sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Request::Article > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
                                                       bool ignoreDiacritics ) override
@@ -126,7 +126,7 @@ public:
 
   QString const& getDescription() override;
 
-  sptr< Dictionary::DataRequest >
+  sptr< Request::Blob >
   getSearchResults( QString const & searchString, int searchMode, bool matchCase, bool ignoreDiacritics ) override;
   void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
@@ -246,7 +246,7 @@ uint32_t decodeBase64( string const & str )
   return number;
 }
 
-sptr< Dictionary::DataRequest > DictdDictionary::getArticle( wstring const & word,
+sptr< Request::Article > DictdDictionary::getArticle( wstring const & word,
                                                              vector< wstring > const & alts,
                                                              wstring const &,
                                                              bool ignoreDiacritics )
@@ -410,7 +410,7 @@ sptr< Dictionary::DataRequest > DictdDictionary::getArticle( wstring const & wor
     }
 
     if ( mainArticles.empty() && alternateArticles.empty() )
-      return std::make_shared<Dictionary::DataRequestInstant>( false );
+      return std::make_shared<Request::ArticleInstant >( false );
 
     string result;
 
@@ -422,8 +422,8 @@ sptr< Dictionary::DataRequest > DictdDictionary::getArticle( wstring const & wor
     for( i = alternateArticles.begin(); i != alternateArticles.end(); ++i )
       result += i->second;
 
-    sptr< Dictionary::DataRequestInstant > ret =
-      std::make_shared<Dictionary::DataRequestInstant>( true );
+    auto ret =
+      std::make_shared<Request::ArticleInstant >( true );
 
     ret->getData().resize( result.size() );
 
@@ -433,7 +433,7 @@ sptr< Dictionary::DataRequest > DictdDictionary::getArticle( wstring const & wor
   }
   catch( std::exception & e )
   {
-    return std::make_shared<Dictionary::DataRequestInstant>( QString( e.what() ) );
+    return std::make_shared<Request::ArticleInstant >( QString( e.what() ) );
   }
 }
 
@@ -442,7 +442,7 @@ QString const& DictdDictionary::getDescription()
     if( !dictionaryDescription.isEmpty() )
         return dictionaryDescription;
 
-    sptr< Dictionary::DataRequest > req =
+   auto req =
       getArticle(  U"00databaseinfo" , vector< wstring >(), wstring(), false );
 
     if ( req->dataSize() > 0 ) {
@@ -563,7 +563,7 @@ void DictdDictionary::getArticleText( uint32_t articleAddress, QString & headwor
   }
 }
 
-sptr< Dictionary::DataRequest >
+sptr< Request::Blob >
 DictdDictionary::getSearchResults( QString const & searchString, int searchMode, bool matchCase, bool ignoreDiacritics )
 {
   return std::make_shared< FtsHelpers::FTSResultsRequest >( *this,

--- a/src/dict/dictionary.hh
+++ b/src/dict/dictionary.hh
@@ -20,6 +20,7 @@
 #include "sptr.hh"
 #include "utils.hh"
 #include "wstring.hh"
+#include "dictionary_requests.hh"
 
 /// Abstract dictionary-related stuff
 namespace Dictionary {
@@ -38,224 +39,7 @@ enum Property
 };
 
 DEF_EX( Ex, "Dictionary error", std::exception )
-DEF_EX( exIndexOutOfRange, "The supplied index is out of range", Ex )
-DEF_EX( exSliceOutOfRange, "The requested data slice is out of range", Ex )
-DEF_EX( exRequestUnfinished, "The request hasn't yet finished", Ex )
-
 DEF_EX_STR( exCantReadFile, "Can't read file", Dictionary::Ex )
-
-/// When you request a search to be performed in a dictionary, you get
-/// this structure in return. It accumulates search results over time.
-/// The finished() signal is emitted when the search has finished and there's
-/// no more matches to be expected. Note that before connecting to it, check
-/// the result of isFinished() -- if it's 'true', the search was instantaneous.
-/// Destroy the object when you are not interested in results anymore.
-///
-/// Creating, destroying and calling member functions of the requests is done
-/// in the GUI thread, however. Therefore, it is important to make sure those
-/// operations are fast (this is most important for word searches, where
-/// new requests are created and old ones deleted immediately upon a user
-/// changing query).
-class Request: public QObject
-{
-  Q_OBJECT
-
-public:
-  Request( QObject * parent = nullptr ) : QObject( parent )
-  {
-  }
-  /// Returns whether the request has been processed in full and finished.
-  /// This means that the data accumulated is final and won't change anymore.
-  bool isFinished();
-
-  /// Either returns an empty string in case there was no error processing
-  /// the request, or otherwise a human-readable string describing the problem.
-  /// Note that an empty result, such as a lack of word or of an article isn't
-  /// an error -- but any kind of failure to connect to, or read the dictionary
-  /// is.
-  QString getErrorString();
-
-  /// Cancels the ongoing request. This may make Request destruct faster some
-  /// time in the future, Use this in preparation to destruct many Requests,
-  /// so that they'd be cancelling in parallel. When the request was fully
-  /// cancelled, it must emit the finished() signal, either as a result of an
-  /// actual finish which has happened just before the cancellation, or solely as
-  /// a result of a request being cancelled (in the latter case, the actual
-  /// request result may be empty or incomplete). That is, finish() must be
-  /// called by a derivative at least once if cancel() was called, either after
-  /// or before it was called.
-  virtual void cancel()=0;
-
-  virtual ~Request()
-  {}
-
-signals:
-
-  /// This signal is emitted when more data becomes available. Local
-  /// dictionaries typically don't call this, since it is preferred that all
-  /// data would be available from them at once, but network dictionaries
-  /// might call that.
-  void updated();
-
-  /// This signal is emitted when the request has been processed in full and
-  /// finished. That is, it's emitted when isFinished() turns true.
-  void finished();
-
-  void matchCount(int);
-
-protected:
-
-  /// Called by derivatives to signal update().
-  void update();
-
-  /// Called by derivatives to set isFinished() flag and signal finished().
-  void finish();
-
-  /// Sets the error string to be returned by getErrorString().
-  void setErrorString( QString const & );
-
-private:
-
-  QAtomicInt isFinishedFlag;
-
-  QMutex errorStringMutex;
-  QString errorString;
-};
-
-/// This structure represents the word found. In addition to holding the
-/// word itself, it also holds its weight. It is 0 by default. Negative
-/// values should be used to store distance from Levenstein-like matching
-/// algorithms. Positive values are used by morphology matches.
-struct WordMatch
-{
-  wstring word;
-  int weight;
-
-  WordMatch(): weight( 0 ) {}
-  WordMatch( wstring const & word_ ): word( word_ ), weight( 0 ){}
-  WordMatch( wstring const & word_, int weight_ ): word( word_ ),
-    weight( weight_ ) {}
-};
-
-/// This request type corresponds to all types of word searching operations.
-class WordSearchRequest: public Request
-{
-  Q_OBJECT
-
-public:
-
-  WordSearchRequest(): uncertain( false )
-  {}
-
-  /// Returns the number of matches found. The value can grow over time
-  /// unless isFinished() is true.
-  size_t matchesCount();
-
-  /// Returns the match with the given zero-based index, which should be less
-  /// than matchesCount().
-  WordMatch operator [] ( size_t index ) ;
-
-  /// Returns all the matches found. Since no further locking can or would be
-  /// done, this can only be called after the request has finished.
-  vector< WordMatch > & getAllMatches() ;
-
-  /// Returns true if the match was uncertain -- that is, there may be more
-  /// results in the dictionary itself, the dictionary index isn't good enough
-  /// to tell that.
-  bool isUncertain() const
-  { return uncertain; }
-
-  /// Add match if one is not presented in matches list
-  void addMatch( WordMatch const & match );
-
-protected:
-
-  // Subclasses should be filling up the 'matches' array, locking the mutex when
-  // whey work with it.
-  QMutex dataMutex;
-
-  vector< WordMatch > matches;
-  bool uncertain;
-};
-
-/// This request type corresponds to any kinds of data responses where a
-/// single large blob of binary data is returned. It currently used of article
-/// bodies and resources.
-class DataRequest: public Request
-{
-  Q_OBJECT
-
-public:
-  /// Returns the number of bytes read, with a -1 meaning that so far it's
-  /// uncertain whether resource even exists or not, and any non-negative value
-  /// meaning that that amount of bytes is not available.
-  /// If -1 is still being returned after the request has finished, that means
-  /// the resource wasn't found.
-  long dataSize();
-
-  /// Writes "size" bytes starting from "offset" of the data read to the given
-  /// buffer. "size + offset" must be <= than dataSize().
-  void getDataSlice( size_t offset, size_t size, void * buffer );
-  void appendDataSlice( const void * buffer, size_t size );
-
-  /// Returns all the data read. Since no further locking can or would be
-  /// done, this can only be called after the request has finished.
-  vector< char > & getFullData() ;
-
-  DataRequest( QObject * parent = 0 ) : Request( parent ), hasAnyData( false )
-  {
-  }
-
-protected:
-
-  // Subclasses should be filling up the 'data' array, locking the mutex when
-  // whey work with it.
-  QMutex dataMutex;
-
-  bool hasAnyData; // With this being false, dataSize() always returns -1
-  vector< char > data;
-};
-
-/// A helper class for synchronous word search implementations.
-class WordSearchRequestInstant: public WordSearchRequest
-{
-public:
-
-  WordSearchRequestInstant()
-  {
-    finish();
-  }
-
-  void cancel() override {}
-
-  vector< WordMatch > & getMatches()
-  {
-    return matches;
-  }
-
-  void setUncertain( bool value )
-  {
-    uncertain = value;
-  }
-};
-
-/// A helper class for synchronous data read implementations.
-class DataRequestInstant: public DataRequest
-{
-public:
-
-  DataRequestInstant( bool succeeded )
-  { hasAnyData = succeeded; finish(); }
-
-  DataRequestInstant( QString const & errorString )
-  { setErrorString( errorString ); finish(); }
-
-  virtual void cancel()
-  {}
-
-  vector< char > & getData()
-  { return data; }
-};
 
 /// Dictionary features. Different dictionaries can possess different features,
 /// which hint at some of their aspects.
@@ -392,7 +176,7 @@ public:
   /// prefix results should be added. Not more than maxResults results should
   /// be stored. The whole operation is supposed to be fast, though some
   /// dictionaries, the network ones particularly, may of course be slow.
-  virtual sptr< WordSearchRequest > prefixMatch( wstring const &,
+  virtual sptr< Request::WordSearch > prefixMatch( wstring const &,
                                                  unsigned long maxResults ) =0;
 
   /// Looks up a given word in the dictionary, aiming to find different forms
@@ -403,7 +187,7 @@ public:
   /// Since the goal is to find forms of the words, no matches where a word
   /// in the middle of a phrase got matched should be returned.
   /// The default implementation does nothing, returning an empty result.
-  virtual sptr< WordSearchRequest > stemmedMatch( wstring const &,
+  virtual sptr< Request::WordSearch > stemmedMatch( wstring const &,
                                                   unsigned minLength,
                                                   unsigned maxSuffixVariation,
                                                   unsigned long maxResults ) ;
@@ -412,7 +196,7 @@ public:
   /// the given word is a synonym. If a dictionary can't perform this operation,
   /// it should leave the default implementation which always returns an empty
   /// result.
-  virtual sptr< WordSearchRequest > findHeadwordsForSynonym( wstring const & )
+  virtual sptr< Request::WordSearch > findHeadwordsForSynonym( wstring const & )
     ;
 
   /// For a given word, provides alternate writings of it which are to be looked
@@ -422,7 +206,7 @@ public:
   /// synchronously.
   virtual vector< wstring > getAlternateWritings( wstring const & )
     noexcept;
-  
+
   /// Returns a definition for the given word. The definition should
   /// be an html fragment (without html/head/body tags) in an utf8 encoding.
   /// The 'alts' vector could contain a list of words the definitions of which
@@ -430,7 +214,7 @@ public:
   /// synonyms for the main word.
   /// context is a dictionary-specific data, currently only used for the
   /// 'Websites' feature.
-  virtual sptr< DataRequest > getArticle( wstring const &,
+  virtual sptr< Request::Article > getArticle( wstring const &,
                                           vector< wstring > const & alts,
                                           wstring const & context = wstring(),
                                           bool ignoreDiacritics = false )
@@ -440,11 +224,11 @@ public:
   /// usually a picture file referenced in the article or something like that.
   /// The default implementation always returns the non-existing resource
   /// response.
-  virtual sptr< DataRequest > getResource( string const & /*name*/ )
+  virtual sptr< Request::Blob > getResource( string const & /*name*/ )
     ;
 
   /// Returns a results of full-text search of given string similar getArticle().
-  virtual sptr< DataRequest >
+  virtual sptr< Request::Blob >
   getSearchResults( QString const & searchString, int searchMode, bool matchCase, bool ignoreDiacritics );
 
   // Return dictionary description if presented

--- a/src/dict/dictionary_requests.cc
+++ b/src/dict/dictionary_requests.cc
@@ -1,0 +1,156 @@
+#include "dict/dictionary_requests.hh"
+#include "common/utils.hh"
+
+namespace Request {
+
+bool Base::isFinished()
+{
+  return Utils::AtomicInt::loadAcquire( isFinishedFlag );
+}
+
+void Base::update()
+{
+  if ( !Utils::AtomicInt::loadAcquire( isFinishedFlag ) )
+    emit updated();
+}
+
+void Base::finish()
+{
+  if ( !Utils::AtomicInt::loadAcquire( isFinishedFlag ) ) {
+    isFinishedFlag.ref();
+
+    emit finished();
+  }
+}
+
+void Base::setErrorString( QString const & str )
+{
+  QMutexLocker _( &errorStringMutex );
+
+  errorString = str;
+}
+
+QString Base::getErrorString()
+{
+  QMutexLocker _( &errorStringMutex );
+
+  return errorString;
+}
+
+
+///////// WordSearchRequest
+
+size_t WordSearch::matchesCount()
+{
+  QMutexLocker _( &dataMutex );
+
+  return matches.size();
+}
+
+WordMatch WordSearch::operator[]( size_t index )
+{
+  QMutexLocker _( &dataMutex );
+
+  if ( index >= matches.size() )
+    throw exIndexOutOfRange();
+
+  return matches[ index ];
+}
+
+std::vector< WordMatch > & WordSearch::getAllMatches()
+{
+  if ( !isFinished() )
+    throw exRequestUnfinished();
+
+  return matches;
+}
+
+void WordSearch::addMatch( WordMatch const & match )
+{
+  unsigned n;
+  for ( n = 0; n < matches.size(); n++ )
+    if ( matches[ n ].word.compare( match.word ) == 0 )
+      break;
+
+  if ( n >= matches.size() )
+    matches.push_back( match );
+}
+
+////////////// DataRequest
+
+long Blob::dataSize()
+{
+  QMutexLocker _( &dataMutex );
+
+  return hasAnyData ? (long)data.size() : -1;
+}
+
+void Blob::appendDataSlice( const void * buffer, size_t size )
+{
+  QMutexLocker _( &dataMutex );
+
+  size_t offset = data.size();
+
+  data.resize( data.size() + size );
+
+  memcpy( &data.front() + offset, buffer, size );
+}
+
+void Blob::getDataSlice( size_t offset, size_t size, void * buffer )
+{
+  if ( size == 0 )
+    return;
+
+  QMutexLocker _( &dataMutex );
+
+  if ( !hasAnyData )
+    throw exSliceOutOfRange();
+
+  memcpy( buffer, &data[ offset ], size );
+}
+
+std::vector< char > & Blob::getFullData()
+{
+  if ( !isFinished() )
+    throw exRequestUnfinished();
+
+  return data;
+}
+
+std::vector< char > & Article::getFullData()
+{
+  auto * result = new std::vector< char >( data.begin(), data.end() );
+  return *result;
+}
+
+long Article::dataSize()
+{
+  return data.size();
+}
+
+void Article::appendStrToData( const QStringView & s )
+{
+  hasAnyData = true;
+  data.append( s.toUtf8().data() );
+}
+
+void Article::appendStrToData( const std::string_view & s )
+{
+  hasAnyData = true;
+  data.append( s );
+}
+
+void Article::getDataSlice( size_t offset, size_t size, void * buffer )
+{
+  if ( size == 0 )
+    return;
+
+  QMutexLocker _( &dataMutex );
+
+  if ( !hasAnyData )
+    throw exSliceOutOfRange();
+
+  memcpy( buffer, &data[ offset ], size );
+}
+
+} // namespace Request

--- a/src/dict/dictionary_requests.hh
+++ b/src/dict/dictionary_requests.hh
@@ -1,0 +1,347 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QMutex>
+#include <vector>
+#include "common/wstring.hh"
+#include "common/ex.hh"
+
+namespace Request {
+
+using wstring = gd::wstring;
+
+DEF_EX( Ex, "Dictionary Request Exception", std::exception )
+DEF_EX( exRequestUnfinished, "The request hasn't yet finished", Ex )
+DEF_EX( exIndexOutOfRange, "The supplied index is out of range", Ex )
+DEF_EX( exSliceOutOfRange, "The requested data slice is out of range", Ex )
+
+/// When you request a search to be performed in a dictionary, you get
+/// this structure in return. It accumulates search results over time.
+/// The finished() signal is emitted when the search has finished and there's
+/// no more matches to be expected. Note that before connecting to it, check
+/// the result of isFinished() -- if it's 'true', the search was instantaneous.
+/// Destroy the object when you are not interested in results anymore.
+///
+/// Creating, destroying and calling member functions of the requests is done
+/// in the GUI thread, however. Therefore, it is important to make sure those
+/// operations are fast (this is most important for word searches, where
+/// new requests are created and old ones deleted immediately upon a user
+/// changing query).
+class Base: public QObject
+{
+  Q_OBJECT
+
+public:
+  explicit Base( QObject * parent = nullptr ):
+    QObject( parent )
+  {
+  }
+  /// Returns whether the request has been processed in full and finished.
+  /// This means that the data accumulated is final and won't change anymore.
+  bool isFinished();
+
+  /// Either returns an empty string in case there was no error processing
+  /// the request, or otherwise a human-readable string describing the problem.
+  /// Note that an empty result, such as a lack of word or of an article isn't
+  /// an error -- but any kind of failure to connect to, or read the dictionary
+  /// is.
+  QString getErrorString();
+
+  /// Cancels the ongoing request. This may make Request destruct faster some
+  /// time in the future, Use this in preparation to destruct many Requests,
+  /// so that they'd be cancelling in parallel. When the request was fully
+  /// cancelled, it must emit the finished() signal, either as a result of an
+  /// actual finish which has happened just before the cancellation, or solely as
+  /// a result of a request being cancelled (in the latter case, the actual
+  /// request result may be empty or incomplete). That is, finish() must be
+  /// called by a derivative at least once if cancel() was called, either after
+  /// or before it was called.
+  virtual void cancel() = 0;
+
+  virtual ~Base() {}
+
+signals:
+
+  /// This signal is emitted when more data becomes available. Local
+  /// dictionaries typically don't call this, since it is preferred that all
+  /// data would be available from them at once, but network dictionaries
+  /// might call that.
+  void updated();
+
+  /// This signal is emitted when the request has been processed in full and
+  /// finished. That is, it's emitted when isFinished() turns true.
+  void finished();
+
+  void matchCount( int );
+
+protected:
+
+  /// Called by derivatives to signal update().
+  void update();
+
+  /// Called by derivatives to set isFinished() flag and signal finished().
+  void finish();
+
+  /// Sets the error string to be returned by getErrorString().
+  void setErrorString( QString const & );
+
+private:
+
+  QAtomicInt isFinishedFlag;
+
+  QMutex errorStringMutex;
+  QString errorString;
+};
+
+/// This structure represents the word found. In addition to holding the
+/// word itself, it also holds its weight. It is 0 by default. Negative
+/// values should be used to store distance from Levenstein-like matching
+/// algorithms. Positive values are used by morphology matches.
+struct WordMatch
+{
+  wstring word;
+  int weight;
+
+  WordMatch():
+    weight( 0 )
+  {
+  }
+  WordMatch( wstring const & word_ ):
+    word( word_ ),
+    weight( 0 )
+  {
+  }
+  WordMatch( wstring const & word_, int weight_ ):
+    word( word_ ),
+    weight( weight_ )
+  {
+  }
+};
+
+/// This request type corresponds to all types of word searching operations.
+class WordSearch: public Base
+{
+  Q_OBJECT
+
+public:
+
+  WordSearch():
+    uncertain( false )
+  {
+  }
+
+  /// Returns the number of matches found. The value can grow over time
+  /// unless isFinished() is true.
+  size_t matchesCount();
+
+  /// Returns the match with the given zero-based index, which should be less
+  /// than matchesCount().
+  WordMatch operator[]( size_t index );
+
+  /// Returns all the matches found. Since no further locking can or would be
+  /// done, this can only be called after the request has finished.
+  std::vector< WordMatch > & getAllMatches();
+
+  /// Returns true if the match was uncertain -- that is, there may be more
+  /// results in the dictionary itself, the dictionary index isn't good enough
+  /// to tell that.
+  bool isUncertain() const
+  {
+    return uncertain;
+  }
+
+  /// Add match if one is not presented in matches list
+  void addMatch( WordMatch const & match );
+
+protected:
+
+  // Subclasses should be filling up the 'matches' array, locking the mutex when
+  // whey work with it.
+  QMutex dataMutex;
+
+  std::vector< WordMatch > matches;
+  bool uncertain;
+};
+
+/// A helper class for synchronous word search implementations.
+class WordSearchInstant: public WordSearch
+{
+public:
+
+  WordSearchInstant()
+  {
+    finish();
+  }
+
+  void cancel() override {}
+
+  std::vector< WordMatch > & getMatches()
+  {
+    return matches;
+  }
+
+  void setUncertain( bool value )
+  {
+    uncertain = value;
+  }
+};
+
+class Dict: public Base
+{
+  Q_OBJECT
+
+public:
+  explicit Dict( QObject * parent = nullptr ):
+    Base( parent ){};
+
+
+  /// Returns all the data read. Since no further locking can or would be
+  /// done, this can only be called after the request has finished.
+  virtual std::vector< char > & getFullData() = 0;
+
+  /// Returns the number of bytes read, with a -1 meaning that so far it's
+  /// uncertain whether resource even exists or not, and any non-negative value
+  /// meaning that that amount of bytes is not available.
+  /// If -1 is still being returned after the request has finished, that means
+  /// the resource wasn't found.
+  virtual long dataSize() = 0;
+
+  virtual void getDataSlice( size_t offset, size_t size, void * buffer ) = 0;
+
+protected:
+  bool hasAnyData; // With this being false, dataSize() always returns -1
+};
+
+/// This request type corresponds to any kinds of data responses where a
+/// single large blob of binary data is returned. It currently used of article
+/// bodies and resources.
+class Blob: public Dict
+{
+  Q_OBJECT
+
+public:
+
+  /// Writes "size" bytes starting from "offset" of the data read to the given
+  /// buffer. "size + offset" must be <= than dataSize().
+  void getDataSlice( size_t offset, size_t size, void * buffer ) override;
+  void appendDataSlice( const void * buffer, size_t size );
+
+  /// Returns all the data read. Since no further locking can or would be
+  /// done, this can only be called after the request has finished.
+  std::vector< char > & getFullData() override;
+
+  /// Returns the number of bytes read, with a -1 meaning that so far it's
+  /// uncertain whether resource even exists or not, and any non-negative value
+  /// meaning that that amount of bytes is not available.
+  /// If -1 is still being returned after the request has finished, that means
+  /// the resource wasn't found.
+  long dataSize() override;
+
+  Blob( QObject * parent = 0 ):
+    Dict( parent ),
+    hasAnyData( false )
+  {
+  }
+
+protected:
+  // Subclasses should be filling up the 'data' array, locking the mutex when
+  // they work with it.
+  QMutex dataMutex;
+
+  bool hasAnyData; // With this being false, dataSize() always returns -1
+  std::vector< char > data;
+};
+
+/// A helper class for synchronous data read implementations.
+class BlobInstant: public Blob
+{
+public:
+
+  BlobInstant( bool succeeded )
+  {
+    hasAnyData = succeeded;
+    finish();
+  }
+
+  BlobInstant( QString const & errorString )
+  {
+    setErrorString( errorString );
+    finish();
+  }
+
+  virtual void cancel() {}
+
+  std::vector< char > & getData()
+  {
+    return data;
+  }
+};
+
+
+/// This request type corresponds to any kinds of data responses where a
+/// single large blob of binary data is returned. It currently used of article
+/// bodies and resources.
+class Article: public Dict
+{
+  Q_OBJECT
+
+public:
+
+  explicit Article( QObject * parent = 0 ):
+    Dict( parent ),
+    hasAnyData( false )
+  {
+  }
+
+  std::vector< char > & getFullData() override;
+
+  /// Returns the number of bytes read, with a -1 meaning that so far it's
+  /// uncertain whether resource even exists or not, and any non-negative value
+  /// meaning that that amount of bytes is not available.
+  /// If -1 is still being returned after the request has finished, that means
+  /// the resource wasn't found.
+  long dataSize() override;
+
+  void getDataSlice( size_t offset, size_t size, void * buffer ) override;
+
+
+  void appendStrToData( const QStringView & );
+  void appendStrToData( const std::string_view & );
+
+protected:
+  // Subclasses should be filling up the 'data' array, locking the mutex when
+  // they work with it.
+  QMutex dataMutex;
+  bool hasAnyData; // With this being false, dataSize() always returns -1
+  std::string data;
+};
+
+/// A helper class for synchronous data read implementations.
+class ArticleInstant: public Article
+{
+public:
+
+  ArticleInstant( bool succeeded )
+  {
+    hasAnyData = succeeded;
+    finish();
+  }
+
+  ArticleInstant( QString const & errorString )
+  {
+    setErrorString( errorString );
+    finish();
+  }
+
+  virtual void cancel() {}
+
+  std::vector< char > & getData()
+  {
+    auto * result = new std::vector< char >( data.begin(), data.end() );
+    return *result;
+  }
+};
+
+
+} // namespace Request

--- a/src/dict/dictserver.cc
+++ b/src/dict/dictserver.cc
@@ -222,10 +222,10 @@ public:
   unsigned long getWordCount() noexcept override
   { return 0; }
 
-  sptr< WordSearchRequest > prefixMatch( wstring const &,
+  sptr< Request::WordSearch > prefixMatch( wstring const &,
                                                  unsigned long maxResults ) override ;
 
-  sptr< DataRequest > getArticle( wstring const &, vector< wstring > const & alts,
+  sptr< Request::Article > getArticle( wstring const &, vector< wstring > const & alts,
                                           wstring const &, bool ) override
     ;
 
@@ -348,7 +348,7 @@ void DictServerDictionary::getServerDatabases()
   delete socket;
 }
 
-class DictServerWordSearchRequest: public Dictionary::WordSearchRequest
+class DictServerWordSearchRequest: public Request::WordSearch
 {
   QAtomicInt isCancelled;
   wstring word;
@@ -536,7 +536,7 @@ void DictServerWordSearchRequest::cancel()
   finish();
 }
 
-class DictServerArticleRequest: public Dictionary::DataRequest
+class DictServerArticleRequest: public Request::Article
 {
   QAtomicInt isCancelled;
   wstring word;
@@ -865,7 +865,7 @@ void DictServerArticleRequest::cancel()
   finish();
 }
 
-sptr< WordSearchRequest > DictServerDictionary::prefixMatch( wstring const & word,
+sptr< Request::WordSearch > DictServerDictionary::prefixMatch( wstring const & word,
                                                              unsigned long maxResults )
   
 {
@@ -874,13 +874,13 @@ sptr< WordSearchRequest > DictServerDictionary::prefixMatch( wstring const & wor
   {
     // Don't make excessively large queries -- they're fruitless anyway
 
-    return std::make_shared<WordSearchRequestInstant>();
+    return std::make_shared<Request::WordSearchInstant>();
   }
   else
     return std::make_shared<DictServerWordSearchRequest>( word, *this );
 }
 
-sptr< DataRequest > DictServerDictionary::getArticle( wstring const & word,
+sptr< Request::Article > DictServerDictionary::getArticle( wstring const & word,
                                                       vector< wstring > const &,
                                                       wstring const &, bool )
   
@@ -889,7 +889,7 @@ sptr< DataRequest > DictServerDictionary::getArticle( wstring const & word,
   {
     // Don't make excessively large queries -- they're fruitless anyway
 
-    return std::make_shared<DataRequestInstant>( false );
+    return std::make_shared<Request::ArticleInstant >( false );
   }
   else
     return std::make_shared<DictServerArticleRequest>( word, *this );

--- a/src/dict/dsl.cc
+++ b/src/dict/dsl.cc
@@ -204,16 +204,16 @@ public:
 
 
 
-  sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Request::Article > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
                                                       bool ignoreDiacritics ) override
     ;
 
-  sptr< Dictionary::DataRequest > getResource( string const & name ) override
+  sptr< Request::Blob > getResource( string const & name ) override
     ;
 
-  sptr< Dictionary::DataRequest >
+  sptr< Request::Blob >
   getSearchResults( QString const & searchString, int searchMode, bool matchCase, bool ignoreDiacritics ) override;
   QString const& getDescription() override;
 
@@ -1503,7 +1503,7 @@ void DslDictionary::getArticleText( uint32_t articleAddress, QString & headword,
 
 /// DslDictionary::getArticle()
 
-class DslArticleRequest: public Dictionary::DataRequest
+class DslArticleRequest: public Request::Article
 {
   wstring word;
   vector< wstring > alts;
@@ -1653,18 +1653,13 @@ void DslArticleRequest::run()
 
     QMutexLocker _( &dataMutex );
 
-    data.resize( data.size() + articleText.size() );
-
-    memcpy( &data.front() + data.size() - articleText.size(),
-            articleText.data(), articleText.size() );
-
-    hasAnyData = true;
+    appendStrToData(articleText);
   }
 
   finish();
 }
 
-sptr< Dictionary::DataRequest > DslDictionary::getArticle( wstring const & word,
+sptr< Request::Article > DslDictionary::getArticle( wstring const & word,
                                                            vector< wstring > const & alts,
                                                            wstring const &,
                                                            bool ignoreDiacritics )
@@ -1675,7 +1670,7 @@ sptr< Dictionary::DataRequest > DslDictionary::getArticle( wstring const & word,
 
 //// DslDictionary::getResource()
 
-class DslResourceRequest: public Dictionary::DataRequest
+class DslResourceRequest: public Request::Blob
 {
   DslDictionary & dict;
 
@@ -1795,14 +1790,14 @@ void DslResourceRequest::run()
   finish();
 }
 
-sptr< Dictionary::DataRequest > DslDictionary::getResource( string const & name )
+sptr< Request::Blob > DslDictionary::getResource( string const & name )
   
 {
   return std::make_shared<DslResourceRequest>( *this, name );
 }
 
 
-sptr< Dictionary::DataRequest > DslDictionary::getSearchResults( QString const & searchString,
+sptr< Request::Blob > DslDictionary::getSearchResults( QString const & searchString,
                                                                  int searchMode,
                                                                  bool matchCase,
 

--- a/src/dict/epwing.cc
+++ b/src/dict/epwing.cc
@@ -130,16 +130,16 @@ public:
 
   void getHeadwordPos( wstring const & word_, QVector< int > & pg, QVector< int > & off );
 
-  sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Request::Article > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
                                                       bool ignoreDiacritics ) override
     ;
 
-  sptr< Dictionary::DataRequest > getResource( string const & name ) override
+  sptr< Request::Blob > getResource( string const & name ) override
     ;
 
-  sptr< Dictionary::DataRequest >
+  sptr< Request::Blob >
   getSearchResults( QString const & searchString, int searchMode, bool matchCase, bool ignoreDiacritics ) override;
   void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
@@ -161,11 +161,11 @@ public:
 
   static bool isJapanesePunctiation( gd::wchar ch );
 
-  sptr< Dictionary::WordSearchRequest > prefixMatch( wstring const &,
+  sptr< Request::WordSearch > prefixMatch( wstring const &,
                                                              unsigned long ) override
     ;
 
-  sptr< Dictionary::WordSearchRequest > stemmedMatch( wstring const &,
+  sptr< Request::WordSearch > stemmedMatch( wstring const &,
                                                               unsigned minLength,
                                                               unsigned maxSuffixVariation,
                                                               unsigned long maxResults ) override
@@ -185,7 +185,7 @@ private:
                     int & articleOffset );
 
 
-  sptr< Dictionary::WordSearchRequest > findHeadwordsForSynonym( wstring const & word ) override;
+  sptr< Request::WordSearch > findHeadwordsForSynonym( wstring const & word ) override;
 
   void loadArticleNextPage( string & articleHeadword, string & articleText, int & articlePage, int & articleOffset );
   void loadArticlePreviousPage( string & articleHeadword, string & articleText, int & articlePage, int & articleOffset );
@@ -520,7 +520,7 @@ void EpwingDictionary::getArticleText( uint32_t articleAddress, QString & headwo
 
 
 
-class EpwingHeadwordsRequest: public Dictionary::WordSearchRequest
+class EpwingHeadwordsRequest: public Request::WordSearch
 {
   wstring str;
   EpwingDictionary & dict;
@@ -604,14 +604,14 @@ void EpwingHeadwordsRequest::run()
 
   finish();
 }
-sptr< Dictionary::WordSearchRequest > EpwingDictionary::findHeadwordsForSynonym( wstring const & word )
+sptr< Request::WordSearch > EpwingDictionary::findHeadwordsForSynonym( wstring const & word )
 {
   return synonymSearchEnabled ? std::make_shared< EpwingHeadwordsRequest >( word, *this ) :
                                 Class::findHeadwordsForSynonym( word );
 }
 /// EpwingDictionary::getArticle()
 
-class EpwingArticleRequest: public Dictionary::DataRequest
+class EpwingArticleRequest: public Request::Article
 {
   wstring word;
   vector< wstring > alts;
@@ -856,7 +856,7 @@ void EpwingDictionary::getHeadwordPos( wstring const & word_, QVector< int > & p
   }
 }
 
-sptr< Dictionary::DataRequest > EpwingDictionary::getArticle( wstring const & word,
+sptr< Request::Article > EpwingDictionary::getArticle( wstring const & word,
                                                               vector< wstring > const & alts,
                                                               wstring const &,
                                                               bool ignoreDiacritics )
@@ -867,7 +867,7 @@ sptr< Dictionary::DataRequest > EpwingDictionary::getArticle( wstring const & wo
 
 //// EpwingDictionary::getResource()
 
-class EpwingResourceRequest: public Dictionary::DataRequest
+class EpwingResourceRequest: public Request::Blob
 {
   EpwingDictionary & dict;
 
@@ -954,14 +954,14 @@ void EpwingResourceRequest::run()
   finish();
 }
 
-sptr< Dictionary::DataRequest > EpwingDictionary::getResource( string const & name )
+sptr< Request::Blob > EpwingDictionary::getResource( string const & name )
   
 {
   return std::make_shared<EpwingResourceRequest>( *this, name );
 }
 
 
-sptr< Dictionary::DataRequest > EpwingDictionary::getSearchResults( QString const & searchString,
+sptr< Request::Blob > EpwingDictionary::getSearchResults( QString const & searchString,
                                                                     int searchMode,
                                                                     bool matchCase,
                                                                     bool ignoreDiacritics )
@@ -1077,14 +1077,14 @@ void EpwingWordSearchRequest::findMatches()
   finish();
 }
 
-sptr< Dictionary::WordSearchRequest > EpwingDictionary::prefixMatch(
+sptr< Request::WordSearch > EpwingDictionary::prefixMatch(
   wstring const & str, unsigned long maxResults )
   
 {
   return std::make_shared<EpwingWordSearchRequest>( *this, str, 0, -1, true, maxResults );
 }
 
-sptr< Dictionary::WordSearchRequest > EpwingDictionary::stemmedMatch(
+sptr< Request::WordSearch > EpwingDictionary::stemmedMatch(
   wstring const & str, unsigned minLength, unsigned maxSuffixVariation,
   unsigned long maxResults )
   

--- a/src/dict/forvo.cc
+++ b/src/dict/forvo.cc
@@ -50,17 +50,17 @@ public:
   unsigned long getWordCount() noexcept override
   { return 0; }
 
-  sptr< WordSearchRequest > prefixMatch( wstring const & /*word*/,
+  sptr< Request::WordSearch > prefixMatch( wstring const & /*word*/,
                                                  unsigned long /*maxResults*/ ) override 
   {
-    sptr< WordSearchRequestInstant > sr =  std::make_shared<WordSearchRequestInstant>();
+    sptr< Request::WordSearchInstant > sr =  std::make_shared<Request::WordSearchInstant>();
 
     sr->setUncertain( true );
 
     return sr;
   }
 
-  sptr< DataRequest > getArticle( wstring const &, vector< wstring > const & alts, wstring const &, bool ) override;
+  sptr< Request::Article > getArticle( wstring const &, vector< wstring > const & alts, wstring const &, bool ) override;
 
 protected:
 
@@ -68,7 +68,7 @@ protected:
 
 };
 
-sptr< DataRequest > ForvoDictionary::getArticle( wstring const & word,
+sptr< Request::Article > ForvoDictionary::getArticle( wstring const & word,
                                                  vector< wstring > const & alts,
                                                  wstring const &, bool )
   
@@ -77,7 +77,7 @@ sptr< DataRequest > ForvoDictionary::getArticle( wstring const & word,
   {
     // Don't make excessively large queries -- they're fruitless anyway
 
-    return std::make_shared<DataRequestInstant>( false );
+    return std::make_shared<Request::ArticleInstant >( false );
   }
   else
   {

--- a/src/dict/forvo.hh
+++ b/src/dict/forvo.hh
@@ -24,7 +24,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries(
     ;
 
 /// Exposed here for moc
-class ForvoArticleRequest: public Dictionary::DataRequest
+class ForvoArticleRequest: public Request::Article
 {
   Q_OBJECT
 

--- a/src/dict/gls.cc
+++ b/src/dict/gls.cc
@@ -388,23 +388,23 @@ public:
   inline quint32 getLangTo() const override
   { return idxHeader.langTo; }
 
-  sptr< Dictionary::WordSearchRequest > findHeadwordsForSynonym( wstring const & ) override
+  sptr< Request::WordSearch > findHeadwordsForSynonym( wstring const & ) override
     ;
 
-  sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Request::Article > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
                                                       bool ignoreDiacritics ) override
     ;
 
-  sptr< Dictionary::DataRequest > getResource( string const & name ) override
+  sptr< Request::Blob > getResource( string const & name ) override
     ;
 
   QString const& getDescription() override;
 
   QString getMainFilename() override;
 
-  sptr< Dictionary::DataRequest >
+  sptr< Request::Blob >
   getSearchResults( QString const & searchString, int searchMode, bool matchCase, bool ignoreDiacritics ) override;
 
   void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
@@ -853,7 +853,7 @@ void GlsDictionary::getArticleText( uint32_t articleAddress, QString & headword,
 
 /// GlsDictionary::findHeadwordsForSynonym()
 
-class GlsHeadwordsRequest: public Dictionary::WordSearchRequest
+class GlsHeadwordsRequest: public Request::WordSearch
 {
   wstring word;
   GlsDictionary & dict;
@@ -933,7 +933,7 @@ void GlsHeadwordsRequest::run()
   finish();
 }
 
-sptr< Dictionary::WordSearchRequest >
+sptr< Request::WordSearch >
   GlsDictionary::findHeadwordsForSynonym( wstring const & word )
   
 {
@@ -944,7 +944,7 @@ sptr< Dictionary::WordSearchRequest >
 
 /// GlsDictionary::getArticle()
 
-class GlsArticleRequest: public Dictionary::DataRequest
+class GlsArticleRequest: public Request::Article
 {
 
   wstring word;
@@ -1086,7 +1086,7 @@ void GlsArticleRequest::run()
   finish();
 }
 
-sptr< Dictionary::DataRequest > GlsDictionary::getArticle( wstring const & word,
+sptr< Request::Article > GlsDictionary::getArticle( wstring const & word,
                                                            vector< wstring > const & alts,
                                                            wstring const &,
                                                            bool ignoreDiacritics )
@@ -1097,7 +1097,7 @@ sptr< Dictionary::DataRequest > GlsDictionary::getArticle( wstring const & word,
 
 //////////////// GlsDictionary::getResource()
 
-class GlsResourceRequest: public Dictionary::DataRequest
+class GlsResourceRequest: public Request::Blob
 {
 
   GlsDictionary & dict;
@@ -1249,13 +1249,13 @@ void GlsResourceRequest::run()
   finish();
 }
 
-sptr< Dictionary::DataRequest > GlsDictionary::getResource( string const & name )
+sptr< Request::Blob > GlsDictionary::getResource( string const & name )
   
 {
   return std::make_shared<GlsResourceRequest>( *this, name );
 }
 
-sptr< Dictionary::DataRequest > GlsDictionary::getSearchResults( QString const & searchString,
+sptr< Request::Blob > GlsDictionary::getSearchResults( QString const & searchString,
                                                                  int searchMode,
                                                                  bool matchCase,
 

--- a/src/dict/hunspell.cc
+++ b/src/dict/hunspell.cc
@@ -80,14 +80,14 @@ public:
   unsigned long getWordCount() noexcept override
   { return 0; }
 
-  sptr< WordSearchRequest > prefixMatch( wstring const &,
+  sptr< Request::WordSearch > prefixMatch( wstring const &,
                                                  unsigned long maxResults ) override
     ;
 
-  sptr< WordSearchRequest > findHeadwordsForSynonym( wstring const & ) override
+  sptr< Request::WordSearch > findHeadwordsForSynonym( wstring const & ) override
     ;
 
-  sptr< DataRequest > getArticle( wstring const &,
+  sptr< Request::Article > getArticle( wstring const &,
                                           vector< wstring > const & alts,
                                           wstring const &,
                                           bool ) override
@@ -179,7 +179,7 @@ vector< wstring > HunspellDictionary::getAlternateWritings( wstring const & word
 
 /// HunspellDictionary::getArticle()
 
-class HunspellArticleRequest: public Dictionary::DataRequest
+class HunspellArticleRequest: public Request::Article
 {
 
   QMutex & hunspellMutex;
@@ -304,7 +304,7 @@ void HunspellArticleRequest::run()
   finish();
 }
 
-sptr< DataRequest > HunspellDictionary::getArticle( wstring const & word,
+sptr< Request::Article > HunspellDictionary::getArticle( wstring const & word,
                                                     vector< wstring > const &,
                                                     wstring const &, bool )
   
@@ -314,7 +314,7 @@ sptr< DataRequest > HunspellDictionary::getArticle( wstring const & word,
 
 /// HunspellDictionary::findHeadwordsForSynonym()
 
-class HunspellHeadwordsRequest: public Dictionary::WordSearchRequest
+class HunspellHeadwordsRequest: public Request::WordSearch
 {
 
   QMutex & hunspellMutex;
@@ -453,7 +453,7 @@ QVector< wstring > suggest( wstring & word, QMutex & hunspellMutex, Hunspell & h
 }
 
 
-sptr< WordSearchRequest > HunspellDictionary::findHeadwordsForSynonym( wstring const & word )
+sptr< Request::WordSearch > HunspellDictionary::findHeadwordsForSynonym( wstring const & word )
   
 {
   return std::make_shared<HunspellHeadwordsRequest>( word, getHunspellMutex(), hunspell );
@@ -462,7 +462,7 @@ sptr< WordSearchRequest > HunspellDictionary::findHeadwordsForSynonym( wstring c
 
 /// HunspellDictionary::prefixMatch()
 
-class HunspellPrefixMatchRequest: public Dictionary::WordSearchRequest
+class HunspellPrefixMatchRequest: public Request::WordSearch
 {
 
   QMutex & hunspellMutex;
@@ -528,7 +528,7 @@ void HunspellPrefixMatchRequest::run()
 
       QMutexLocker _( &dataMutex );
 
-      matches.push_back( WordMatch( trimmedWord, 1 ) );
+      matches.push_back( Request::WordMatch( trimmedWord, 1 ) );
     }
   }
   catch( Iconv::Ex & e )
@@ -539,7 +539,7 @@ void HunspellPrefixMatchRequest::run()
   finish();
 }
 
-sptr< WordSearchRequest > HunspellDictionary::prefixMatch( wstring const & word,
+sptr< Request::WordSearch > HunspellDictionary::prefixMatch( wstring const & word,
                                                            unsigned long /*maxResults*/ )
   
 {

--- a/src/dict/lingualibre.cc
+++ b/src/dict/lingualibre.cc
@@ -300,16 +300,16 @@ WHERE {
 
     unsigned long getWordCount() noexcept override { return 0; }
 
-    sptr< WordSearchRequest > prefixMatch( wstring const & /*word*/, unsigned long /*maxResults*/ ) override
+    sptr< Request::WordSearch > prefixMatch( wstring const & /*word*/, unsigned long /*maxResults*/ ) override
     {
-      sptr< WordSearchRequestInstant > sr = std::make_shared< WordSearchRequestInstant >();
+      auto sr = std::make_shared< Request::WordSearchInstant >();
 
       sr->setUncertain( true );
 
       return sr;
     }
 
-    sptr< DataRequest > getArticle(
+    sptr< Request::Article > getArticle(
       wstring const & word, vector< wstring > const & alts, wstring const &, bool ) override
     {
       if( word.size() < 50 )
@@ -317,7 +317,7 @@ WHERE {
         return std::make_shared< LinguaArticleRequest >( word, alts, languageCode,langWikipediaID, getId(), netMgr );
 
       } else {
-        return std::make_shared< DataRequestInstant >( false );
+        return std::make_shared< Request::ArticleInstant >( false );
       }
     }
 

--- a/src/dict/lingualibre.hh
+++ b/src/dict/lingualibre.hh
@@ -21,7 +21,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries(
 
 
 /// Exposed here for moc
-class LinguaArticleRequest: public Dictionary::DataRequest
+class LinguaArticleRequest: public Request::Article
 {
   Q_OBJECT
 

--- a/src/dict/lsa.cc
+++ b/src/dict/lsa.cc
@@ -174,13 +174,13 @@ public:
   unsigned long getWordCount() noexcept override
   { return getArticleCount(); }
 
-  sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Request::Article > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
                                                       bool ignoreDiacritics ) override
     ;
 
-  sptr< Dictionary::DataRequest > getResource( string const & name ) override
+  sptr< Request::Blob > getResource( string const & name ) override
     ;
 
 protected:
@@ -212,7 +212,7 @@ LsaDictionary::LsaDictionary( string const & id,
              idx, idxMutex );
 }
 
-sptr< Dictionary::DataRequest > LsaDictionary::getArticle( wstring const & word,
+sptr< Request::Article > LsaDictionary::getArticle( wstring const & word,
                                                            vector< wstring > const & alts,
                                                            wstring const &,
                                                            bool ignoreDiacritics )
@@ -265,7 +265,7 @@ sptr< Dictionary::DataRequest > LsaDictionary::getArticle( wstring const & word,
   }
 
   if ( mainArticles.empty() && alternateArticles.empty() )
-    return std::make_shared<Dictionary::DataRequestInstant>( false ); // No such word
+    return std::make_shared<Request::ArticleInstant >( false ); // No such word
 
   string result;
 
@@ -310,14 +310,14 @@ sptr< Dictionary::DataRequest > LsaDictionary::getArticle( wstring const & word,
 
   result += "</table>";
 
-  Dictionary::DataRequestInstant * ret =
-    new Dictionary::DataRequestInstant( true );
+  auto * ret =
+    new Request::ArticleInstant( true );
 
   ret->getData().resize( result.size() );
 
   memcpy( &(ret->getData().front()), result.data(), result.size() );
 
-  return std::shared_ptr<Dictionary::DataRequestInstant>(ret);
+  return std::shared_ptr<Request::ArticleInstant >(ret);
 }
 
 /// This wraps around file operations
@@ -397,7 +397,7 @@ __attribute__((packed))
 #endif
 ;
 
-sptr< Dictionary::DataRequest > LsaDictionary::getResource( string const & name )
+sptr< Request::Blob > LsaDictionary::getResource( string const & name )
   
 {
   // See if the name ends in .wav. Remove that extension then
@@ -409,7 +409,7 @@ sptr< Dictionary::DataRequest > LsaDictionary::getResource( string const & name 
   vector< WordArticleLink > chain = findArticles( Utf8::decode( strippedName ) );
 
   if ( chain.empty() )
-    return std::make_shared<Dictionary::DataRequestInstant>( false ); // No such resource
+    return std::make_shared<Request::BlobInstant >( false ); // No such resource
 
   File::Class f( getDictionaryFilenames()[ 0 ], "rb" );
 
@@ -439,8 +439,8 @@ sptr< Dictionary::DataRequest > LsaDictionary::getResource( string const & name 
     throw exFailedToRetrieveVorbisInfo();
   }
 
-  sptr< Dictionary::DataRequestInstant > dr = std::make_shared<
-    Dictionary::DataRequestInstant>( true );
+  sptr< Request::BlobInstant > dr = std::make_shared<
+    Request::BlobInstant >( true );
 
   vector< char > & data = dr->getData();
 

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -250,14 +250,14 @@ public:
     return idxHeader.langTo;
   }
 
-  sptr< Dictionary::DataRequest > getArticle( wstring const & word,
+  sptr< Request::Article > getArticle( wstring const & word,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
                                                       bool ignoreDiacritics ) override ;
-  sptr< Dictionary::DataRequest > getResource( string const & name ) override ;
+  sptr< Request::Blob > getResource( string const & name ) override ;
   QString const & getDescription() override;
 
-  sptr< Dictionary::DataRequest >
+  sptr< Request::Blob >
   getSearchResults( QString const & searchString, int searchMode, bool matchCase, bool ignoreDiacritics ) override;
   void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
@@ -509,7 +509,7 @@ void MdxDictionary::getArticleText( uint32_t articleAddress, QString & headword,
   }
 }
 
-sptr< Dictionary::DataRequest > MdxDictionary::getSearchResults( QString const & searchString,
+sptr< Request::Blob > MdxDictionary::getSearchResults( QString const & searchString,
                                                                  int searchMode,
                                                                  bool matchCase,
 
@@ -524,7 +524,7 @@ sptr< Dictionary::DataRequest > MdxDictionary::getSearchResults( QString const &
 
 /// MdxDictionary::getArticle
 
-class MdxArticleRequest: public Dictionary::DataRequest
+class MdxArticleRequest: public Request::Article
 {
   wstring word;
   vector< wstring > alts;
@@ -668,14 +668,14 @@ void MdxArticleRequest::run()
   finish();
 }
 
-sptr<Dictionary::DataRequest> MdxDictionary::getArticle( const wstring & word, const vector<wstring> & alts,
+sptr<Request::Article > MdxDictionary::getArticle( const wstring & word, const vector<wstring> & alts,
                                                          const wstring &, bool ignoreDiacritics ) 
 {
   return  std::make_shared<MdxArticleRequest>( word, alts, *this, ignoreDiacritics );
 }
 
 /// MdxDictionary::getResource
-class MddResourceRequest: public Dictionary::DataRequest
+class MddResourceRequest: public Request::Blob
 {
   MdxDictionary & dict;
   wstring resourceName;
@@ -685,7 +685,7 @@ class MddResourceRequest: public Dictionary::DataRequest
 public:
 
   MddResourceRequest( MdxDictionary & dict_, string const & resourceName_ ) :
-    Dictionary::DataRequest( &dict_ ), dict( dict_ ), resourceName( Utf8::decode( resourceName_ ) )
+    Request::Blob( &dict_ ), dict( dict_ ), resourceName( Utf8::decode( resourceName_ ) )
   {
     f = QtConcurrent::run( [ this ]() { this->run(); } );
   }
@@ -821,7 +821,7 @@ void MddResourceRequest::run()
   finish();
 }
 
-sptr<Dictionary::DataRequest> MdxDictionary::getResource( const string & name ) 
+sptr<Request::Blob > MdxDictionary::getResource( const string & name )
 {
   return std::make_shared<MddResourceRequest>( *this, name );
 }

--- a/src/dict/mediawiki.cc
+++ b/src/dict/mediawiki.cc
@@ -60,10 +60,10 @@ public:
   unsigned long getWordCount() noexcept override
   { return 0; }
 
-  sptr< WordSearchRequest > prefixMatch( wstring const &,
+  sptr< Request::WordSearch > prefixMatch( wstring const &,
                                                  unsigned long maxResults ) override ;
 
-  sptr< DataRequest > getArticle( wstring const &, vector< wstring > const & alts,
+  sptr< Request::Article > getArticle( wstring const &, vector< wstring > const & alts,
                                           wstring const &, bool ) override;
 
   quint32 getLangFrom() const override
@@ -684,7 +684,7 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
     update();
 }
 
-sptr< WordSearchRequest > MediaWikiDictionary::prefixMatch( wstring const & word,
+sptr< Request::WordSearch > MediaWikiDictionary::prefixMatch( wstring const & word,
                                                             unsigned long maxResults )
   
 {
@@ -693,13 +693,13 @@ sptr< WordSearchRequest > MediaWikiDictionary::prefixMatch( wstring const & word
   {
     // Don't make excessively large queries -- they're fruitless anyway
 
-    return std::make_shared<WordSearchRequestInstant>();
+    return std::make_shared< Request::WordSearchInstant >();
   }
   else
     return std::make_shared< MediaWikiWordSearchRequest>( word, url, netMgr );
 }
 
-sptr< DataRequest > MediaWikiDictionary::getArticle( wstring const & word,
+sptr< Request::Article > MediaWikiDictionary::getArticle( wstring const & word,
                                                      vector< wstring > const & alts,
                                                      wstring const &, bool )
   
@@ -708,7 +708,7 @@ sptr< DataRequest > MediaWikiDictionary::getArticle( wstring const & word,
   {
     // Don't make excessively large queries -- they're fruitless anyway
 
-    return  std::make_shared<DataRequestInstant>( false );
+    return  std::make_shared<Request::ArticleInstant >( false );
   }
   else
     return  std::make_shared<MediaWikiArticleRequest>( word, alts, url, netMgr, this );

--- a/src/dict/mediawiki.hh
+++ b/src/dict/mediawiki.hh
@@ -21,7 +21,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries(
     ;
 
 /// Exposed here for moc
-class MediaWikiWordSearchRequestSlots: public Dictionary::WordSearchRequest
+class MediaWikiWordSearchRequestSlots: public Request::WordSearch
 {
   Q_OBJECT
 
@@ -32,7 +32,7 @@ protected slots:
 };
 
 /// Exposed here for moc
-class MediaWikiDataRequestSlots: public Dictionary::DataRequest
+class MediaWikiDataRequestSlots: public Request::Article
 {
   Q_OBJECT
 

--- a/src/dict/programs.cc
+++ b/src/dict/programs.cc
@@ -43,11 +43,11 @@ public:
   unsigned long getWordCount() noexcept override
   { return 0; }
 
-  sptr< WordSearchRequest > prefixMatch( wstring const & word,
+  sptr< Request::WordSearch > prefixMatch( wstring const & word,
                                                  unsigned long maxResults ) override
     ;
 
-  sptr< DataRequest > getArticle( wstring const &,
+  sptr< Request::Article > getArticle( wstring const &,
                                           vector< wstring > const & alts,
                                           wstring const &, bool ) override
     ;
@@ -57,7 +57,7 @@ protected:
   void loadIcon() noexcept override;
 };
 
-sptr< WordSearchRequest > ProgramsDictionary::prefixMatch( wstring const & word,
+sptr< Request::WordSearch > ProgramsDictionary::prefixMatch( wstring const & word,
                                                            unsigned long /*maxResults*/ )
   
 {
@@ -65,7 +65,7 @@ sptr< WordSearchRequest > ProgramsDictionary::prefixMatch( wstring const & word,
     return  std::make_shared<ProgramWordSearchRequest>( QString::fromStdU32String( word ), prg );
   else
   {
-    sptr< WordSearchRequestInstant > sr =  std::make_shared<WordSearchRequestInstant>();
+    sptr< Request::WordSearchInstant > sr =  std::make_shared<Request::WordSearchInstant>();
 
     sr->setUncertain( true );
 
@@ -73,7 +73,7 @@ sptr< WordSearchRequest > ProgramsDictionary::prefixMatch( wstring const & word,
   }
 }
 
-sptr< Dictionary::DataRequest > ProgramsDictionary::getArticle(
+sptr< Request::Article > ProgramsDictionary::getArticle(
   wstring const & word, vector< wstring > const &, wstring const &, bool )
   
 {
@@ -102,7 +102,7 @@ sptr< Dictionary::DataRequest > ProgramsDictionary::getArticle(
                 Html::escape( wordUtf8 ) + "</a></td>";
       result += "</tr></table>";
 
-      sptr< DataRequestInstant > ret =  std::make_shared<DataRequestInstant>( true );
+      auto ret =  std::make_shared<Request::ArticleInstant >( true );
 
       ret->getData().resize( result.size() );
 
@@ -115,7 +115,7 @@ sptr< Dictionary::DataRequest > ProgramsDictionary::getArticle(
       return  std::make_shared<ProgramDataRequest>( QString::fromStdU32String( word ), prg );
 
     default:
-      return  std::make_shared<DataRequestInstant>( false );
+      return  std::make_shared<Request::ArticleInstant >( false );
   }
 }
 
@@ -358,7 +358,7 @@ void ProgramWordSearchRequest::instanceFinished( QByteArray output, QString erro
       QString::fromUtf8( output ).split( "\n", Qt::SkipEmptyParts );
 
     for( int x = 0; x < result.size(); ++x )
-      matches.push_back( Dictionary::WordMatch( gd::toWString( result[ x ] ) ) );
+      matches.push_back( Request::WordMatch( gd::toWString( result[ x ] ) ) );
 
     if ( !error.isEmpty() )
       setErrorString( error );

--- a/src/dict/programs.hh
+++ b/src/dict/programs.hh
@@ -45,7 +45,7 @@ private slots:
   void handleProcessFinished();
 };
 
-class ProgramDataRequest: public Dictionary::DataRequest
+class ProgramDataRequest: public Request::Article
 {
   Q_OBJECT
   Config::Program prg;
@@ -62,7 +62,7 @@ private slots:
   void instanceFinished( QByteArray output, QString error );
 };
 
-class ProgramWordSearchRequest: public Dictionary::WordSearchRequest
+class ProgramWordSearchRequest: public Request::WordSearch
 {
   Q_OBJECT
   Config::Program prg;

--- a/src/dict/sdict.cc
+++ b/src/dict/sdict.cc
@@ -155,7 +155,7 @@ class SdictDictionary: public BtreeIndexing::BtreeDictionary
     inline quint32 getLangTo() const override
     { return idxHeader.langTo; }
 
-    sptr< Dictionary::DataRequest > getArticle( wstring const &,
+    sptr< Request::Article > getArticle( wstring const &,
                                                         vector< wstring > const & alts,
                                                         wstring const &,
                                                         bool ignoreDiacritics ) override
@@ -163,7 +163,7 @@ class SdictDictionary: public BtreeIndexing::BtreeDictionary
 
     QString const & getDescription() override;
 
-    sptr< Dictionary::DataRequest >
+    sptr< Request::Blob >
     getSearchResults( QString const & searchString, int searchMode, bool matchCase, bool ignoreDiacritics ) override;
     void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
@@ -456,7 +456,7 @@ void SdictDictionary::getArticleText( uint32_t articleAddress, QString & headwor
   }
 }
 
-sptr< Dictionary::DataRequest >
+sptr< Request::Blob >
 SdictDictionary::getSearchResults( QString const & searchString, int searchMode, bool matchCase, bool ignoreDiacritics )
 {
   return std::make_shared< FtsHelpers::FTSResultsRequest >( *this,
@@ -469,7 +469,7 @@ SdictDictionary::getSearchResults( QString const & searchString, int searchMode,
 /// SdictDictionary::getArticle()
 
 
-class SdictArticleRequest: public Dictionary::DataRequest
+class SdictArticleRequest: public Request::Article
 {
 
   wstring word;
@@ -626,7 +626,7 @@ void SdictArticleRequest::run()
   finish();
 }
 
-sptr< Dictionary::DataRequest > SdictDictionary::getArticle( wstring const & word,
+sptr< Request::Article > SdictDictionary::getArticle( wstring const & word,
                                                              vector< wstring > const & alts,
                                                              wstring const &,
                                                              bool ignoreDiacritics )

--- a/src/dict/slob.cc
+++ b/src/dict/slob.cc
@@ -608,13 +608,13 @@ public:
     inline quint32 getLangTo() const override
     { return idxHeader.langTo; }
 
-    sptr< Dictionary::DataRequest > getArticle( wstring const &,
+    sptr< Request::Article > getArticle( wstring const &,
                                                         vector< wstring > const & alts,
                                                         wstring const &,
                                                         bool ignoreDiacritics ) override
       ;
 
-    sptr< Dictionary::DataRequest > getResource( string const & name ) override
+    sptr< Request::Blob > getResource( string const & name ) override
       ;
 
     QString const& getDescription() override;
@@ -622,7 +622,7 @@ public:
     /// Loads the resource.
     void loadResource( std::string &resourceName, string & data );
 
-    sptr< Dictionary::DataRequest >
+    sptr< Request::Blob >
     getSearchResults( QString const & searchString, int searchMode, bool matchCase, bool ignoreDiacritics ) override;
     void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
@@ -1173,7 +1173,7 @@ void SlobDictionary::getArticleText( uint32_t articleAddress, QString & headword
 }
 
 
-sptr< Dictionary::DataRequest >
+sptr< Request::Blob >
 SlobDictionary::getSearchResults( QString const & searchString, int searchMode, bool matchCase, bool ignoreDiacritics )
 {
   return std::make_shared< FtsHelpers::FTSResultsRequest >( *this,
@@ -1187,7 +1187,7 @@ SlobDictionary::getSearchResults( QString const & searchString, int searchMode, 
 /// SlobDictionary::getArticle()
 
 
-class SlobArticleRequest: public Dictionary::DataRequest
+class SlobArticleRequest: public Request::Article
 {
 
   wstring word;
@@ -1339,7 +1339,7 @@ void SlobArticleRequest::run()
   finish();
 }
 
-sptr< Dictionary::DataRequest > SlobDictionary::getArticle( wstring const & word,
+sptr< Request::Article > SlobDictionary::getArticle( wstring const & word,
                                                             vector< wstring > const & alts,
                                                             wstring const &,
                                                             bool ignoreDiacritics )
@@ -1350,7 +1350,7 @@ sptr< Dictionary::DataRequest > SlobDictionary::getArticle( wstring const & word
 
 //// SlobDictionary::getResource()
 
-class SlobResourceRequest: public Dictionary::DataRequest
+class SlobResourceRequest: public Request::Blob
 {
 
   SlobDictionary & dict;
@@ -1441,7 +1441,7 @@ void SlobResourceRequest::run()
   finish();
 }
 
-sptr< Dictionary::DataRequest > SlobDictionary::getResource( string const & name )
+sptr< Request::Blob > SlobDictionary::getResource( string const & name )
   
 {
   return std::make_shared<SlobResourceRequest>( *this, name );

--- a/src/dict/sounddir.cc
+++ b/src/dict/sounddir.cc
@@ -90,13 +90,13 @@ public:
   unsigned long getWordCount() noexcept override
   { return getArticleCount(); }
 
-  sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Request::Article > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
                                                       bool ignoreDiacritics ) override
     ;
 
-  sptr< Dictionary::DataRequest > getResource( string const & name ) override
+  sptr< Request::Blob > getResource( string const & name ) override
     ;
 
 protected:
@@ -123,7 +123,7 @@ SoundDirDictionary::SoundDirDictionary( string const & id,
              idx, idxMutex );
 }
 
-sptr< Dictionary::DataRequest > SoundDirDictionary::getArticle( wstring const & word,
+sptr< Request::Article > SoundDirDictionary::getArticle( wstring const & word,
                                                                 vector< wstring > const & alts,
                                                                 wstring const &,
                                                                 bool ignoreDiacritics )
@@ -177,7 +177,7 @@ sptr< Dictionary::DataRequest > SoundDirDictionary::getArticle( wstring const & 
   }
 
   if ( mainArticles.empty() && alternateArticles.empty() )
-    return  std::make_shared<Dictionary::DataRequestInstant>( false ); // No such word
+    return  std::make_shared<Request::ArticleInstant >( false ); // No such word
 
   string result;
 
@@ -278,14 +278,14 @@ sptr< Dictionary::DataRequest > SoundDirDictionary::getArticle( wstring const & 
 
   result += "</table>";
 
-  Dictionary::DataRequestInstant * ret =
-    new Dictionary::DataRequestInstant( true );
+  Request::ArticleInstant * ret =
+    new Request::ArticleInstant( true );
 
   ret->getData().resize( result.size() );
 
   memcpy( &(ret->getData().front()), result.data(), result.size() );
 
-  return std::shared_ptr<Dictionary::DataRequestInstant>(ret);
+  return std::shared_ptr<Request::ArticleInstant >(ret);
 }
 
 void SoundDirDictionary::loadIcon() noexcept
@@ -304,7 +304,7 @@ void SoundDirDictionary::loadIcon() noexcept
   dictionaryIconLoaded = true;
 }
 
-sptr< Dictionary::DataRequest > SoundDirDictionary::getResource( string const & name )
+sptr< Request::Blob > SoundDirDictionary::getResource( string const & name )
   
 {
   bool isNumber = false;
@@ -312,7 +312,7 @@ sptr< Dictionary::DataRequest > SoundDirDictionary::getResource( string const & 
   uint32_t articleOffset = QString::fromUtf8( name.c_str() ).toULong( &isNumber );
 
   if ( !isNumber )
-    return std::make_shared<Dictionary::DataRequestInstant>( false ); // No such resource
+    return std::make_shared<Request::BlobInstant >( false ); // No such resource
 
   vector< char > chunk;
   char * articleData;
@@ -333,7 +333,7 @@ sptr< Dictionary::DataRequest > SoundDirDictionary::getResource( string const & 
   catch(  ChunkedStorage::exAddressOutOfRange & )
   {
     // Bad address
-    return std::make_shared<Dictionary::DataRequestInstant>( false ); // No such resource
+    return std::make_shared<Request::BlobInstant >( false ); // No such resource
   }
 
   chunk.back() = 0; // It must end with 0 anyway, but just in case
@@ -348,8 +348,8 @@ sptr< Dictionary::DataRequest > SoundDirDictionary::getResource( string const & 
   {
     File::Class f( fileName.toStdString(), "rb" );
 
-    sptr< Dictionary::DataRequestInstant > dr =
-            std::make_shared<Dictionary::DataRequestInstant>( true );
+    sptr< Request::BlobInstant > dr =
+            std::make_shared<Request::BlobInstant >( true );
 
     vector< char > & data = dr->getData();
 
@@ -364,7 +364,7 @@ sptr< Dictionary::DataRequest > SoundDirDictionary::getResource( string const & 
   }
   catch( File::Ex & )
   {
-    return std::make_shared<Dictionary::DataRequestInstant>( false ); // No such resource
+    return std::make_shared<Request::BlobInstant >( false ); // No such resource
   }
 }
 

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -177,18 +177,18 @@ public:
   inline quint32 getLangTo() const override
   { return idxHeader.langTo; }
 
-  sptr< Dictionary::WordSearchRequest > findHeadwordsForSynonym( wstring const & ) override;
+  sptr< Request::WordSearch > findHeadwordsForSynonym( wstring const & ) override;
 
-  sptr< Dictionary::DataRequest >
+  sptr< Request::Article >
   getArticle( wstring const &, vector< wstring > const & alts, wstring const &, bool ignoreDiacritics ) override;
 
-  sptr< Dictionary::DataRequest > getResource( string const & name ) override;
+  sptr< Request::Blob > getResource( string const & name ) override;
 
   QString const& getDescription() override;
 
   QString getMainFilename() override;
 
-  sptr< Dictionary::DataRequest >
+  sptr< Request::Blob >
   getSearchResults( QString const & searchString, int searchMode, bool matchCase, bool ignoreDiacritics ) override;
   void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
@@ -1199,7 +1199,7 @@ void StardictDictionary::getArticleText( uint32_t articleAddress, QString & head
   }
 }
 
-sptr< Dictionary::DataRequest > StardictDictionary::getSearchResults( QString const & searchString,
+sptr< Request::Blob > StardictDictionary::getSearchResults( QString const & searchString,
                                                                       int searchMode,
                                                                       bool matchCase,
                                                                       bool ignoreDiacritics )
@@ -1213,7 +1213,7 @@ sptr< Dictionary::DataRequest > StardictDictionary::getSearchResults( QString co
 
 /// StardictDictionary::findHeadwordsForSynonym()
 
-class StardictHeadwordsRequest: public Dictionary::WordSearchRequest
+class StardictHeadwordsRequest: public Request::WordSearch
 {
 
   wstring word;
@@ -1295,7 +1295,7 @@ void StardictHeadwordsRequest::run()
   finish();
 }
 
-sptr< Dictionary::WordSearchRequest >
+sptr< Request::WordSearch >
   StardictDictionary::findHeadwordsForSynonym( wstring const & word )
   
 {
@@ -1307,7 +1307,7 @@ sptr< Dictionary::WordSearchRequest >
 /// StardictDictionary::getArticle()
 
 
-class StardictArticleRequest: public Dictionary::DataRequest
+class StardictArticleRequest: public Request::Article
 {
 
   wstring word;
@@ -1470,7 +1470,7 @@ void StardictArticleRequest::run()
   finish();
 }
 
-sptr< Dictionary::DataRequest > StardictDictionary::getArticle( wstring const & word,
+sptr< Request::Article > StardictDictionary::getArticle( wstring const & word,
                                                                 vector< wstring > const & alts,
                                                                 wstring const &,
                                                                 bool ignoreDiacritics )
@@ -1573,7 +1573,7 @@ Ifo::Ifo( File::Class & f ):
 //// StardictDictionary::getResource()
 
 
-class StardictResourceRequest: public Dictionary::DataRequest
+class StardictResourceRequest: public Request::Blob
 {
 
   StardictDictionary & dict;
@@ -1722,7 +1722,7 @@ void StardictResourceRequest::run()
   finish();
 }
 
-sptr< Dictionary::DataRequest > StardictDictionary::getResource( string const & name )
+sptr< Request::Blob > StardictDictionary::getResource( string const & name )
   
 {
   return std::make_shared<StardictResourceRequest>( *this, name );

--- a/src/dict/transliteration.cc
+++ b/src/dict/transliteration.cc
@@ -34,20 +34,20 @@ unsigned long BaseTransliterationDictionary::getArticleCount() noexcept
 unsigned long BaseTransliterationDictionary::getWordCount() noexcept
 { return 0; }
 
-sptr< Dictionary::WordSearchRequest > BaseTransliterationDictionary::prefixMatch( wstring const &,
+sptr< Request::WordSearch > BaseTransliterationDictionary::prefixMatch( wstring const &,
                                                                                   unsigned long ) 
-{ return std::make_shared<Dictionary::WordSearchRequestInstant>(); }
+{ return std::make_shared<Request::WordSearchInstant>(); }
 
-sptr< Dictionary::DataRequest > BaseTransliterationDictionary::getArticle( wstring const &,
+sptr< Request::Article > BaseTransliterationDictionary::getArticle( wstring const &,
                                                                            vector< wstring > const &,
                                                                            wstring const &, bool )
   
-{ return std::make_shared<Dictionary::DataRequestInstant>( false ); }
+{ return std::make_shared<Request::ArticleInstant >( false ); }
 
-sptr< Dictionary::WordSearchRequest > BaseTransliterationDictionary::findHeadwordsForSynonym( wstring const & str )
+sptr< Request::WordSearch > BaseTransliterationDictionary::findHeadwordsForSynonym( wstring const & str )
   
 {
-  sptr< Dictionary::WordSearchRequestInstant > result = std::make_shared<Dictionary::WordSearchRequestInstant>();
+  sptr< Request::WordSearchInstant > result = std::make_shared<Request::WordSearchInstant>();
 
   vector< wstring > alts = getAlternateWritings( str );
 

--- a/src/dict/transliteration.hh
+++ b/src/dict/transliteration.hh
@@ -39,13 +39,13 @@ public:
   virtual vector< wstring > getAlternateWritings( wstring const & )
     noexcept = 0;
 
-  virtual sptr< Dictionary::WordSearchRequest > findHeadwordsForSynonym( wstring const & )
+  virtual sptr< Request::WordSearch > findHeadwordsForSynonym( wstring const & )
     ;
 
-  virtual sptr< Dictionary::WordSearchRequest > prefixMatch( wstring const &,
+  virtual sptr< Request::WordSearch > prefixMatch( wstring const &,
                                                              unsigned long ) ;
 
-  virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  virtual sptr< Request::Article > getArticle( wstring const &,
                                                       vector< wstring > const &,
                                                       wstring const &, bool )
     ;

--- a/src/dict/voiceengines.cc
+++ b/src/dict/voiceengines.cc
@@ -56,11 +56,11 @@ public:
   unsigned long getWordCount() noexcept override
   { return 0; }
 
-  sptr< WordSearchRequest > prefixMatch( wstring const & word,
+  sptr< Request::WordSearch > prefixMatch( wstring const & word,
                                                  unsigned long maxResults ) override
     ;
 
-  sptr< DataRequest > getArticle( wstring const &,
+  sptr< Request::Article > getArticle( wstring const &,
                                           vector< wstring > const & alts,
                                           wstring const &, bool ) override
     ;
@@ -70,16 +70,16 @@ protected:
   void loadIcon() noexcept override;
 };
 
-sptr< WordSearchRequest > VoiceEnginesDictionary::prefixMatch( wstring const & /*word*/,
+sptr< Request::WordSearch > VoiceEnginesDictionary::prefixMatch( wstring const & /*word*/,
                                                                unsigned long /*maxResults*/ )
   
 {
-  WordSearchRequestInstant * sr = new WordSearchRequestInstant();
+  Request::WordSearchInstant * sr = new Request::WordSearchInstant();
   sr->setUncertain( true );
-  return std::shared_ptr<WordSearchRequestInstant>(sr);
+  return std::shared_ptr< Request::WordSearchInstant >(sr);
 }
 
-sptr< Dictionary::DataRequest > VoiceEnginesDictionary::getArticle(
+sptr< Request::Article > VoiceEnginesDictionary::getArticle(
   wstring const & word, vector< wstring > const &, wstring const &, bool )
   
 {
@@ -104,7 +104,7 @@ sptr< Dictionary::DataRequest > VoiceEnginesDictionary::getArticle(
   result += "<td><a href=" + ref + ">" + Html::escape( wordUtf8 ) + "</a></td>";
   result += "</tr></table>";
 
-  sptr< DataRequestInstant > ret = std::make_shared<DataRequestInstant>( true );
+  auto ret = std::make_shared<Request::ArticleInstant >( true );
   ret->getData().resize( result.size() );
   memcpy( &( ret->getData().front() ), result.data(), result.size() );
   return ret;

--- a/src/dict/website.cc
+++ b/src/dict/website.cc
@@ -2,15 +2,14 @@
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
 #include "website.hh"
+#include "website_p.hh"
 #include "wstring_qt.hh"
 #include "utf8.hh"
 #include <QUrl>
 #include <QTextCodec>
 #include <QDir>
 #include <QFileInfo>
-#include "gddebug.hh"
 #include "globalbroadcaster.hh"
-
 #include <QRegularExpression>
 
 namespace WebSite {
@@ -64,15 +63,15 @@ public:
   unsigned long getWordCount() noexcept override
   { return 0; }
 
-  sptr< WordSearchRequest > prefixMatch( wstring const & word,
+  sptr< Request::WordSearch > prefixMatch( wstring const & word,
                                                  unsigned long ) override ;
 
-  sptr< DataRequest > getArticle( wstring const &,
+  sptr< Request::Article > getArticle( wstring const &,
                                           vector< wstring > const & alts,
                                           wstring const & context, bool ) override
     ;
 
-  sptr< Dictionary::DataRequest > getResource( string const & name ) override ;
+  sptr< Request::Blob > getResource( string const & name ) override ;
 
   void isolateWebCSS( QString & css );
 
@@ -81,10 +80,10 @@ protected:
   void loadIcon() noexcept override;
 };
 
-sptr< WordSearchRequest > WebSiteDictionary::prefixMatch( wstring const & /*word*/,
+sptr< Request::WordSearch > WebSiteDictionary::prefixMatch( wstring const & /*word*/,
                                                           unsigned long ) 
 {
-  sptr< WordSearchRequestInstant > sr = std::make_shared<WordSearchRequestInstant>();
+  sptr< Request::WordSearchInstant > sr = std::make_shared< Request::WordSearchInstant >();
 
   sr->setUncertain( true );
 
@@ -96,228 +95,7 @@ void WebSiteDictionary::isolateWebCSS( QString & css )
   isolateCSS( css, ".website" );
 }
 
-class WebSiteArticleRequest: public WebSiteDataRequestSlots
-{
-  QNetworkReply * netReply;
-  QString url;
-  Class * dictPtr;
-  QNetworkAccessManager & mgr;
-
-public:
-
-  WebSiteArticleRequest( QString const & url, QNetworkAccessManager & _mgr,
-                         Class * dictPtr_ );
-  ~WebSiteArticleRequest()
-  {}
-
-  void cancel() override;
-
-private:
-
-  void requestFinished( QNetworkReply * ) override;
-  static QTextCodec * codecForHtml( QByteArray const & ba );
-};
-
-void WebSiteArticleRequest::cancel()
-{
-  finish();
-}
-
-WebSiteArticleRequest::WebSiteArticleRequest( QString const & url_,
-                                              QNetworkAccessManager & _mgr,
-                                              Class * dictPtr_ ):
-  url( url_ ), dictPtr( dictPtr_ ), mgr( _mgr )
-{
-  connect( &mgr, SIGNAL( finished( QNetworkReply * ) ),
-           this, SLOT( requestFinished( QNetworkReply * ) ),
-           Qt::QueuedConnection );
-
-  QUrl reqUrl( url );
-
-  auto request = QNetworkRequest( reqUrl );
-  request.setAttribute( QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy );
-  netReply = mgr.get( request );
-
-#ifndef QT_NO_SSL
-  connect( netReply, SIGNAL( sslErrors( QList< QSslError > ) ),
-           netReply, SLOT( ignoreSslErrors() ) );
-#endif
-}
-
-QTextCodec * WebSiteArticleRequest::codecForHtml( QByteArray const & ba )
-{
-  return QTextCodec::codecForHtml( ba, 0 );
-}
-
-void WebSiteArticleRequest::requestFinished( QNetworkReply * r )
-{
-  if ( isFinished() ) // Was cancelled
-    return;
-
-  if ( r != netReply )
-  {
-    // Well, that's not our reply, don't do anything
-    return;
-  }
-
-  if ( netReply->error() == QNetworkReply::NoError )
-  {
-    // Check for redirect reply
-
-    QVariant possibleRedirectUrl = netReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
-    QUrl redirectUrl = possibleRedirectUrl.toUrl();
-    if( !redirectUrl.isEmpty() )
-    {
-      disconnect( netReply, 0, 0, 0 );
-      netReply->deleteLater();
-      netReply = mgr.get( QNetworkRequest( redirectUrl ) );
-#ifndef QT_NO_SSL
-      connect( netReply, SIGNAL( sslErrors( QList< QSslError > ) ),
-               netReply, SLOT( ignoreSslErrors() ) );
-#endif
-      return;
-    }
-
-    // Handle reply data
-
-    QByteArray replyData = netReply->readAll();
-    QString articleString;
-
-    QTextCodec * codec = WebSiteArticleRequest::codecForHtml( replyData );
-    if( codec )
-      articleString = codec->toUnicode( replyData );
-    else
-      articleString = QString::fromUtf8( replyData );
-
-    // Change links from relative to absolute
-
-    QString root = netReply->url().scheme() + "://" + netReply->url().host();
-    QString base = root + netReply->url().path();
-    while( !base.isEmpty() && !base.endsWith( "/" ) )
-      base.chop( 1 );
-
-    QRegularExpression tags( R"(<\s*(a|link|img|script)\s+[^>]*(src|href)\s*=\s*['"][^>]+>)",
-                             QRegularExpression::CaseInsensitiveOption );
-    QRegularExpression links( R"(\b(src|href)\s*=\s*(['"])([^'"]+['"]))",
-                              QRegularExpression::CaseInsensitiveOption );
-    int pos = 0;
-    QString articleNewString;
-    QRegularExpressionMatchIterator it = tags.globalMatch( articleString );
-    while( it.hasNext() )
-    {
-      QRegularExpressionMatch match = it.next();
-      articleNewString += articleString.mid( pos, match.capturedStart() - pos );
-      pos = match.capturedEnd();
-
-      QString tag = match.captured();
-
-      QRegularExpressionMatch match_links = links.match( tag );
-      if( !match_links.hasMatch() )
-      {
-        articleNewString += tag;
-        continue;
-      }
-
-      QString url = match_links.captured( 3 );
-
-      if( url.indexOf( ":/" ) >= 0 || url.indexOf( "data:" ) >= 0
-          || url.indexOf( "mailto:" ) >= 0 || url.startsWith( "#" )
-          || url.startsWith( "javascript:" ) )
-      {
-        // External link, anchor or base64-encoded data
-        articleNewString += tag;
-        continue;
-      }
-
-      QString newUrl = match_links.captured( 1 ) + "=" + match_links.captured( 2 );
-      if( url.startsWith( "//" ) )
-        newUrl += netReply->url().scheme() + ":";
-      else
-      if( url.startsWith( "/" ) )
-        newUrl += root;
-      else
-        newUrl += base;
-      newUrl += match_links.captured( 3 );
-
-      tag.replace( match_links.capturedStart(), match_links.capturedLength(), newUrl );
-      articleNewString += tag;
-    }
-    if( pos )
-    {
-      articleNewString += articleString.mid( pos );
-      articleString = articleNewString;
-      articleNewString.clear();
-    }
-
-    // Redirect CSS links to own handler
-
-    QString prefix = QString( "bres://" ) + dictPtr->getId().c_str() + "/";
-    QRegularExpression linkTags( R"((<\s*link\s[^>]*rel\s*=\s*['"]stylesheet['"]\s+[^>]*href\s*=\s*['"])([^'"]+)://([^'"]+['"][^>]+>))",
-                                 QRegularExpression::CaseInsensitiveOption );
-    pos = 0;
-    it = linkTags.globalMatch( articleString );
-
-    while( it.hasNext() )
-    {
-      QRegularExpressionMatch match = it.next();
-      articleNewString += articleString.mid( pos, match.capturedStart() - pos );
-      pos = match.capturedEnd();
-
-      QString newTag = match.captured( 1 ) + prefix + match.captured( 2 )
-                       + "/" + match.captured( 3 );
-      articleNewString += newTag;
-    }
-    if( pos )
-    {
-      articleNewString += articleString.mid( pos );
-      articleString = articleNewString;
-      articleNewString.clear();
-    }
-
-    // See Issue #271: A mechanism to clean-up invalid HTML cards.
-    articleString += QString::fromStdString(Utils::Html::getHtmlCleaner());
-
-    QByteArray articleBody = articleString.toUtf8();
-
-    QString divStr = QString( "<div class=\"website\"" );
-    divStr += dictPtr->isToLanguageRTL() ? " dir=\"rtl\">" : ">";
-
-    articleBody.prepend( divStr.toUtf8() );
-    articleBody.append( "</div>" );
-
-    articleBody.prepend( "<div class=\"website_padding\"></div>" );
-
-    QMutexLocker _( &dataMutex );
-
-    size_t prevSize = data.size();
-
-    data.resize( prevSize + articleBody.size() );
-
-    memcpy( &data.front() + prevSize, articleBody.data(), articleBody.size() );
-
-    hasAnyData = true;
-
-  }
-  else
-  {
-    if( netReply->url().scheme() == "file" )
-    {
-      gdWarning( "WebSites: Failed loading article from \"%s\", reason: %s\n", dictPtr->getName().c_str(),
-                 netReply->errorString().toUtf8().data() );
-    }
-    else
-    {
-      setErrorString( netReply->errorString() );
-    }
-  }
-
-  disconnect( netReply, 0, 0, 0 );
-  netReply->deleteLater();
-
-  finish();
-}
-
-sptr< DataRequest > WebSiteDictionary::getArticle( wstring const & str,
+sptr< Request::Article > WebSiteDictionary::getArticle( wstring const & str,
                                                    vector< wstring > const &,
                                                    wstring const & context, bool )
   
@@ -372,7 +150,7 @@ sptr< DataRequest > WebSiteDictionary::getArticle( wstring const & str,
   {
     // Just insert link in <iframe> tag
 
-    sptr< DataRequestInstant > dr = std::make_shared<DataRequestInstant>( true );
+    auto dr = std::make_shared<Request::ArticleInstant >( true );
 
     string result = "<div class=\"website_padding\"></div>";
 
@@ -409,115 +187,13 @@ sptr< DataRequest > WebSiteDictionary::getArticle( wstring const & str,
   return std::make_shared<WebSiteArticleRequest>( urlString, netMgr, this );
 }
 
-class WebSiteResourceRequest: public WebSiteDataRequestSlots
-{
-  QNetworkReply * netReply;
-  QString url;
-  WebSiteDictionary * dictPtr;
-  QNetworkAccessManager & mgr;
-
-public:
-
-  WebSiteResourceRequest( QString const & url_, QNetworkAccessManager & _mgr,
-                          WebSiteDictionary * dictPtr_ );
-  ~WebSiteResourceRequest()
-  {}
-
-  void cancel() override;
-
-private:
-
-  void requestFinished( QNetworkReply * ) override;
-};
-
-WebSiteResourceRequest::WebSiteResourceRequest( QString const & url_,
-                                                QNetworkAccessManager & _mgr,
-                                                WebSiteDictionary * dictPtr_ ):
-  url( url_ ), dictPtr( dictPtr_ ), mgr( _mgr )
-{
-  connect( &mgr, SIGNAL( finished( QNetworkReply * ) ),
-           this, SLOT( requestFinished( QNetworkReply * ) ),
-           Qt::QueuedConnection );
-
-  QUrl reqUrl( url );
-
-  netReply = mgr.get( QNetworkRequest( reqUrl ) );
-
-#ifndef QT_NO_SSL
-  connect( netReply, SIGNAL( sslErrors( QList< QSslError > ) ),
-           netReply, SLOT( ignoreSslErrors() ) );
-#endif
-}
-
-void WebSiteResourceRequest::cancel()
-{
-  finish();
-}
-
-void WebSiteResourceRequest::requestFinished( QNetworkReply * r )
-{
-  if ( isFinished() ) // Was cancelled
-    return;
-
-  if ( r != netReply )
-  {
-    // Well, that's not our reply, don't do anything
-    return;
-  }
-
-  if ( netReply->error() == QNetworkReply::NoError )
-  {
-    // Check for redirect reply
-
-    QVariant possibleRedirectUrl = netReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
-    QUrl redirectUrl = possibleRedirectUrl.toUrl();
-    if( !redirectUrl.isEmpty() )
-    {
-      disconnect( netReply, 0, 0, 0 );
-      netReply->deleteLater();
-      netReply = mgr.get( QNetworkRequest( redirectUrl ) );
-#ifndef QT_NO_SSL
-      connect( netReply, SIGNAL( sslErrors( QList< QSslError > ) ),
-               netReply, SLOT( ignoreSslErrors() ) );
-#endif
-      return;
-    }
-
-    // Handle reply data
-
-    QByteArray replyData = netReply->readAll();
-    QString cssString = QString::fromUtf8( replyData );
-
-    dictPtr->isolateWebCSS( cssString );
-
-    QByteArray cssData = cssString.toUtf8();
-
-    QMutexLocker _( &dataMutex );
-
-    size_t prevSize = data.size();
-
-    data.resize( prevSize + cssData.size() );
-
-    memcpy( &data.front() + prevSize, cssData.data(), cssData.size() );
-
-    hasAnyData = true;
-  }
-  else
-    setErrorString( netReply->errorString() );
-
-  disconnect( netReply, 0, 0, 0 );
-  netReply->deleteLater();
-
-  finish();
-}
-
-sptr< Dictionary::DataRequest > WebSiteDictionary::getResource( string const & name ) 
+sptr< Request::Blob > WebSiteDictionary::getResource( string const & name )
 {
   QString link = QString::fromUtf8( name.c_str() );
   int pos = link.indexOf( '/' );
   if( pos > 0 )
     link.replace( pos, 1, "://" );
-  return std::make_shared<WebSiteResourceRequest>( link, netMgr, this );
+  return std::make_shared< WebSiteResourceRequest >( link, netMgr, this );
 }
 
 void WebSiteDictionary::loadIcon() noexcept

--- a/src/dict/website.hh
+++ b/src/dict/website.hh
@@ -6,6 +6,7 @@
 
 #include "dictionary.hh"
 #include "config.hh"
+#include <QTextCodec>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 
@@ -18,18 +19,6 @@ using std::string;
 vector< sptr< Dictionary::Class > > makeDictionaries( Config::WebSites const &,
                                                       QNetworkAccessManager & )
     ;
-
-/// Exposed here for moc
-class WebSiteDataRequestSlots: public Dictionary::DataRequest
-{
-  Q_OBJECT
-
-protected slots:
-
-  virtual void requestFinished( QNetworkReply * )
-  {}
-};
-
 }
 
 #endif

--- a/src/dict/website_p.cc
+++ b/src/dict/website_p.cc
@@ -1,0 +1,380 @@
+#include "website_p.hh"
+#include "gddebug.hh"
+
+namespace WebSite {
+void WebSiteArticleRequest::cancel()
+{
+  finish();
+}
+
+WebSiteArticleRequest::WebSiteArticleRequest( QString const & url_,
+                                              QNetworkAccessManager & _mgr,
+                                              Dictionary::Class * dictPtr_ ):
+  url( url_ ),
+  dictPtr( dictPtr_ ),
+  mgr( _mgr )
+{
+  connect( &mgr,
+           SIGNAL( finished( QNetworkReply * ) ),
+           this,
+           SLOT( requestFinished( QNetworkReply * ) ),
+           Qt::QueuedConnection );
+
+  QUrl reqUrl( url );
+
+  auto request = QNetworkRequest( reqUrl );
+  request.setAttribute( QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy );
+  netReply = mgr.get( request );
+
+#ifndef QT_NO_SSL
+  connect( netReply, SIGNAL( sslErrors( QList< QSslError > ) ), netReply, SLOT( ignoreSslErrors() ) );
+#endif
+}
+
+QTextCodec * WebSiteArticleRequest::codecForHtml( QByteArray const & ba )
+{
+  return QTextCodec::codecForHtml( ba, 0 );
+}
+
+void WebSiteArticleRequest::requestFinished( QNetworkReply * r )
+{
+  if ( isFinished() ) // Was cancelled
+    return;
+
+  if ( r != netReply ) {
+    // Well, that's not our reply, don't do anything
+    return;
+  }
+
+  if ( netReply->error() == QNetworkReply::NoError ) {
+    // Check for redirect reply
+
+    QVariant possibleRedirectUrl = netReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
+    QUrl redirectUrl             = possibleRedirectUrl.toUrl();
+    if ( !redirectUrl.isEmpty() ) {
+      disconnect( netReply, 0, 0, 0 );
+      netReply->deleteLater();
+      netReply = mgr.get( QNetworkRequest( redirectUrl ) );
+#ifndef QT_NO_SSL
+      connect( netReply, SIGNAL( sslErrors( QList< QSslError > ) ), netReply, SLOT( ignoreSslErrors() ) );
+#endif
+      return;
+    }
+
+    // Handle reply data
+
+    QByteArray replyData = netReply->readAll();
+    QString articleString;
+
+    QTextCodec * codec = WebSiteArticleRequest::codecForHtml( replyData );
+    if ( codec )
+      articleString = codec->toUnicode( replyData );
+    else
+      articleString = QString::fromUtf8( replyData );
+
+    // Change links from relative to absolute
+
+    QString root = netReply->url().scheme() + "://" + netReply->url().host();
+    QString base = root + netReply->url().path();
+    while ( !base.isEmpty() && !base.endsWith( "/" ) )
+      base.chop( 1 );
+
+    QRegularExpression tags( R"(<\s*(a|link|img|script)\s+[^>]*(src|href)\s*=\s*['"][^>]+>)",
+                             QRegularExpression::CaseInsensitiveOption );
+    QRegularExpression links( R"(\b(src|href)\s*=\s*(['"])([^'"]+['"]))", QRegularExpression::CaseInsensitiveOption );
+    int pos = 0;
+    QString articleNewString;
+    QRegularExpressionMatchIterator it = tags.globalMatch( articleString );
+    while ( it.hasNext() ) {
+      QRegularExpressionMatch match = it.next();
+      articleNewString += articleString.mid( pos, match.capturedStart() - pos );
+      pos = match.capturedEnd();
+
+      QString tag = match.captured();
+
+      QRegularExpressionMatch match_links = links.match( tag );
+      if ( !match_links.hasMatch() ) {
+        articleNewString += tag;
+        continue;
+      }
+
+      QString url = match_links.captured( 3 );
+
+      if ( url.indexOf( ":/" ) >= 0 || url.indexOf( "data:" ) >= 0 || url.indexOf( "mailto:" ) >= 0
+           || url.startsWith( "#" ) || url.startsWith( "javascript:" ) ) {
+        // External link, anchor or base64-encoded data
+        articleNewString += tag;
+        continue;
+      }
+
+      QString newUrl = match_links.captured( 1 ) + "=" + match_links.captured( 2 );
+      if ( url.startsWith( "//" ) )
+        newUrl += netReply->url().scheme() + ":";
+      else if ( url.startsWith( "/" ) )
+        newUrl += root;
+      else
+        newUrl += base;
+      newUrl += match_links.captured( 3 );
+
+      tag.replace( match_links.capturedStart(), match_links.capturedLength(), newUrl );
+      articleNewString += tag;
+    }
+    if ( pos ) {
+      articleNewString += articleString.mid( pos );
+      articleString = articleNewString;
+      articleNewString.clear();
+    }
+
+    // Redirect CSS links to own handler
+
+    QString prefix = QString( "bres://" ) + dictPtr->getId().c_str() + "/";
+    QRegularExpression linkTags(
+      R"((<\s*link\s[^>]*rel\s*=\s*['"]stylesheet['"]\s+[^>]*href\s*=\s*['"])([^'"]+)://([^'"]+['"][^>]+>))",
+      QRegularExpression::CaseInsensitiveOption );
+    pos = 0;
+    it  = linkTags.globalMatch( articleString );
+
+    while ( it.hasNext() ) {
+      QRegularExpressionMatch match = it.next();
+      articleNewString += articleString.mid( pos, match.capturedStart() - pos );
+      pos = match.capturedEnd();
+
+      QString newTag = match.captured( 1 ) + prefix + match.captured( 2 ) + "/" + match.captured( 3 );
+      articleNewString += newTag;
+    }
+    if ( pos ) {
+      articleNewString += articleString.mid( pos );
+      articleString = articleNewString;
+      articleNewString.clear();
+    }
+
+    // See Issue #271: A mechanism to clean-up invalid HTML cards.
+    articleString += QString::fromStdString( Utils::Html::getHtmlCleaner() );
+
+    QByteArray articleBody = articleString.toUtf8();
+
+    QString divStr = QString( "<div class=\"website\"" );
+    divStr += dictPtr->isToLanguageRTL() ? " dir=\"rtl\">" : ">";
+
+    articleBody.prepend( divStr.toUtf8() );
+    articleBody.append( "</div>" );
+
+    articleBody.prepend( "<div class=\"website_padding\"></div>" );
+
+    QMutexLocker _( &dataMutex );
+
+    size_t prevSize = data.size();
+
+    data.resize( prevSize + articleBody.size() );
+
+    memcpy( &data.front() + prevSize, articleBody.data(), articleBody.size() );
+
+    hasAnyData = true;
+  }
+  else {
+    if ( netReply->url().scheme() == "file" ) {
+      gdWarning( "WebSites: Failed loading article from \"%s\", reason: %s\n",
+                 dictPtr->getName().c_str(),
+                 netReply->errorString().toUtf8().data() );
+    }
+    else {
+      setErrorString( netReply->errorString() );
+    }
+  }
+
+  disconnect( netReply, 0, 0, 0 );
+  netReply->deleteLater();
+
+  finish();
+}
+
+// =====================
+
+
+void WebSiteResourceRequest::cancel()
+{
+  finish();
+}
+
+WebSiteResourceRequest::WebSiteResourceRequest( QString const & url_,
+                                              QNetworkAccessManager & _mgr,
+                                              Dictionary::Class * dictPtr_ ):
+  url( url_ ),
+  dictPtr( dictPtr_ ),
+  mgr( _mgr )
+{
+  connect( &mgr,
+           SIGNAL( finished( QNetworkReply * ) ),
+           this,
+           SLOT( requestFinished( QNetworkReply * ) ),
+           Qt::QueuedConnection );
+
+  QUrl reqUrl( url );
+
+  auto request = QNetworkRequest( reqUrl );
+  request.setAttribute( QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy );
+  netReply = mgr.get( request );
+
+#ifndef QT_NO_SSL
+  connect( netReply, SIGNAL( sslErrors( QList< QSslError > ) ), netReply, SLOT( ignoreSslErrors() ) );
+#endif
+}
+
+QTextCodec * WebSiteResourceRequest::codecForHtml( QByteArray const & ba )
+{
+  return QTextCodec::codecForHtml( ba, 0 );
+}
+
+void WebSiteResourceRequest::requestFinished( QNetworkReply * r )
+{
+  if ( isFinished() ) // Was cancelled
+    return;
+
+  if ( r != netReply ) {
+    // Well, that's not our reply, don't do anything
+    return;
+  }
+
+  if ( netReply->error() == QNetworkReply::NoError ) {
+    // Check for redirect reply
+
+    QVariant possibleRedirectUrl = netReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
+    QUrl redirectUrl             = possibleRedirectUrl.toUrl();
+    if ( !redirectUrl.isEmpty() ) {
+      disconnect( netReply, 0, 0, 0 );
+      netReply->deleteLater();
+      netReply = mgr.get( QNetworkRequest( redirectUrl ) );
+#ifndef QT_NO_SSL
+      connect( netReply, SIGNAL( sslErrors( QList< QSslError > ) ), netReply, SLOT( ignoreSslErrors() ) );
+#endif
+      return;
+    }
+
+    // Handle reply data
+
+    QByteArray replyData = netReply->readAll();
+    QString articleString;
+
+    QTextCodec * codec = WebSiteResourceRequest::codecForHtml( replyData );
+    if ( codec )
+      articleString = codec->toUnicode( replyData );
+    else
+      articleString = QString::fromUtf8( replyData );
+
+    // Change links from relative to absolute
+
+    QString root = netReply->url().scheme() + "://" + netReply->url().host();
+    QString base = root + netReply->url().path();
+    while ( !base.isEmpty() && !base.endsWith( "/" ) )
+      base.chop( 1 );
+
+    QRegularExpression tags( R"(<\s*(a|link|img|script)\s+[^>]*(src|href)\s*=\s*['"][^>]+>)",
+                             QRegularExpression::CaseInsensitiveOption );
+    QRegularExpression links( R"(\b(src|href)\s*=\s*(['"])([^'"]+['"]))", QRegularExpression::CaseInsensitiveOption );
+    int pos = 0;
+    QString articleNewString;
+    QRegularExpressionMatchIterator it = tags.globalMatch( articleString );
+    while ( it.hasNext() ) {
+      QRegularExpressionMatch match = it.next();
+      articleNewString += articleString.mid( pos, match.capturedStart() - pos );
+      pos = match.capturedEnd();
+
+      QString tag = match.captured();
+
+      QRegularExpressionMatch match_links = links.match( tag );
+      if ( !match_links.hasMatch() ) {
+        articleNewString += tag;
+        continue;
+      }
+
+      QString url = match_links.captured( 3 );
+
+      if ( url.indexOf( ":/" ) >= 0 || url.indexOf( "data:" ) >= 0 || url.indexOf( "mailto:" ) >= 0
+           || url.startsWith( "#" ) || url.startsWith( "javascript:" ) ) {
+        // External link, anchor or base64-encoded data
+        articleNewString += tag;
+        continue;
+      }
+
+      QString newUrl = match_links.captured( 1 ) + "=" + match_links.captured( 2 );
+      if ( url.startsWith( "//" ) )
+        newUrl += netReply->url().scheme() + ":";
+      else if ( url.startsWith( "/" ) )
+        newUrl += root;
+      else
+        newUrl += base;
+      newUrl += match_links.captured( 3 );
+
+      tag.replace( match_links.capturedStart(), match_links.capturedLength(), newUrl );
+      articleNewString += tag;
+    }
+    if ( pos ) {
+      articleNewString += articleString.mid( pos );
+      articleString = articleNewString;
+      articleNewString.clear();
+    }
+
+    // Redirect CSS links to own handler
+
+    QString prefix = QString( "bres://" ) + dictPtr->getId().c_str() + "/";
+    QRegularExpression linkTags(
+      R"((<\s*link\s[^>]*rel\s*=\s*['"]stylesheet['"]\s+[^>]*href\s*=\s*['"])([^'"]+)://([^'"]+['"][^>]+>))",
+      QRegularExpression::CaseInsensitiveOption );
+    pos = 0;
+    it  = linkTags.globalMatch( articleString );
+
+    while ( it.hasNext() ) {
+      QRegularExpressionMatch match = it.next();
+      articleNewString += articleString.mid( pos, match.capturedStart() - pos );
+      pos = match.capturedEnd();
+
+      QString newTag = match.captured( 1 ) + prefix + match.captured( 2 ) + "/" + match.captured( 3 );
+      articleNewString += newTag;
+    }
+    if ( pos ) {
+      articleNewString += articleString.mid( pos );
+      articleString = articleNewString;
+      articleNewString.clear();
+    }
+
+    // See Issue #271: A mechanism to clean-up invalid HTML cards.
+    articleString += QString::fromStdString( Utils::Html::getHtmlCleaner() );
+
+    QByteArray articleBody = articleString.toUtf8();
+
+    QString divStr = QString( "<div class=\"website\"" );
+    divStr += dictPtr->isToLanguageRTL() ? " dir=\"rtl\">" : ">";
+
+    articleBody.prepend( divStr.toUtf8() );
+    articleBody.append( "</div>" );
+
+    articleBody.prepend( "<div class=\"website_padding\"></div>" );
+
+    QMutexLocker _( &dataMutex );
+
+    size_t prevSize = data.size();
+
+    data.resize( prevSize + articleBody.size() );
+
+    memcpy( &data.front() + prevSize, articleBody.data(), articleBody.size() );
+
+    hasAnyData = true;
+  }
+  else {
+    if ( netReply->url().scheme() == "file" ) {
+      gdWarning( "WebSites: Failed loading article from \"%s\", reason: %s\n",
+                 dictPtr->getName().c_str(),
+                 netReply->errorString().toUtf8().data() );
+    }
+    else {
+      setErrorString( netReply->errorString() );
+    }
+  }
+
+  disconnect( netReply, 0, 0, 0 );
+  netReply->deleteLater();
+
+  finish();
+}
+
+} // namespace WebSite

--- a/src/dict/website_p.hh
+++ b/src/dict/website_p.hh
@@ -1,0 +1,56 @@
+#pragma once
+#include "dictionary.hh"
+#include "config.hh"
+#include <QTextCodec>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+
+namespace WebSite {
+
+class WebSiteArticleRequest: public Request::Article
+{
+  Q_OBJECT
+  QNetworkReply * netReply;
+  QString url;
+  Dictionary::Class * dictPtr;
+  QNetworkAccessManager & mgr;
+
+public:
+
+  WebSiteArticleRequest( QString const & url, QNetworkAccessManager & _mgr, Dictionary::Class * dictPtr_ );
+  ~WebSiteArticleRequest() {}
+
+  void cancel() override;
+
+private:
+
+  static QTextCodec * codecForHtml( QByteArray const & ba );
+
+public slots:
+  void requestFinished( QNetworkReply * );
+};
+
+
+class WebSiteResourceRequest: public Request::Blob
+{
+  Q_OBJECT
+  QNetworkReply * netReply;
+  QString url;
+  Dictionary::Class * dictPtr;
+  QNetworkAccessManager & mgr;
+
+public:
+
+  WebSiteResourceRequest( QString const & url, QNetworkAccessManager & _mgr, Dictionary::Class * dictPtr_ );
+  ~WebSiteResourceRequest() {}
+
+  void cancel() override;
+
+private:
+
+  static QTextCodec * codecForHtml( QByteArray const & ba );
+
+public slots:
+  void requestFinished( QNetworkReply * );
+};
+} // namespace WebSite

--- a/src/dict/xdxf.cc
+++ b/src/dict/xdxf.cc
@@ -180,20 +180,20 @@ public:
   inline quint32 getLangTo() const override
   { return idxHeader.langTo; }
 
-  sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Request::Article > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
                                                       bool ignoreDiacritics ) override
     ;
 
-  sptr< Dictionary::DataRequest > getResource( string const & name ) override
+  sptr< Request::Blob > getResource( string const & name ) override
     ;
 
   QString const& getDescription() override;
 
   QString getMainFilename() override;
 
-  sptr< Dictionary::DataRequest >
+  sptr< Request::Blob >
   getSearchResults( QString const & searchString, int searchMode, bool matchCase, bool ignoreDiacritics ) override;
   void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
@@ -425,7 +425,7 @@ void XdxfDictionary::getArticleText( uint32_t articleAddress, QString & headword
   }
 }
 
-sptr< Dictionary::DataRequest >
+sptr< Request::Blob >
 XdxfDictionary::getSearchResults( QString const & searchString, int searchMode, bool matchCase, bool ignoreDiacritics )
 {
   return std::make_shared< FtsHelpers::FTSResultsRequest >( *this,
@@ -438,7 +438,7 @@ XdxfDictionary::getSearchResults( QString const & searchString, int searchMode, 
 /// XdxfDictionary::getArticle()
 
 
-class XdxfArticleRequest: public Dictionary::DataRequest
+class XdxfArticleRequest: public Request::Article
 {
 
   wstring word;
@@ -592,7 +592,7 @@ void XdxfArticleRequest::run()
   finish();
 }
 
-sptr< Dictionary::DataRequest > XdxfDictionary::getArticle( wstring const & word,
+sptr< Request::Article > XdxfDictionary::getArticle( wstring const & word,
                                                             vector< wstring > const & alts,
                                                             wstring const &,
                                                             bool ignoreDiacritics )
@@ -935,7 +935,7 @@ void indexArticle( GzippedFile & gzFile,
 
 //// XdxfDictionary::getResource()
 
-class XdxfResourceRequest: public Dictionary::DataRequest
+class XdxfResourceRequest: public Request::Blob
 {
 
   XdxfDictionary & dict;
@@ -1047,7 +1047,7 @@ void XdxfResourceRequest::run()
   finish();
 }
 
-sptr< Dictionary::DataRequest > XdxfDictionary::getResource( string const & name )
+sptr< Request::Blob > XdxfDictionary::getResource( string const & name )
   
 {
   return std::make_shared<XdxfResourceRequest>( *this, name );

--- a/src/dict/zim.cc
+++ b/src/dict/zim.cc
@@ -205,17 +205,17 @@ public:
     return idxHeader.langTo;
   }
 
-  sptr< Dictionary::DataRequest >
+  sptr< Request::Article >
   getArticle( wstring const &, vector< wstring > const & alts, wstring const &, bool ignoreDiacritics ) override;
 
-  sptr< Dictionary::DataRequest > getResource( string const & name ) override;
+  sptr< Request::Blob > getResource( string const & name ) override;
 
   QString const & getDescription() override;
 
   /// Loads the resource.
   void loadResource( std::string & resourceName, string & data );
 
-  sptr< Dictionary::DataRequest >
+  sptr< Request::Blob >
   getSearchResults( QString const & searchString, int searchMode, bool matchCase, bool ignoreDiacritics ) override;
   void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
@@ -554,7 +554,7 @@ void ZimDictionary::getArticleText( uint32_t articleAddress, QString & headword,
   }
 }
 
-sptr< Dictionary::DataRequest >
+sptr< Request::Blob >
 ZimDictionary::getSearchResults( QString const & searchString, int searchMode, bool matchCase, bool ignoreDiacritics )
 {
   return std::make_shared< FtsHelpers::FTSResultsRequest >( *this,
@@ -566,7 +566,7 @@ ZimDictionary::getSearchResults( QString const & searchString, int searchMode, b
 
 /// ZimDictionary::getArticle()
 
-class ZimArticleRequest: public Dictionary::DataRequest
+class ZimArticleRequest: public Request::Article
 {
   wstring word;
   vector< wstring > alts;
@@ -724,7 +724,7 @@ void ZimArticleRequest::run()
   finish();
 }
 
-sptr< Dictionary::DataRequest > ZimDictionary::getArticle( wstring const & word,
+sptr< Request::Article > ZimDictionary::getArticle( wstring const & word,
                                                            vector< wstring > const & alts,
                                                            wstring const &,
                                                            bool ignoreDiacritics )
@@ -735,7 +735,7 @@ sptr< Dictionary::DataRequest > ZimDictionary::getArticle( wstring const & word,
 
 //// ZimDictionary::getResource()
 
-class ZimResourceRequest: public Dictionary::DataRequest
+class ZimResourceRequest: public Request::Blob
 {
   //the dict will outlive this object, so the reference & used here is proper.
   ZimDictionary & dict;
@@ -822,7 +822,7 @@ void ZimResourceRequest::run()
   finish();
 }
 
-sptr< Dictionary::DataRequest > ZimDictionary::getResource( string const & name )
+sptr< Request::Blob > ZimDictionary::getResource( string const & name )
 {
   auto noLeadingDot = QString::fromStdString( name ).remove( RX::Zim::leadingDotSlash );
   return std::make_shared<ZimResourceRequest>( *this, noLeadingDot.toStdString() );

--- a/src/dict/zipsounds.cc
+++ b/src/dict/zipsounds.cc
@@ -124,13 +124,13 @@ public:
   unsigned long getWordCount() noexcept override
   { return getArticleCount(); }
 
-  sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Request::Article > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
                                                       bool ignoreDiacritics ) override
     ;
 
-  sptr< Dictionary::DataRequest > getResource( string const & name ) override
+  sptr< Request::Blob > getResource( string const & name ) override
     ;
 
 protected:
@@ -172,7 +172,7 @@ string ZipSoundsDictionary::getName() noexcept
   return result;
 }
 
-sptr< Dictionary::DataRequest > ZipSoundsDictionary::getArticle( wstring const & word,
+sptr< Request::Article > ZipSoundsDictionary::getArticle( wstring const & word,
                                                                  vector< wstring > const & alts,
                                                                  wstring const &,
                                                                  bool ignoreDiacritics )
@@ -225,7 +225,7 @@ sptr< Dictionary::DataRequest > ZipSoundsDictionary::getArticle( wstring const &
   }
 
   if ( mainArticles.empty() && alternateArticles.empty() )
-    return std::make_shared<Dictionary::DataRequestInstant>( false ); // No such word
+    return std::make_shared<Request::ArticleInstant >( false ); // No such word
 
   string result;
 
@@ -330,17 +330,17 @@ sptr< Dictionary::DataRequest > ZipSoundsDictionary::getArticle( wstring const &
 
   result += "</table>";
 
-  Dictionary::DataRequestInstant * ret =
-    new Dictionary::DataRequestInstant( true );
+  auto * ret =
+    new Request::ArticleInstant( true );
 
   ret->getData().resize( result.size() );
 
   memcpy( &(ret->getData().front()), result.data(), result.size() );
 
-  return std::shared_ptr<Dictionary::DataRequestInstant>(ret);
+  return std::shared_ptr<Request::ArticleInstant >(ret);
 }
 
-sptr< Dictionary::DataRequest > ZipSoundsDictionary::getResource( string const & name )
+sptr< Request::Blob > ZipSoundsDictionary::getResource( string const & name )
   
 {
   // Remove extension for sound files (like in sound dirs)
@@ -350,7 +350,7 @@ sptr< Dictionary::DataRequest > ZipSoundsDictionary::getResource( string const &
   vector< WordArticleLink > chain = findArticles( strippedName );
 
   if ( chain.empty() )
-    return std::make_shared<Dictionary::DataRequestInstant>( false ); // No such resource
+    return std::make_shared<Request::BlobInstant >( false ); // No such resource
 
   // Find sound
 
@@ -373,13 +373,13 @@ sptr< Dictionary::DataRequest > ZipSoundsDictionary::getResource( string const &
       break;
   }
 
-  sptr< Dictionary::DataRequestInstant > dr =
-    std::make_shared<Dictionary::DataRequestInstant>( true );
+  sptr< Request::BlobInstant > dr =
+    std::make_shared<Request::BlobInstant >( true );
 
   if ( zipsFile.loadFile( dataOffset, dr->getData() ) )
     return dr;
 
-  return std::make_shared<Dictionary::DataRequestInstant>( false );
+  return std::make_shared<Request::BlobInstant >( false );
 }
 
 void ZipSoundsDictionary::loadIcon() noexcept

--- a/src/ftshelpers.hh
+++ b/src/ftshelpers.hh
@@ -23,7 +23,7 @@ bool ftsIndexIsOldOrBad( BtreeIndexing::BtreeDictionary * dict );
 
 void makeFTSIndex( BtreeIndexing::BtreeDictionary * dict, QAtomicInt & isCancelled );
 
-class FTSResultsRequest : public Dictionary::DataRequest
+class FTSResultsRequest : public Request::Blob
 {
   BtreeIndexing::BtreeDictionary & dict;
 

--- a/src/fulltextsearch.cc
+++ b/src/fulltextsearch.cc
@@ -284,7 +284,7 @@ void FullTextSearchDialog::stopSearch()
 {
   if( !searchReqs.empty() )
   {
-    for( std::list< sptr< Dictionary::DataRequest > >::iterator it = searchReqs.begin();
+    for( std::list< sptr< Request::Blob > >::iterator it = searchReqs.begin();
          it != searchReqs.end(); ++it )
       if( !(*it)->isFinished() )
         (*it)->cancel();
@@ -363,16 +363,16 @@ void FullTextSearchDialog::accept()
       continue;
     }
     //max results=100
-    sptr< Dictionary::DataRequest > req =
+    sptr< Request::Blob > req =
       activeDicts[ x ]->getSearchResults( ui.searchLine->text(), mode, false, false );
     connect( req.get(),
-      &Dictionary::Request::finished,
+      &Request::Base::finished,
       this,
       &FullTextSearchDialog::searchReqFinished,
       Qt::QueuedConnection );
 
     connect( req.get(),
-      &Dictionary::Request::matchCount,
+      &Request::Base::matchCount,
       this,
       &FullTextSearchDialog::matchCount,
       Qt::QueuedConnection );
@@ -388,7 +388,7 @@ void FullTextSearchDialog::searchReqFinished()
   QList< FtsHeadword > allHeadwords;
   while ( searchReqs.size() )
   {
-    std::list< sptr< Dictionary::DataRequest > >::iterator it;
+    std::list< sptr< Request::Blob > >::iterator it;
     for( it = searchReqs.begin(); it != searchReqs.end(); ++it )
     {
       if ( (*it)->isFinished() )

--- a/src/fulltextsearch.hh
+++ b/src/fulltextsearch.hh
@@ -199,7 +199,7 @@ class FullTextSearchDialog : public QDialog
   unsigned group;
   std::vector< sptr< Dictionary::Class > > activeDicts;
 
-  std::list< sptr< Dictionary::DataRequest > > searchReqs;
+  std::list< sptr< Request::Blob > > searchReqs;
 
   FtsIndexing & ftsIdx;
 

--- a/src/headwordsmodel.cc
+++ b/src/headwordsmodel.cc
@@ -42,7 +42,7 @@ void HeadwordListModel::setFilter( QRegularExpression reg )
   filtering = true;
   filterWords.clear();
   auto sr = _dict->prefixMatch( gd::removeTrailingZero( reg.pattern() ), 500 );
-  connect( sr.get(), &Dictionary::Request::finished, this, &HeadwordListModel::requestFinished, Qt::QueuedConnection );
+  connect( sr.get(), &Request::Base::finished, this, &HeadwordListModel::requestFinished, Qt::QueuedConnection );
   queuedRequests.push_back( sr );
 }
 

--- a/src/headwordsmodel.hh
+++ b/src/headwordsmodel.hh
@@ -48,7 +48,7 @@ private:
   int index;
   char * ptr;
   QMutex lock;
-  std::list< sptr< Dictionary::WordSearchRequest > > queuedRequests;
+  std::list< sptr< Request::WordSearch > > queuedRequests;
 };
 
 #endif // HEADWORDSMODEL_H

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -1065,12 +1065,12 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref, QString const & 
 
     if ( Dictionary::WebMultimediaDownload::isAudioUrl( url ) )
     {
-      sptr< Dictionary::DataRequest > req =
+      sptr< Request::Blob > req =
         std::make_shared<Dictionary::WebMultimediaDownload>( url, articleNetMgr );
 
       resourceDownloadRequests.push_back( req );
 
-      connect( req.get(), &Dictionary::Request::finished, this, &ArticleView::resourceDownloadFinished );
+      connect( req.get(), &Request::Base::finished, this, &ArticleView::resourceDownloadFinished );
     }
     else
     if ( url.scheme() == "gdau" && url.host() == "search" )
@@ -1108,7 +1108,7 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref, QString const & 
               if( preferredName.compare( QString::fromUtf8( (*activeDicts)[ x ]->getName().c_str() ) ) == 0 )
               {
                 preferred = x;
-                sptr< Dictionary::DataRequest > req =
+                sptr< Request::Blob > req =
                   (*activeDicts)[ x ]->getResource(
                     url.path().mid( 1 ).toUtf8().data() );
 
@@ -1117,7 +1117,7 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref, QString const & 
                 if ( !req->isFinished() )
                 {
                   // Queued loading
-                  connect( req.get(), &Dictionary::Request::finished, this, &ArticleView::resourceDownloadFinished );
+                  connect( req.get(), &Request::Base::finished, this, &ArticleView::resourceDownloadFinished );
                 }
                 else
                 {
@@ -1147,7 +1147,7 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref, QString const & 
             if( x == preferred )
               continue;
 
-            sptr< Dictionary::DataRequest > req =
+            sptr< Request::Blob > req =
               (*activeDicts)[ x ]->getResource(
                 url.path().mid( 1 ).toUtf8().data() );
 
@@ -1156,7 +1156,7 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref, QString const & 
             if ( !req->isFinished() )
             {
               // Queued loading
-              connect( req.get(), &Dictionary::Request::finished, this, &ArticleView::resourceDownloadFinished );
+              connect( req.get(), &Request::Base::finished, this, &ArticleView::resourceDownloadFinished );
             }
             else
             {
@@ -1182,7 +1182,7 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref, QString const & 
       // Normal resource download
       QString contentType;
 
-      sptr< Dictionary::DataRequest > req =
+      sptr< Request::Dict > req =
         articleNetMgr.getResource( url, contentType );
 
       if ( !req.get() )
@@ -1205,7 +1205,7 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref, QString const & 
 
         resourceDownloadRequests.push_back( req );
 
-        connect( req.get(), &Dictionary::Request::finished, this, &ArticleView::resourceDownloadFinished );
+        connect( req.get(), &Request::Base::finished, this, &ArticleView::resourceDownloadFinished );
       }
     }
 
@@ -1282,7 +1282,7 @@ ResourceToSaveHandler * ArticleView::saveResource( const QUrl & url, const QStri
 ResourceToSaveHandler * ArticleView::saveResource( const QUrl & url, const QUrl & ref, const QString & fileName )
 {
   ResourceToSaveHandler * handler = new ResourceToSaveHandler( this, fileName );
-  sptr< Dictionary::DataRequest > req;
+  sptr< Request::Dict > req;
 
   if( url.scheme() == "bres" || url.scheme() == "gico" || url.scheme() == "gdau" || url.scheme() == "gdvideo" )
   {
@@ -1321,7 +1321,7 @@ ResourceToSaveHandler * ArticleView::saveResource( const QUrl & url, const QUrl 
               if( preferredName.compare( QString::fromUtf8( (*activeDicts)[ x ]->getName().c_str() ) ) == 0 )
               {
                 preferred = x;
-                sptr< Dictionary::DataRequest > data_request =
+                sptr< Request::Blob > data_request =
                   ( *activeDicts )[ x ]->getResource( url.path().mid( 1 ).toUtf8().data() );
 
                 handler->addRequest( data_request );
@@ -1888,7 +1888,7 @@ void ArticleView::resourceDownloadFinished()
     return; // Stray signal
 
   // Find any finished resources
-  for( list< sptr< Dictionary::DataRequest > >::iterator i =
+  for( auto i =
        resourceDownloadRequests.begin(); i != resourceDownloadRequests.end(); )
   {
     if ( (*i)->isFinished() )
@@ -2438,12 +2438,12 @@ ResourceToSaveHandler::ResourceToSaveHandler( ArticleView * view, QString fileNa
   connect( this, &ResourceToSaveHandler::statusBarMessage, view, &ArticleView::statusBarMessage );
 }
 
-void ResourceToSaveHandler::addRequest( const sptr< Dictionary::DataRequest > & req )
+void ResourceToSaveHandler::addRequest( const sptr< Request::Dict > & req )
 {
   if ( !alreadyDone ) {
     downloadRequests.push_back( req );
 
-    connect( req.get(), &Dictionary::Request::finished, this, &ResourceToSaveHandler::downloadFinished );
+    connect( req.get(), &Request::Base::finished, this, &ResourceToSaveHandler::downloadFinished );
   }
 }
 

--- a/src/ui/articleview.hh
+++ b/src/ui/articleview.hh
@@ -61,7 +61,7 @@ class ArticleView: public QWidget
   /// Any resource we've decided to download off the dictionary gets stored here.
   /// Full vector capacity is used for search requests, where we have to make
   /// a multitude of requests.
-  std::list< sptr< Dictionary::DataRequest > > resourceDownloadRequests;
+  std::list< sptr< Request::Dict > > resourceDownloadRequests;
   /// Url of the resourceDownloadRequests
   QUrl resourceDownloadUrl;
 
@@ -435,7 +435,7 @@ class ResourceToSaveHandler: public QObject
 
 public:
   explicit ResourceToSaveHandler( ArticleView * view, QString fileName );
-  void addRequest( const sptr< Dictionary::DataRequest > & req );
+  void addRequest( const sptr< Request::Dict > & req );
   bool isEmpty()
   {
     return downloadRequests.empty();
@@ -449,7 +449,7 @@ public slots:
   void downloadFinished();
 
 private:
-  std::list< sptr< Dictionary::DataRequest > > downloadRequests;
+  std::list< sptr< Request::Dict > > downloadRequests;
   QString fileName;
   bool alreadyDone;
 };

--- a/src/webmultimediadownload.hh
+++ b/src/webmultimediadownload.hh
@@ -8,7 +8,7 @@ namespace Dictionary {
 
 /// Downloads data from the web, wrapped as a dictionary's DataRequest. This
 /// is useful for multimedia files, like sounds and pronunciations.
-class WebMultimediaDownload: public DataRequest
+class WebMultimediaDownload: public Request::Blob
 {
   Q_OBJECT
 

--- a/src/wordfinder.cc
+++ b/src/wordfinder.cc
@@ -145,11 +145,11 @@ void WordFinder::startSearch()
 
     for ( const auto & allWordWriting : allWordWritings ) {
       try {
-        sptr< Dictionary::WordSearchRequest > sr = ( searchType == PrefixMatch || searchType == ExpressionMatch ) ?
+        sptr< Request::WordSearch > sr = ( searchType == PrefixMatch || searchType == ExpressionMatch ) ?
           inputDict->prefixMatch( allWordWriting, requestedMaxResults ) :
           inputDict->stemmedMatch( allWordWriting, stemmedMinLength, stemmedMaxSuffixVariation, requestedMaxResults );
 
-        connect( sr.get(), &Dictionary::Request::finished, this, &WordFinder::requestFinished, Qt::QueuedConnection );
+        connect( sr.get(), &Request::Base::finished, this, &WordFinder::requestFinished, Qt::QueuedConnection );
 
         queuedRequests.push_back( sr );
       }

--- a/src/wordfinder.hh
+++ b/src/wordfinder.hh
@@ -29,7 +29,7 @@ private:
   SearchResults searchResults;
   QString searchErrorString;
   bool searchResultsUncertain;
-  std::list< sptr< Dictionary::WordSearchRequest > > queuedRequests, finishedRequests;
+  std::list< sptr< Request::WordSearch > > queuedRequests, finishedRequests;
   bool searchInProgress;
 
   QTimer updateResultsTimer;


### PR DESCRIPTION
This PR is not intended to be merged. Just a demo of #890 with bugs for discussion.

If we actually want this, a few smaller refactors are needed beforehand. This PR also needs a redo 

---

Every `*blobRequst` & `*articleRequest`'s constructor and other shared code can be eliminated.

If a consumer of Request doesn't care how the content is produced, get `Request::Dict`.

If an actual concrete class is needed like `dslArticleRequest`, then inherit from `Request::Article/Blob`

![image](https://github.com/xiaoyifang/goldendict-ng/assets/20123683/dc318c78-4263-4a38-8185-e8f517cdddfc)