### PR TITLE
doc: update fts related strings 

### DIFF
--- a/src/fulltextsearch.cc
+++ b/src/fulltextsearch.cc
@@ -227,7 +227,7 @@ FullTextSearchDialog::FullTextSearchDialog( QWidget * parent,
            this,
            &FullTextSearchDialog::setNewIndexingName );
 
-  ui.searchMode->addItem( tr( "Whole words" ), WholeWords );
+  ui.searchMode->addItem( tr( "Default" ), WholeWords );
   ui.searchMode->addItem( tr( "Plain text"), PlainText );
   ui.searchMode->addItem( tr( "Wildcards" ), Wildcards );
 

--- a/src/fulltextsearch.hh
+++ b/src/fulltextsearch.hh
@@ -40,7 +40,7 @@ enum {
 
 enum SearchMode
 {
-  WholeWords = 0,
+  WholeWords = 0, // aka Default search using Xapian query syntax
   PlainText,
   Wildcards,
   RegExp

--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -1299,10 +1299,10 @@ download page.</string>
           <item row="7" column="0">
            <widget class="QCheckBox" name="enablePosition">
             <property name="toolTip">
-             <string>Applies only to new incoming dictionaries.</string>
+             <string>Positional information is required to use Xapian's phrase searching and NEAR operator, but the database size will be much bigger. Applies only to new incoming dictionaries.</string>
             </property>
             <property name="text">
-             <string>Enable positional information in the fulltext</string>
+             <string>Enable index with positional information</string>
             </property>
            </widget>
           </item>

--- a/website/docs/ui_fulltextsearch.md
+++ b/website/docs/ui_fulltextsearch.md
@@ -2,21 +2,19 @@ The full-text search dialog can be opened via menu "Search" or "Ctrl+Shift+F".
 
 Full-text search allow to search words or sentences not in dictionary headwords but in articles text of dictionaries from current dictionaries group.
 
-!!! note
-    The dictionary will index for full-text search in background and started immediately after program start, name of the currently indexing dictionary is displayed in the status line. This process can take a long time and require many computing resources.You may turn off indexing for huge dictionaries like Wikipedias or Wiktionaries in preferences. To find dictionary which can't be indexed check GoldenDict with `--log-to-file` or check `stdout`.
-
-
 ![full text serach](img/fulltext.png){ width="450" }
 
 Type the desired word in "Search line" to search.
 
 Search modes
 
-* "Whole words" - This follow the xapian search syntax . check   [query syntax](https://xapian.org/docs/queryparser.html).
+* "Default" — This follows the [xapian search syntax](https://xapian.org/docs/queryparser.html). Note that phrase searching and NEAR operator needs `Enable index with positional information` enabled at settings.
 * "Plain text" - mode like "Whole words" but every word in search line can be treated as word fragment.
-* "Wildcards" - the search line contains a Unix-like template. Such template can contain wildcard symbols `?` (matches any one character), `*` (matches any characters number) or ranges of characters `[...]` To find characters `?`, `*`, `[` and `]` it should be escaped by backslash like `\?`, `\*`, `\[`, `\]`.
+* "Wildcards" - the search line contains a Unix-like template. Such template can contain wildcard symbols `?` (matches any one character), `*` (matches any character number) or ranges of characters `[...]` To find characters `?`, `*`, `[` and `]` it should be escaped by backslash like `\?`, `\*`, `\[`, `\]`.
 
+"Available dictionaries in group" - here you can view how many dictionaries in the current group are suitable for full-text search, how many dictionaries already indexed and how many dictionaries wait for indexing.
 
-"Available dictionaries in group" - here you can view how many dictionaries in current group are suitable for full-text search, how many dictionaries already indexed and how many dictionaries wait for indexing.
+When you place mouse cursor over headword in results list, the tooltip with dictionary list contains such articles matched the search conditions will be shown.
 
-When you place mouse cursor over headword in results list the tooltip with dictionaries list contains such articles matched the search conditions will be shown.
+!!! note
+    The dictionary will index for full-text search in background and started immediately after program start, name of the currently indexing dictionary is displayed in the status line. This process can take a long time and require many computing resources.You may turn off indexing for huge dictionaries like Wikipedias or Wiktionaries in preferences. To find dictionary which can't be indexed check GoldenDict with `--log-to-file` or check `stdout`.


### PR DESCRIPTION
* rename "Whole word" to "Default"
* add a tooltip explaining what it is "positional info"
  * add a note in doc mentioning it is needed for operator NEAR 