### PR TITLE
fix: use png file for appstream's metainfo.xml

### DIFF
--- a/redist/org.xiaoyifang.GoldenDict_NG.metainfo.xml
+++ b/redist/org.xiaoyifang.GoldenDict_NG.metainfo.xml
@@ -16,13 +16,13 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <image>https://xiaoyifang.github.io/goldendict-ng/img/linux_genshin.webp</image>
+      <image>https://user-images.githubusercontent.com/20123683/255323975-4f12d2aa-c8c9-4dc6-b3d4-cfbc46d70889.png</image>
     </screenshot>
     <screenshot>
-      <image>https://xiaoyifang.github.io/goldendict-ng/img/mac_black.webp</image>
+      <image>https://user-images.githubusercontent.com/20123683/255323667-e76a55bc-4c81-487c-9f2b-14ece7e25f7c.png</image>
     </screenshot>
     <screenshot>
-      <image>https://xiaoyifang.github.io/goldendict-ng/img/windows_white.webp</image>
+      <image>https://user-images.githubusercontent.com/20123683/239691144-5145f844-ed88-4a24-ac86-4904ede13a32.png</image>
     </screenshot>
   </screenshots>
   <url type="homepage">https://github.com/xiaoyifang/goldendict-ng</url>


### PR DESCRIPTION
flatpak need this this:

https://github.com/flathub/flathub/wiki/App-Requirements#appstream

```
> flatpak run org.freedesktop.appstream-glib validate org.xiaoyifang.GoldenDict_NG.metainfo.xml
org.xiaoyifang.GoldenDict_NG.metainfo.xml: FAILED:
• file-invalid          : <screenshot> failed to load [https://xiaoyifang.github.io/goldendict-ng/img/linux_genshin.webp]
• file-invalid          : <screenshot> failed to load [https://xiaoyifang.github.io/goldendict-ng/img/windows_white.webp]
• tag-missing           : <release> required
Validation of files failed
```

Also failed on debian's check.
https://appstream.debian.org/sid/main/issues/goldendict-ng.html


> The value of the <image/> tag is a direct HTTP/HTTPS URL to a screenshot uploaded to a public location on the web. Images should ideally be provided in the PNG format; using JPEG or WebP is also permitted for images in metainfo files. 

They say WebP is OK, but the toolchains as of today are not updated yet :sweat_smile: 

https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-screenshots

