### PR TITLE
clean: unify DataRequest string data appends

### DIFF
--- a/src/article_maker.cc
+++ b/src/article_maker.cc
@@ -334,7 +334,7 @@ sptr< Dictionary::DataRequest > ArticleMaker::makeDefinitionFor(
 
     sptr< Dictionary::DataRequestInstant > r =  std::make_shared<Dictionary::DataRequestInstant>( true );
 
-    r->appendDataSlice( result.data(), result.size() );
+    r->appendString( result );
     return r;
   }
 
@@ -390,7 +390,7 @@ sptr< Dictionary::DataRequest > ArticleMaker::makeNotFoundTextFor(
 
   sptr< Dictionary::DataRequestInstant > r = std::make_shared<Dictionary::DataRequestInstant>( true );
 
-  r->appendDataSlice( result.data(), result.size() );
+  r->appendString(result);
   return r;
 }
 
@@ -402,7 +402,7 @@ sptr< Dictionary::DataRequest > ArticleMaker::makeEmptyPage() const
   sptr< Dictionary::DataRequestInstant > r =
     std::make_shared<Dictionary::DataRequestInstant>( true );
 
-  r->appendDataSlice( result.data(), result.size() );
+  r->appendString( result );
   return r;
 }
 
@@ -416,7 +416,7 @@ sptr< Dictionary::DataRequest > ArticleMaker::makePicturePage( string const & ur
   sptr< Dictionary::DataRequestInstant > r =
       std::make_shared<Dictionary::DataRequestInstant>( true );
 
-  r->appendDataSlice( result.data(), result.size() );
+  r->appendString( result );
   return r;
 }
 
@@ -460,7 +460,7 @@ ArticleRequest::ArticleRequest( QString const & word,
 
   hasAnyData = true;
 
-  appendDataSlice( (void *) header.data(), header.size() );
+  appendString( header );
 
   //clear founded dicts.
   emit GlobalBroadcaster::instance()->dictionaryClear( ActiveDictIds{group.id, word} );
@@ -708,7 +708,7 @@ void ArticleRequest::bodyFinished()
             + Html::escape( tr( "Query error: %1" ).arg( errorString ).toUtf8().data() ) + "</div>";
         }
 
-        appendDataSlice( head.data(), head.size() );
+        appendString( head );
 
         try {
           if( req.dataSize() > 0 ) {
@@ -777,7 +777,7 @@ void ArticleRequest::bodyFinished()
         footer += "</body></html>";
       }
 
-      appendDataSlice( footer.data(), footer.size() );
+      appendString( footer );
     }
 
 
@@ -875,7 +875,7 @@ void ArticleRequest::stemmedSearchFinished()
     footer += "</body></html>";
 
   {
-    appendDataSlice( footer.data(), footer.size() );
+    appendString( footer );
   }
 
   if( continueMatching )
@@ -946,7 +946,7 @@ void ArticleRequest::compoundSearchNextStep( bool lastSearchSucceeded )
 
       footer += "</body></html>";
 
-      appendToData( footer );
+      appendString( footer );
 
       finish();
 
@@ -955,7 +955,7 @@ void ArticleRequest::compoundSearchNextStep( bool lastSearchSucceeded )
 
     if ( footer.size() )
     {
-      appendToData( footer );
+      appendString( footer );
       update();
     }
 
@@ -1064,11 +1064,6 @@ void ArticleRequest::individualWordFinished()
   }
 
   compoundSearchNextStep( false );
-}
-
-void ArticleRequest::appendToData( std::string const & str )
-{
-  appendDataSlice( str.data(), str.size() );
 }
 
 QPair< ArticleRequest::Words, ArticleRequest::Spacings > ArticleRequest::splitIntoWords( QString const & input )

--- a/src/article_maker.hh
+++ b/src/article_maker.hh
@@ -135,8 +135,6 @@ private slots:
 
 private:
   int htmlTextSize( QString html );
-  /// Appends the given string to 'data', with locking its mutex.
-  void appendToData( std::string const & );
 
   /// Uses stemmedWordFinder to perform the next step of looking up word
   /// combinations.

--- a/src/dict/aard.cc
+++ b/src/dict/aard.cc
@@ -767,11 +767,7 @@ void AardArticleRequest::run()
       result += i->second.second;
   }
 
-  QMutexLocker _( &dataMutex );
-
-  data.resize( result.size() );
-
-  memcpy( &data.front(), result.data(), result.size() );
+  appendString(result);
 
   hasAnyData = true;
 

--- a/src/dict/bgl.cc
+++ b/src/dict/bgl.cc
@@ -837,11 +837,7 @@ void BglArticleRequest::run()
            .toUtf8().data();
 
 
-  QMutexLocker _( &dataMutex );
-
-  data.resize( result.size() );
-
-  memcpy( &data.front(), result.data(), result.size() );
+  appendString(result);
 
   hasAnyData = true;
 

