### PR TITLE
rewrite release check

### DIFF
--- a/src/config.hh
+++ b/src/config.hh
@@ -711,8 +711,8 @@ struct Class
   MutedDictionaries mutedDictionaries; // Disabled via dictionary bar
   MutedDictionaries popupMutedDictionaries; // Disabled via dictionary bar in popup
 
-  QDateTime timeForNewReleaseCheck; // Only effective if
-                                    // preferences.checkForNewReleases is set
+  QDateTime timeForNewReleaseCheck;         // Last time when the release was checked.
+
   QString skippedRelease; // Empty by default
 
   bool showingDictBarNames;

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -148,10 +148,6 @@ private:
 
   sptr< HotkeyWrapper > hotkeyWrapper;
 
-  QTimer newReleaseCheckTimer; // Countdown to a check for the new program
-                               // release, if enabled
-  QNetworkReply *latestReleaseReply;
-
   sptr< QPrinter > printer; // The printer we use for all printing operations
 
   bool wordListSelChanged;
@@ -250,21 +246,15 @@ private:
   void changeWebEngineViewFont() const;
   bool isWordPresentedInFavorites( QString const & word, unsigned groupId );
   void errorMessageOnStatusBar( const QString & errStr );
+
 private slots:
+
+  /// Try check new release, popup a dialog, and update the check time & skippedRelease version
+  void checkNewRelease();
 
   void hotKeyActivated( int );
 
-  /// If new release checks are on, santizies the next check time and starts
-  /// the timer. Does nothing otherwise.
-  void prepareNewReleaseChecks();
-
   void updateFoundInDictsList();
-
-  /// Does the new release check.
-  void checkForNewRelease();
-
-  /// Signalled when the lastestReleaseReply is finished()
-  void latestReleaseReplyReady();
 
   /// Receive click on "Found in:" pane
   void foundDictsPaneClicked( QListWidgetItem * item );


### PR DESCRIPTION
This is pretty much a simplification of https://github.com/xiaoyifang/goldendict-ng/commit/e1b8c323c08033f14b5f83a9e9c75c6109566fc3, which will pop up the notification dialog in the middle of a session, like after 2 hours if the check fails on startup or opening GD for exactly 2 days :sweat_smile: 

close https://github.com/xiaoyifang/goldendict-ng/issues/964

* check 1 time per day on startup and no more
* use github's release api instead of scraping the html page

This api:
https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-the-latest-release

The api depends on the tag's format. THe tag must starts with `v23.07.16....`

The rate limit for unauthorized users is 60/h which is more than enough.

The data that will be written in the config:
```
 <timeForNewReleaseCheck>2023-07-16T03:52:27</timeForNewReleaseCheck>
 <skippedRelease>23.06.01</skippedRelease>
```
 
