### PR TITLE
fix: treat unknown dsl tags as text

### DIFF
--- a/src/dict/dsl_details.cc
+++ b/src/dict/dsl_details.cc
@@ -656,17 +656,11 @@ void ArticleDom::closeTag( wstring const & name,
   if ( n != stack.rend() )
   {
     // If there is a corresponding tag, close all tags above it,
-    // then close the tag itself, then reopen all the tags which got
-    // closed.
-
-    list< Node > nodesToReopen;
+    // then close the tag itself
 
     while ( !stack.empty() ) {
       bool found = stack.back()->tagName == name ||
                    checkM( stack.back()->tagName, name );
-
-      if ( !found )
-        nodesToReopen.emplace_back( Node::Tag(), stack.back()->tagName, stack.back()->tagAttrs );
 
       if( stack.back()->empty() && stack.back()->tagName !=  U"br"  )
       {
@@ -683,21 +677,6 @@ void ArticleDom::closeTag( wstring const & name,
 
       if ( found )
         break;
-    }
-
-    while ( !nodesToReopen.empty() ) {
-      if ( stack.empty() )
-      {
-        root.push_back( nodesToReopen.back() );
-        stack.push_back( &root.back() );
-      }
-      else
-      {
-        stack.back()->push_back( nodesToReopen.back() );
-        stack.push_back( &stack.back()->back() );
-      }
-
-      nodesToReopen.pop_back();
     }
   }
   else

--- a/src/stylesheets/article-style.css
+++ b/src/stylesheets/article-style.css
@@ -531,6 +531,10 @@ div.xdxf
   color: gray;
 }
 
+.dsl_unknown{
+	border-bottom: 3px double red;
+}
+
 /* Style for expand optional parts button */
 .hidden_expand_opt
 {


### PR DESCRIPTION
dsl
```
#NAME "en-zh has BOM"
#INDEX_LANGUAGE "English"
#CONTENTS_LANGUAGE "Chinese"

Zhuang Zhou
庄子 
    [m1] ["do","re"] abc[/m]
	[m1]Zhuang Zhou[/m]
	[m1]庄子[/m]
	[m1] [/m]
	[m1] [/m]
	[m1] [/m]
	[m1] [/m]
	[m1] [/m]
	[m1] [/m]
	[m1] [/m]
	[m1] [/m]
	[m1] [/m]
	[m1] [/m]
	[m1] [/m]
	[m1] [/m]

```




![image](https://github.com/xiaoyifang/goldendict-ng/assets/105986/142cbe21-5339-4310-9bac-16ac53e6e2e6)



sample dsl 
```
#NAME "extra close tag"
#INDEX_LANGUAGE "English"
#CONTENTS_LANGUAGE "Chinese"

Zhuang Zhou
庄子 
    [m1] [/abc] abc[/m]
	[m1]Zhuang Zhou[/m]
	[m1]庄子[/m]
	[m1] [/m]
	[m1] [/m]
	[m1] [/m]
	[m1] [/m]
	[m1] [/m]
	[m1] [/m]
	[m1] [/m]
	[m1] [/m]
	[m1] [/m]
	[m1] [/m]
	[m1] [/m]
	[m1] [/m]

```

![image](https://github.com/xiaoyifang/goldendict-ng/assets/105986/a454bc44-2830-4537-908a-607dcc359153)