--- a/src/dict/dictionary.cc
+++ b/src/dict/dictionary.cc
@@ -118,6 +118,13 @@ void DataRequest::appendDataSlice( const void * buffer, size_t size ) {
   memcpy( &data.front() + offset, buffer, size );
 }
 
+void DataRequest::appendString( std::string_view str )
+{
+  QMutexLocker _( &dataMutex );
+  data.reserve( data.size() + str.size() );
+  data.insert( data.end(), str.begin(), str.end() );
+}
+
 void DataRequest::getDataSlice( size_t offset, size_t size, void * buffer )
 {
   if ( size == 0 )

--- a/src/dict/dictionary.hh
+++ b/src/dict/dictionary.hh
@@ -193,10 +193,12 @@ public:
   /// the resource wasn't found.
   long dataSize();
 
+  void appendDataSlice( const void * buffer, size_t size );
+  void appendString( std::string_view str );
+
   /// Writes "size" bytes starting from "offset" of the data read to the given
   /// buffer. "size + offset" must be <= than dataSize().
   void getDataSlice( size_t offset, size_t size, void * buffer );
-  void appendDataSlice( const void * buffer, size_t size );
 
   /// Returns all the data read. Since no further locking can or would be
   /// done, this can only be called after the request has finished.

--- a/src/dict/dictserver.cc
+++ b/src/dict/dictserver.cc
@@ -834,10 +834,7 @@ void DictServerArticleRequest::run()
     }
     if( !Utils::AtomicInt::loadAcquire( isCancelled ) && errorString.isEmpty() && !articleData.empty() )
     {
-      QMutexLocker _( &dataMutex );
-
-      data.resize( articleData.size() );
-      memcpy( &data.front(), articleData.data(), articleData.size() );
+      appendString(articleData);
 
       hasAnyData = true;
     }

--- a/src/dict/dsl.cc
+++ b/src/dict/dsl.cc
@@ -1651,12 +1651,7 @@ void DslArticleRequest::run()
                     + "</span>";
     }
 
-    QMutexLocker _( &dataMutex );
-
-    data.resize( data.size() + articleText.size() );
-
-    memcpy( &data.front() + data.size() - articleText.size(),
-            articleText.data(), articleText.size() );
+    appendString(articleText);
 
     hasAnyData = true;
   }

--- a/src/dict/epwing.cc
+++ b/src/dict/epwing.cc
@@ -789,11 +789,7 @@ void EpwingArticleRequest::run()
 
   result += "</div>";
 
-  QMutexLocker _( &dataMutex );
-
-  data.resize( result.size() );
-
-  memcpy( &data.front(), result.data(), result.size() );
+  appendString(result);
 
   hasAnyData = true;
 

--- a/src/dict/forvo.cc
+++ b/src/dict/forvo.cc
@@ -282,13 +282,7 @@ void ForvoArticleRequest::requestFinished( QNetworkReply * r )
 
             articleBody += "</table>";
 
-            QMutexLocker _( &dataMutex );
-
-            size_t prevSize = data.size();
-            
-            data.resize( prevSize + articleBody.size() );
-  
-            memcpy( &data.front() + prevSize, articleBody.data(), articleBody.size() );
+            appendString(articleBody);
   
             hasAnyData = true;
 

--- a/src/dict/gls.cc
+++ b/src/dict/gls.cc
@@ -1070,11 +1070,7 @@ void GlsArticleRequest::run()
         result += i->second.second;
     }
 
-    QMutexLocker _( &dataMutex );
-
-    data.resize( result.size() );
-
-    memcpy( &data.front(), result.data(), result.size() );
+    appendString(result);
 
     hasAnyData = true;
   }

--- a/src/dict/hunspell.cc
+++ b/src/dict/hunspell.cc
@@ -283,11 +283,7 @@ void HunspellArticleRequest::run()
 
       result += "</div>";
 
-      QMutexLocker _( &dataMutex );
-
-      data.resize( result.size() );
-
-      memcpy( &data.front(), result.data(), result.size() );
+      appendString(result);
 
       hasAnyData = true;
     }

--- a/src/dict/lingualibre.cc
+++ b/src/dict/lingualibre.cc
@@ -485,12 +485,8 @@ void LinguaArticleRequest::requestFinished( QNetworkReply * r )
 
     articleBody += "</p>";
 
-    QMutexLocker _( &dataMutex );
+    appendString( articleBody );
 
-    size_t prevSize = data.size();
-    data.resize( prevSize + articleBody.size() );
-
-    memcpy( &data.front() + prevSize, articleBody.data(), articleBody.size() );
 
     hasAnyData = true;
 

--- a/src/dict/mediawiki.cc
+++ b/src/dict/mediawiki.cc
@@ -648,20 +648,12 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
             // Insert the ToC in the end to improve performance because no replacements are needed in the generated ToC.
             MediaWikiSectionsParser::generateTableOfContentsIfEmpty( parseNode, articleString );
 
