### PR TITLE
docs: simplify unnecessary tech info in the release page

### DIFF
--- a/.github/workflows/macos-homebrew-breakpad.yml
+++ b/.github/workflows/macos-homebrew-breakpad.yml
@@ -214,34 +214,33 @@ jobs:
           release_name: GoldenDict-ng-v${{env.version}}-${{env.version-suffix}}.${{ steps.vars.outputs.release_hm }}.${{ steps.vars.outputs.sha_short }}
           prerelease: ${{env.prerelease}}
           body: |
-            release on date:      ${{steps.vars.outputs.release_date}} time: ${{steps.vars.outputs.release_time_clock}}  
-            branch:               ${{ github.ref_name }}
-            commit:               ${{ steps.vars.outputs.sha_short }} 
-            Qt version:           Qt5.15.2, Qt6.X  
-            Windows built with:   msvc64,  Visual studio 2019
-            ## goldendict.exe can not be used alone 
-            if you have a previous version. replace this maybe ok. if not ,download the whole bundle.
+            #### Install instructions for Windows, macOS and Linux 
 
-            AppImage built with:  Ubuntu-20.04 ,latest gcc
-            macos built with:     macos-10.15,macos-11.0,clang_64 x86_64
-                                  Qt6.X(homebrew build)
-                                  Qt5.15.2(Intel Kind)
-            auto built by github action. use on your on risk:-)
-            **recommend version**:Qt6.X   (with the latest bug fixes and performance enhancements)   
+            <https://xiaoyifang.github.io/goldendict-ng/install/>.
 
-            Filename pattern: **[Qt version]-GoldenDict-[OS]-[release-date].[ext]**
-            [xapian](https://xapian.org/)  is enabled by default which offers 10X~20X performance 
-            ------------------------------
-            文件名的模式: **[Qt version]-GoldenDict-[OS]-[release-date].[ext]** 
-            [xapian](https://xapian.org/) 用于全文索引的创建，提供更快的全文索引创建、搜索支持
-            比如：
-            6.4.3-GoldenDict.exe_windows-2022_20230502.zip
-            表示基于qt6.4.3，windows-2022,  于20230502日创建的版本。
+            #### Filename pattern (文件名模式): **[Qt version]-GoldenDict-ng-[OS]-[release-date].[ext]**  
 
+            Qt6.X is recommended for various enhancements.
 
-            CHANGES:
+            Windows users can use either `****-installer.exe` (for installer) or `****.zip` (unzip and run).
+            The `goldendict.exe` can be dropped into previous installation's folder (if dependencies aren't changed).
+
+            Linux users can use AppImages.
+
+            macOs users can use `.dmg` installer.
+
+            `6.5.1-GoldenDict.exe_windows-2019_20230701.zip` means built with Qt6.5.1, windows/msvc-2019 at 20230701 as a zip archive.
+
+            #### Build Details
+
+            AppImage: Ubuntu-20.04
+            macOS: macOS-12 and macOS-13
+            Windows: Visual studio 2019
+
+            #### Commits
+
             ${{ steps.changelog.outputs.changelog }}  
 
-            ----------------
-
+            #### Changes
+            
             ${{steps.build_changelog.outputs.changelog}}

--- a/.github/workflows/macos-homebrew.yml
+++ b/.github/workflows/macos-homebrew.yml
@@ -213,34 +213,33 @@ jobs:
           release_name: GoldenDict-ng-v${{env.version}}-${{env.version-suffix}}.${{ steps.vars.outputs.release_hm }}.${{ steps.vars.outputs.sha_short }}
           prerelease: ${{env.prerelease}}
           body: |
-            release on date:      ${{steps.vars.outputs.release_date}} time: ${{steps.vars.outputs.release_time_clock}}  
-            branch:               ${{ github.ref_name }}
-            commit:               ${{ steps.vars.outputs.sha_short }} 
-            Qt version:           Qt5.15.2, Qt6.X  
-            Windows built with:   msvc64,  Visual studio 2019
-            ## goldendict.exe can not be used alone 
-            if you have a previous version. replace this maybe ok. if not ,download the whole bundle.
+            #### Install instructions for Windows, macOS and Linux 
 
-            AppImage built with:  Ubuntu-20.04 ,latest gcc
-            macos built with:     macos-10.15,macos-11.0,clang_64 x86_64
-                                  Qt6.X(homebrew build)
-                                  Qt5.15.2(Intel Kind)
-            auto built by github action. use on your on risk:-)
-            **recommend version**:Qt6.X   (with the latest bug fixes and performance enhancements)   
+            <https://xiaoyifang.github.io/goldendict-ng/install/>.
 
