### PR TITLE
feat: XDXF: distinguish `ex_orig` and `ex_tran`

### DIFF
--- a/src/stylesheets/article-style.css
+++ b/src/stylesheets/article-style.css
@@ -306,6 +306,10 @@ div.xdxf
     content:"]"
 }
 
+.xdxf_ex_orig{
+  color: #8761d9;
+}
+
 .xdxf_ex_tran:before
 {
     content:"— "
@@ -357,8 +361,11 @@ div.xdxf
 /* The words in examples that are meaked out; they are marked out only when placed into <ex> tag */
 .xdxf_ex .xdxf_ex_markd, .xdxf_ex_old .xdxf_ex_markd
 {
-  color:black;
   background-color:lightgray;
+  margin-left: 0.2em;
+  margin-right: 0.2em;
+  padding-left: 0.1em;
+  padding-right: 0.1em;
 }
 
 .xdxf_opt


### PR DESCRIPTION
Borrowed from another software, ex_orig should uses a different color

test dict https://gitlab.com/ci-dict/dyu-xdxf/-/blob/main/mandenkan/dict.xdxf by @boydkelly

|Before (left is another software)|After|
|--|--|
|![Screenshot_20230623_135940](https://github.com/xiaoyifang/goldendict-ng/assets/20123683/e65b9bbe-cdd7-435a-ab28-73a21ab7323b)|![image](https://github.com/xiaoyifang/goldendict-ng/assets/20123683/9a1e2437-c00d-4551-b85f-0160ad0e053f)|

test dict https://github.com/soshial/xdxf_makedict/blob/master/dict_samples/rev34.xml 

|Before|After|
|--|--|
|![image](https://github.com/xiaoyifang/goldendict-ng/assets/20123683/7a09c116-2909-489b-98e8-aec59da67bcf)|![Screenshot_20230623_143110](https://github.com/xiaoyifang/goldendict-ng/assets/20123683/c6f56fc7-1d56-4bbb-b3bd-7cb55e948356)|

Also, fix a bug that `ex_marked` has no space before and after. See the marked "home"