### PR TITLE
fix: simultaneous playing sound in wikipedia

### DIFF
--- a/src/audiooutput.cc
+++ b/src/audiooutput.cc
@@ -58,7 +58,7 @@ public:
   AudioOutput * audioOutput = nullptr;
   QByteArray buffer;
   qint64 offset = 0;
-  bool quit     = 0;
+  bool quit     = false;
   QMutex mutex;
   QWaitCondition cond;
   QThreadPool threadPool;
@@ -92,7 +92,6 @@ public:
       memcpy( &data[ bytesWritten ], sampleData, toWrite );
       buffer.remove( 0, toWrite );
       bytesWritten += toWrite;
-      //      data += toWrite;
       len -= toWrite;
     }
 

--- a/src/audiooutput.cc
+++ b/src/audiooutput.cc
@@ -130,9 +130,10 @@ public:
       QObject::connect( audioOutput, &AudioOutput::stateChanged, audioOutput, [ & ]( QAudio::State state ) {
         switch ( state ) {
           case QAudio::StoppedState:
+            quit = true;
+
             if ( audioOutput->error() != QAudio::NoError ) {
               qWarning() << "QAudioOutput stopped:" << audioOutput->error();
-              quit = true;
             }
             break;
           default:
@@ -166,6 +167,14 @@ public:
     audioOutput = nullptr;
   }
 };
+
+void AudioOutput::stop()
+{
+  Q_D( AudioOutput );
+  d->quit = true;
+  d->cond.wakeAll();
+  d->audioPlayFuture.waitForFinished();
+}
 
 AudioOutput::AudioOutput( QObject * parent ):
   QObject( parent ),

--- a/src/audiooutput.hh
+++ b/src/audiooutput.hh
@@ -13,6 +13,7 @@ public:
 
   bool play( const uint8_t * data, qint64 len );
   void setAudioFormat( int sampleRate, int channels );
+  void stop();
 
 protected:
   QScopedPointer< AudioOutputPrivate > d_ptr;

--- a/src/ffmpegaudio.cc
+++ b/src/ffmpegaudio.cc
@@ -43,7 +43,6 @@ AudioService & AudioService::instance()
   return a;
 }
 