-            Filename pattern: **[Qt version]-GoldenDict-[OS]-[release-date].[ext]**
-            [xapian](https://xapian.org/)  is enabled by default which offers 10X~20X performance 
-            ------------------------------
-            文件名的模式: **[Qt version]-GoldenDict-[OS]-[release-date].[ext]** 
-            [xapian](https://xapian.org/) 用于全文索引的创建，提供更快的全文索引创建、搜索支持
-            比如：
-            6.4.3-GoldenDict.exe_windows-2022_20230502.zip
-            表示基于qt6.4.3，windows-2022,  于20230502日创建的版本。
+            #### Filename pattern (文件名模式): **[Qt version]-GoldenDict-ng-[OS]-[release-date].[ext]**  
 
+            Qt6.X is recommended for various enhancements.
 
-            CHANGES:
+            Windows users can use either `****-installer.exe` (for installer) or `****.zip` (unzip and run).
+            The `goldendict.exe` can be dropped into previous installation's folder (if dependencies aren't changed).
+
+            Linux users can use AppImages.
+
+            macOs users can use `.dmg` installer.
+
+            `6.5.1-GoldenDict.exe_windows-2019_20230701.zip` means built with Qt6.5.1, windows/msvc-2019 at 20230701 as a zip archive.
+
+            #### Build Details
+
+            AppImage: Ubuntu-20.04
+            macOS: macOS-12 and macOS-13
+            Windows: Visual studio 2019
+
+            #### Commits
+
             ${{ steps.changelog.outputs.changelog }}  
 
-            ----------------
-
+            #### Changes
+            
             ${{steps.build_changelog.outputs.changelog}}

--- a/.github/workflows/ubuntu-6.2.yml
+++ b/.github/workflows/ubuntu-6.2.yml
@@ -190,34 +190,33 @@ jobs:
           release_name: GoldenDict-ng-v${{env.version}}-${{env.version-suffix}}.${{ steps.vars.outputs.release_hm }}.${{ steps.vars.outputs.sha_short }}
           prerelease: ${{env.prerelease}}
           body: |
-            release on date:      ${{steps.vars.outputs.release_date}} time: ${{steps.vars.outputs.release_time_clock}}  
-            branch:               ${{ github.ref_name }}
-            commit:               ${{ steps.vars.outputs.sha_short }} 
-            Qt version:           Qt5.15.2, Qt6.X  
-            Windows built with:   msvc64,  Visual studio 2019
-            ## goldendict.exe can not be used alone 
-            if you have a previous version. replace this maybe ok. if not ,download the whole bundle.
-            
-            AppImage built with:  Ubuntu-20.04 ,latest gcc
-            macos built with:     macos-10.15,macos-11.0,clang_64 x86_64
-                                  Qt6.X(homebrew build)
-                                  Qt5.15.2(Intel Kind)
-            auto built by github action. use on your on risk:-)
-            **recommend version**:Qt6.X   (with the latest bug fixes and performance enhancements)  
+            #### Install instructions for Windows, macOS and Linux 
 
-            Filename pattern: **[Qt version]-GoldenDict-[OS]-[release-date].[ext]**
-            [xapian](https://xapian.org/)  is enabled by default which offers 10X~20X performance 
-            ------------------------------
-            文件名的模式: **[Qt version]-GoldenDict-[OS]-[release-date].[ext]** 
-            [xapian](https://xapian.org/) 用于全文索引的创建，提供更快的全文索引创建、搜索支持
-            比如：
-            6.4.3-GoldenDict.exe_windows-2022_20230502.zip
-            表示基于qt6.4.3，windows-2022,  于20230502日创建的版本。
+            <https://xiaoyifang.github.io/goldendict-ng/install/>.
 
+            #### Filename pattern (文件名模式): **[Qt version]-GoldenDict-ng-[OS]-[release-date].[ext]**  
 
-            CHANGES:
+            Qt6.X is recommended for various enhancements.
+
+            Windows users can use either `****-installer.exe` (for installer) or `****.zip` (unzip and run).
+            The `goldendict.exe` can be dropped into previous installation's folder (if dependencies aren't changed).
+
+            Linux users can use AppImages.
+
+            macOs users can use `.dmg` installer.
+
+            `6.5.1-GoldenDict.exe_windows-2019_20230701.zip` means built with Qt6.5.1, windows/msvc-2019 at 20230701 as a zip archive.
+
+            #### Build Details
+
+            AppImage: Ubuntu-20.04
+            macOS: macOS-12 and macOS-13
+            Windows: Visual studio 2019
+
+            #### Commits
+
             ${{ steps.changelog.outputs.changelog }}  
 
-            ----------------
-
+            #### Changes
+            
             ${{steps.build_changelog.outputs.changelog}}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -172,34 +172,33 @@ jobs:
           release_name: GoldenDict-ng-v${{env.version}}-${{env.version-suffix}}.${{ steps.vars.outputs.release_hm }}.${{ steps.vars.outputs.sha_short }}
           prerelease: ${{env.prerelease}}
           body: |
-            release on date:      ${{steps.vars.outputs.release_date}} time: ${{steps.vars.outputs.release_time_clock}}  
-            branch:               ${{ github.ref_name }}
-            commit:               ${{ steps.vars.outputs.sha_short }} 
-            Qt version:           Qt5.15.2, Qt6.X  
-            Windows built with:   msvc64,  Visual studio 2019
-            ## goldendict.exe can not be used alone 
-            if you have a previous version. replace this maybe ok. if not ,download the whole bundle.
-            
-            AppImage built with:  Ubuntu-20.04 ,latest gcc
-            macos built with:     macos-10.15,macos-11.0,clang_64 x86_64
-                                  Qt6.X(homebrew build)
-                                  Qt5.15.2(Intel Kind)
-            auto built by github action. use on your on risk:-)
-            **recommend version**:Qt6.X   (with the latest bug fixes and performance enhancements)  
+            #### Install instructions for Windows, macOS and Linux 
 