-            QByteArray articleBody = articleString.toUtf8();
-
-            articleBody.prepend( dictPtr->isToLanguageRTL() ? R"(<div class="mwiki" dir="rtl">)" :
+            articleString.prepend( dictPtr->isToLanguageRTL() ? R"(<div class="mwiki" dir="rtl">)" :
                                                               "<div class=\"mwiki\">" );
-            articleBody.append( "</div>" );
+            articleString.append( "</div>" );
 
-            QMutexLocker _( &dataMutex );
+            appendString( articleString.toStdString() );
 
-            size_t prevSize = data.size();
-            
-            data.resize( prevSize + articleBody.size() );
-  
-            memcpy( &data.front() + prevSize, articleBody.data(), articleBody.size() );
-  
             hasAnyData = true;
 
             updated = true;

--- a/src/dict/sdict.cc
+++ b/src/dict/sdict.cc
@@ -615,11 +615,7 @@ void SdictArticleRequest::run()
         result += "</span>";
   }
 
-  QMutexLocker _( &dataMutex );
-
-  data.resize( result.size() );
-
-  memcpy( &data.front(), result.data(), result.size() );
+  appendString(result);
 
   hasAnyData = true;
 

--- a/src/dict/slob.cc
+++ b/src/dict/slob.cc
@@ -1328,11 +1328,7 @@ void SlobArticleRequest::run()
       result += i->second.second;
   }
 
-  QMutexLocker _( &dataMutex );
-
-  data.resize( result.size() );
-
-  memcpy( &data.front(), result.data(), result.size() );
+  appendString(result);
 
   hasAnyData = true;
 

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -1454,11 +1454,7 @@ void StardictArticleRequest::run()
           result += "</div>";
     }
 
-    QMutexLocker _( &dataMutex );
-
-    data.resize( result.size() );
-
-    memcpy( &data.front(), result.data(), result.size() );
+    appendString(result);
 
     hasAnyData = true;
   }

--- a/src/dict/website.cc
+++ b/src/dict/website.cc
@@ -277,23 +277,16 @@ void WebSiteArticleRequest::requestFinished( QNetworkReply * r )
     // See Issue #271: A mechanism to clean-up invalid HTML cards.
     articleString += QString::fromStdString(Utils::Html::getHtmlCleaner());
 
-    QByteArray articleBody = articleString.toUtf8();
 
     QString divStr = QString( "<div class=\"website\"" );
     divStr += dictPtr->isToLanguageRTL() ? " dir=\"rtl\">" : ">";
 
-    articleBody.prepend( divStr.toUtf8() );
-    articleBody.append( "</div>" );
+    articleString.prepend( divStr.toUtf8() );
+    articleString.append( "</div>" );
 
-    articleBody.prepend( "<div class=\"website_padding\"></div>" );
+    articleString.prepend( "<div class=\"website_padding\"></div>" );
 
-    QMutexLocker _( &dataMutex );
-
-    size_t prevSize = data.size();
-
-    data.resize( prevSize + articleBody.size() );
-
-    memcpy( &data.front() + prevSize, articleBody.data(), articleBody.size() );
+    appendString( articleString.toStdString() );
 
     hasAnyData = true;
 
@@ -490,15 +483,7 @@ void WebSiteResourceRequest::requestFinished( QNetworkReply * r )
 
     dictPtr->isolateWebCSS( cssString );
 
-    QByteArray cssData = cssString.toUtf8();
-
-    QMutexLocker _( &dataMutex );
-
-    size_t prevSize = data.size();
-
-    data.resize( prevSize + cssData.size() );
-
-    memcpy( &data.front() + prevSize, cssData.data(), cssData.size() );
+    appendString(cssString.toStdString());
 
     hasAnyData = true;
   }

--- a/src/dict/xdxf.cc
+++ b/src/dict/xdxf.cc
@@ -581,11 +581,7 @@ void XdxfArticleRequest::run()
       result += cleaner;
   }
 
-  QMutexLocker _( &dataMutex );
-
-  data.resize( result.size() );
-
-  memcpy( &data.front(), result.data(), result.size() );
+  appendString(result);
 
   hasAnyData = true;
 

--- a/src/dict/zim.cc
+++ b/src/dict/zim.cc
@@ -713,11 +713,7 @@ void ZimArticleRequest::run()
       result += cleaner + "</div>";
   }
 
-  QMutexLocker _( &dataMutex );
-
-  data.resize( result.size() );
-
-  memcpy( &data.front(), result.data(), result.size() );
+  appendString(result);
 
   hasAnyData = true;
 


### PR DESCRIPTION
`website.cc` & `mediawiki.cc` is a little bit special: string was converted to QByteArray first which should be unnecessary.

The true purpose is to avoid direct `data` accessing https://github.com/xiaoyifang/goldendict-ng/issues/890 