-AudioService::AudioService() {}
 
 AudioService::~AudioService()
 {
@@ -69,14 +68,14 @@ DecoderContext::DecoderContext( QByteArray const & audioData, QAtomicInt & isCan
   isCancelled_( isCancelled ),
   audioData_( audioData ),
   audioDataStream_( audioData_ ),
-  formatContext_( NULL ),
-  codec_( NULL ),
-  codecContext_( NULL ),
-  avioContext_( NULL ),
-  audioStream_( NULL ),
+  formatContext_( nullptr ),
+  codec_( nullptr ),
+  codecContext_( nullptr ),
+  avioContext_( nullptr ),
+  audioStream_( nullptr ),
   audioOutput( new AudioOutput ),
   avformatOpened_( false ),
-  swr_( NULL )
+  swr_( nullptr )
 {
 }
 
@@ -118,7 +117,7 @@ bool DecoderContext::openCodec( QString & errorString )
   }
 
   // Don't free buffer allocated here (if succeeded), it will be cleaned up automatically.
-  avioContext_ = avio_alloc_context( avioBuffer, kBufferSize, 0, &audioDataStream_, readAudioData, NULL, NULL );
+  avioContext_ = avio_alloc_context( avioBuffer, kBufferSize, 0, &audioDataStream_, readAudioData, nullptr, nullptr );
   if ( !avioContext_ ) {
     av_free( avioBuffer );
     errorString = "avio_alloc_context() failed.";
@@ -135,13 +134,13 @@ bool DecoderContext::openCodec( QString & errorString )
   int ret         = 0;
   avformatOpened_ = true;
 
-  ret = avformat_open_input( &formatContext_, NULL, NULL, NULL );
+  ret = avformat_open_input( &formatContext_, nullptr, nullptr, nullptr );
   if ( ret < 0 ) {
     errorString = QString( "avformat_open_input() failed: %1." ).arg( avErrorString( ret ) );
     return false;
   }
 
-  ret = avformat_find_stream_info( formatContext_, NULL );
+  ret = avformat_find_stream_info( formatContext_, nullptr );
   if ( ret < 0 ) {
     errorString = QString( "avformat_find_stream_info() failed: %1." ).arg( avErrorString( ret ) );
     return false;
@@ -171,7 +170,7 @@ bool DecoderContext::openCodec( QString & errorString )
   }
   avcodec_parameters_to_context( codecContext_, audioStream_->codecpar );
 
-  ret = avcodec_open2( codecContext_, codec_, NULL );
+  ret = avcodec_open2( codecContext_, codec_, nullptr );
   if ( ret < 0 ) {
     errorString = QString( "avcodec_open2() failed: %1." ).arg( avErrorString( ret ) );
     return false;
@@ -189,7 +188,7 @@ bool DecoderContext::openCodec( QString & errorString )
     codecContext_->channel_layout = layout;
   }
 
-  swr_ = swr_alloc_set_opts( NULL,
+  swr_ = swr_alloc_set_opts( nullptr,
                              layout,
                              AV_SAMPLE_FMT_S16,
                              44100,
@@ -197,10 +196,10 @@ bool DecoderContext::openCodec( QString & errorString )
                              codecContext_->sample_fmt,
                              codecContext_->sample_rate,
                              0,
-                             NULL );
+                             nullptr );
 
   if ( !swr_ || swr_init( swr_ ) < 0 ) {
-    av_log( NULL, AV_LOG_ERROR, "Cannot create sample rate converter \n" );
+    av_log( nullptr, AV_LOG_ERROR, "Cannot create sample rate converter \n" );
     swr_free( &swr_ );
     return false;
   }
@@ -217,7 +216,7 @@ void DecoderContext::closeCodec()
   if ( !formatContext_ ) {
     if ( avioContext_ ) {
       av_free( avioContext_->buffer );
-      avioContext_ = NULL;
+      avioContext_ = nullptr;
     }
     return;
   }
@@ -227,12 +226,12 @@ void DecoderContext::closeCodec()
   if ( !avformatOpened_ ) {
     if ( formatContext_ ) {
       avformat_free_context( formatContext_ );
-      formatContext_ = NULL;
+      formatContext_ = nullptr;
     }
 
     if ( avioContext_ ) {
       av_free( avioContext_->buffer );
-      avioContext_ = NULL;
+      avioContext_ = nullptr;
     }
     return;
   }
@@ -296,7 +295,7 @@ bool DecoderContext::play( QString & errorString )
   }
 
   /* flush the decoder */
-  packet->data = NULL;
+  packet->data = nullptr;
   packet->size = 0;
   int ret      = avcodec_send_packet( codecContext_, packet );
   while ( ret >= 0 ) {
@@ -324,22 +323,22 @@ bool DecoderContext::normalizeAudio( AVFrame * frame, vector< uint8_t > & sample
   auto dst_freq     = 44100;
   auto dst_channels = codecContext_->channels;
   int out_count     = (int64_t)frame->nb_samples * dst_freq / frame->sample_rate + 256;
-  int out_size      = av_samples_get_buffer_size( NULL, dst_channels, out_count, AV_SAMPLE_FMT_S16, 1 );
+  int out_size      = av_samples_get_buffer_size( nullptr, dst_channels, out_count, AV_SAMPLE_FMT_S16, 1 );
   samples.resize( out_size );
-  uint8_t * data[ 2 ] = { 0 };
+  uint8_t * data[ 2 ] = { nullptr };
   data[ 0 ]           = &samples.front();
 
   auto out_nb_samples = swr_convert( swr_, data, out_count, (const uint8_t **)frame->extended_data, frame->nb_samples );
 
   if ( out_nb_samples < 0 ) {
-    av_log( NULL, AV_LOG_ERROR, "converte fail \n" );
+    av_log( nullptr, AV_LOG_ERROR, "converte fail \n" );
     return false;
   }
   else {
     //    qDebug( "out_count:%d, out_nb_samples:%d, frame->nb_samples:%d \n", out_count, out_nb_samples, frame->nb_samples );
   }
 
-  int actual_size = av_samples_get_buffer_size( NULL, dst_channels, out_nb_samples, AV_SAMPLE_FMT_S16, 1 );
+  int actual_size = av_samples_get_buffer_size( nullptr, dst_channels, out_nb_samples, AV_SAMPLE_FMT_S16, 1 );
   samples.resize( actual_size );
   return true;
 }

--- a/src/ffmpegaudio.hh
+++ b/src/ffmpegaudio.hh
@@ -2,18 +2,34 @@
 #define __FFMPEGAUDIO_HH_INCLUDED__
 
 #ifdef MAKE_FFMPEG_PLAYER
-
+  #include "audiooutput.hh"
   #include <QObject>
   #include <QMutex>
-  #include <QAtomicInt>
   #include <QByteArray>
   #include <QThread>
+extern "C" {
+  #include <libavcodec/avcodec.h>
+  #include <libavformat/avformat.h>
+  #include <libavutil/avutil.h>
+  #include "libswresample/swresample.h"
+}
 
+  #include <QString>
+  #include <QDataStream>
+
+  #include <vector>
+  #if ( QT_VERSION >= QT_VERSION_CHECK( 6, 2, 0 ) )
+    #include <QMediaDevices>
+
+    #include <QAudioDevice>
+  #endif
+using std::vector;
 namespace Ffmpeg {
-
+class DecoderThread;
 class AudioService: public QObject
 {
   Q_OBJECT
+  std::shared_ptr< DecoderThread > thread;
 
 public:
   static AudioService & instance();
@@ -29,6 +45,43 @@ private:
   ~AudioService();
 };
 
+struct DecoderContext
+{
+  enum {
+    kBufferSize = 32768
+  };
+
+  static QMutex deviceMutex_;
+  QAtomicInt & isCancelled_;
+  QByteArray audioData_;
+  QDataStream audioDataStream_;
+  AVFormatContext * formatContext_;
+  #if LIBAVCODEC_VERSION_MAJOR < 59
+  AVCodec * codec_;
+  #else
+  const AVCodec * codec_;
+  #endif
+  AVCodecContext * codecContext_;
+  AVIOContext * avioContext_;
+  AVStream * audioStream_;
+  AudioOutput * audioOutput;
+  bool avformatOpened_;
+
+  SwrContext * swr_;
+
+  DecoderContext( QByteArray const & audioData, QAtomicInt & isCancelled );
+  ~DecoderContext();
+
+  bool openCodec( QString & errorString );
+  void closeCodec();
+  bool openOutputDevice( QString & errorString );
+  void closeOutputDevice();
+  bool play( QString & errorString );
+  void stop();
+  bool normalizeAudio( AVFrame * frame, vector< uint8_t > & samples );
+  void playFrame( AVFrame * frame );
+};
+
 class DecoderThread: public QThread
 {
   Q_OBJECT
@@ -36,6 +89,7 @@ class DecoderThread: public QThread
   static QMutex deviceMutex_;
   QAtomicInt isCancelled_;
   QByteArray audioData_;
+  DecoderContext d;
 
 public:
   DecoderThread( QByteArray const & audioData, QObject * parent );

--- a/src/ffmpegaudio.hh
+++ b/src/ffmpegaudio.hh
@@ -41,7 +41,7 @@ signals:
   void error( QString const & message );
 
 private:
-  AudioService();
+  AudioService() = default;
   ~AudioService();
 };
 

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -1785,6 +1785,7 @@ void ArticleView::resourceDownloadFinished()
 
         if ( resourceDownloadUrl.scheme() == "gdau" || Utils::Url::isWebAudioUrl( resourceDownloadUrl ) ) {
           // Audio data
+          audioPlayer->stop();
           connect( audioPlayer.data(),
                    &AudioPlayerInterface::error,
                    this,


### PR DESCRIPTION
choose ffmpeg as audio backend.
then
click the audio link repeatly in wikipedia will cuase the sound to play simultaneously

reproduce steps:
use english wikipedia dictionary.
search laughing ,

![image](https://github.com/xiaoyifang/goldendict-ng/assets/105986/85729ee2-09c2-4e2d-aa29-962019d7f16a)