-            Filename pattern: **[Qt version]-GoldenDict-[OS]-[release-date].[ext]**
-            [xapian](https://xapian.org/)  is enabled by default which offers 10X~20X performance 
-            ------------------------------
-            文件名的模式: **[Qt version]-GoldenDict-[OS]-[release-date].[ext]** 
-            [xapian](https://xapian.org/) 用于全文索引的创建，提供更快的全文索引创建、搜索支持
-            比如：
-            6.4.3-GoldenDict.exe_windows-2022_20230502.zip
-            表示基于qt6.4.3，windows-2022,  于20230502日创建的版本。
+            <https://xiaoyifang.github.io/goldendict-ng/install/>.
 
+            #### Filename pattern (文件名模式): **[Qt version]-GoldenDict-ng-[OS]-[release-date].[ext]**  
 
-            CHANGES:
+            Qt6.X is recommended for various enhancements.
+
+            Windows users can use either `****-installer.exe` (for installer) or `****.zip` (unzip and run).
+            The `goldendict.exe` can be dropped into previous installation's folder (if dependencies aren't changed).
+
+            Linux users can use AppImages.
+
+            macOs users can use `.dmg` installer.
+
+            `6.5.1-GoldenDict.exe_windows-2019_20230701.zip` means built with Qt6.5.1, windows/msvc-2019 at 20230701 as a zip archive.
+
+            #### Build Details
+
+            AppImage: Ubuntu-20.04
+            macOS: macOS-12 and macOS-13
+            Windows: Visual studio 2019
+
+            #### Commits
+
             ${{ steps.changelog.outputs.changelog }}  
 
-            ----------------
-
+            #### Changes
+            
             ${{steps.build_changelog.outputs.changelog}}

--- a/.github/workflows/windows-6.x.yml
+++ b/.github/workflows/windows-6.x.yml
@@ -244,31 +244,33 @@ jobs:
           release_name: GoldenDict-ng-v${{env.version}}-${{env.version-suffix}}.${{ steps.vars.outputs.release_hm }}.${{ steps.vars.outputs.sha_short }}
           prerelease: ${{env.prerelease}}
           body: |
-            release on date:      ${{steps.vars.outputs.release_date}} time: ${{steps.vars.outputs.release_time_clock}}  
-            branch:               ${{ github.ref_name }}
-            commit:               ${{ steps.vars.outputs.sha_short }} 
-            Qt version:           Qt5.15.2, Qt6.X  
-            Windows built with:   msvc64,  Visual studio 2019
-            AppImage built with:  Ubuntu-20.04 ,latest gcc
-            macos built with:     macos-10.15,macos-11.0,clang_64 x86_64
-                                  Qt6.X(homebrew build)
-                                  Qt5.15.2(Intel Kind)
-            auto built by github action. use on your on risk:-)
-            **recommend version**:Qt6.X   (with the latest bug fixes and performance enhancements)
+            #### Install instructions for Windows, macOS and Linux 
 
