### PR TITLE
fix: cmake: add LINKER:-as-needed flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,11 @@ if (NOT USE_SYSTEM_FMT)
     target_sources(${GOLDENDICT} PRIVATE thirdparty/fmt/format.cc)
 endif ()
 
+if (LINUX)
+    # related: rpmlint warning unused-direct-shlib-dependency
+    target_link_options(${GOLDENDICT} PRIVATE "LINKER:-as-needed")
+endif ()
+
 ### Common parts amount all platforms
 
 # Note: used as c++ string thus need surrounding " "


### PR DESCRIPTION
https://github.com/xiaoyifang/goldendict-ng/issues/729#issuecomment-1609192553

Right now, the following are not directly needed:
```
> ldd --unused ./goldendict
Unused direct dependencies:gen/
        /usr/lib/libQt6Concurrent.so.6
        /usr/lib/libfmt.so.9
        /usr/lib/libQt6Quick.so.6
        /usr/lib/libQt6QmlModels.so.6
        /usr/lib/libQt6OpenGL.so.6
        /usr/lib/libQt6Qml.so.6
        /usr/lib/libQt6Positioning.so.6
        /usr/lib/libGLX.so.0
        /usr/lib/libOpenGL.so.0
        /usr/lib/libvorbis.so.0
        /usr/lib/libicui18n.so.72
        /usr/lib/libicuuc.so.72
        /usr/lib/libicudata.so.72
```