-            Filename pattern: **[Qt version]-GoldenDict-[OS]-[release-date].[ext]**
-            [xapian](https://xapian.org/)  is enabled by default which offers 10X~20X performance 
-            ------------------------------
-            文件名的模式: **[Qt version]-GoldenDict-[OS]-[release-date].[ext]** 
-            [xapian](https://xapian.org/) 用于全文索引的创建，提供更快的全文索引创建、搜索支持
-            比如：
-            6.4.3-GoldenDict.exe_windows-2022_20230502.zip
-            表示基于qt6.4.3，windows-2022,  于20230502日创建的版本。
+            <https://xiaoyifang.github.io/goldendict-ng/install/>.
 
+            #### Filename pattern (文件名模式): **[Qt version]-GoldenDict-ng-[OS]-[release-date].[ext]**  
 
-            CHANGES:
+            Qt6.X is recommended for various enhancements.
+
+            Windows users can use either `****-installer.exe` (for installer) or `****.zip` (unzip and run).
+            The `goldendict.exe` can be dropped into previous installation's folder (if dependencies aren't changed).
+
+            Linux users can use AppImages.
+
+            macOs users can use `.dmg` installer.
+
+            `6.5.1-GoldenDict.exe_windows-2019_20230701.zip` means built with Qt6.5.1, windows/msvc-2019 at 20230701 as a zip archive.
+
+            #### Build Details
+
+            AppImage: Ubuntu-20.04
+            macOS: macOS-12 and macOS-13
+            Windows: Visual studio 2019
+
+            #### Commits
+
             ${{ steps.changelog.outputs.changelog }}  
 
-            ----------------
-
+            #### Changes
+            
             ${{steps.build_changelog.outputs.changelog}}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -216,33 +216,33 @@ jobs:
           release_name: GoldenDict-ng-v${{env.version}}-${{env.version-suffix}}.${{ steps.vars.outputs.release_hm }}.${{ steps.vars.outputs.sha_short }}
           prerelease: ${{env.prerelease}}
           body: |
-            release on date:      ${{steps.vars.outputs.release_date}} time: ${{steps.vars.outputs.release_time_clock}}  
-            branch:               ${{ github.ref_name }}
-            commit:               ${{ steps.vars.outputs.sha_short }} 
-            Qt version:           Qt5.15.2, Qt6.X  
-            Windows built with:   msvc64,  Visual studio 2019
-            ## goldendict.exe can not be used alone 
-            if you have a previous version. replace this maybe ok. if not ,download the whole bundle.
-            AppImage built with:  Ubuntu-20.04 ,latest gcc
-            macos built with:     macos-10.15,macos-11.0,clang_64 x86_64
-                                  Qt6.X(homebrew build)
-                                  Qt5.15.2(Intel Kind)
-            auto built by github action. use on your on risk:-)
-            **recommend version**:Qt6.X   (with the latest bug fixes and performance enhancements)
+            #### Install instructions for Windows, macOS and Linux 
 
-            Filename pattern: **[Qt version]-GoldenDict-[OS]-[release-date].[ext]**
-            [xapian](https://xapian.org/)  is enabled by default which offers 10X~20X performance 
-            ------------------------------
-            文件名的模式: **[Qt version]-GoldenDict-[OS]-[release-date].[ext]** 
-            [xapian](https://xapian.org/) 用于全文索引的创建，提供更快的全文索引创建、搜索支持
-            比如：
-            6.4.3-GoldenDict.exe_windows-2022_20230502.zip
-            表示基于qt6.4.3，windows-2022,  于20230502日创建的版本。
+            <https://xiaoyifang.github.io/goldendict-ng/install/>.
 
+            #### Filename pattern (文件名模式): **[Qt version]-GoldenDict-ng-[OS]-[release-date].[ext]**  
 
-            CHANGES:
+            Qt6.X is recommended for various enhancements.
+
+            Windows users can use either `****-installer.exe` (for installer) or `****.zip` (unzip and run).
+            The `goldendict.exe` can be dropped into previous installation's folder (if dependencies aren't changed).
+
+            Linux users can use AppImages.
+
+            macOs users can use `.dmg` installer.
+
+            `6.5.1-GoldenDict.exe_windows-2019_20230701.zip` means built with Qt6.5.1, windows/msvc-2019 at 20230701 as a zip archive.
+
+            #### Build Details
+
+            AppImage: Ubuntu-20.04
+            macOS: macOS-12 and macOS-13
+            Windows: Visual studio 2019
+
+            #### Commits
+
             ${{ steps.changelog.outputs.changelog }}  
 
-            ----------------
-
+            #### Changes
+            
             ${{steps.build_changelog.outputs.changelog}}


### PR DESCRIPTION
Result: https://github.com/shenlebantongying/goldendict-ng/releases/tag/tag-alpha.6fce7b3c

The download page is too technical, and I have seen people asking which to download multiple times.

The pages contain too many terms that are overwhelming for non-geeks. I don't think any non-geeks care about or have any ideas about those technical details.

I think something like this is better https://github.com/wez/wezterm/releases/tag/20230408-112425-69ae8472

![image](https://github.com/xiaoyifang/goldendict-ng/assets/20123683/d8497458-226e-437e-a03e-3234e8c795ab)

![image](https://github.com/xiaoyifang/goldendict-ng/assets/20123683/6802c1e6-5738-4ff0-a4ea-d36dbadfb6c3)



The release date/hashtag/ other details are duplicated with the sidebar.

![image](https://github.com/xiaoyifang/goldendict-ng/assets/20123683/56d7c884-853c-41ce-8a6e-0a758a0c04de)

