### PR TITLE
fix: cmake version.txt generation when built without git

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,16 +42,19 @@ find_package(Qt6 REQUIRED COMPONENTS
 
 #### Compile time files and preprocessor flags
 
-# Obtain git commit hash
-execute_process(
-        COMMAND git rev-parse --short=8 HEAD
-        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-        OUTPUT_VARIABLE GIT_HASH
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-string(TIMESTAMP date_for_version_file) # note: this variable is cached for every run, but for user installation, this doesn't matter much
-configure_file(version.txt.in ${CMAKE_SOURCE_DIR}/version.txt)
+block() # generate version.txt
+    string(TIMESTAMP build_time)
+    find_package(Git)
+    if (EXISTS "${CMAKE_SOURCE_DIR}/.git" AND GIT_FOUND)
+        execute_process(
+                COMMAND ${GIT_EXECUTABLE} -C "${CMAKE_SOURCE_DIR}" rev-parse --short HEAD
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                OUTPUT_VARIABLE GIT_HASH)
+        file(WRITE "${CMAKE_SOURCE_DIR}/version.txt" "${PROJECT_VERSION}.${GIT_HASH} at ${build_time}")
+    else () # not built in a git repo
+        file(WRITE "${CMAKE_SOURCE_DIR}/version.txt" "${PROJECT_VERSION} at ${build_time}")
+    endif ()
+endblock()
 
 #### Sources Files
 

--- a/src/version.cc
+++ b/src/version.cc
@@ -17,8 +17,8 @@ QString version()
 QString everything()
 {
   return QStringLiteral( "Goldendict-ng " ) + Version::version() + "\n" + "Qt " + QLatin1String( qVersion() ) + " "
-    + Version::compiler + QSysInfo::productType() + " " + QSysInfo::kernelType() + " " + QSysInfo::kernelVersion() + " "
-    + QSysInfo::buildAbi() + "\n" + "Flags:" + flags;
+    + Version::compiler + " " + QSysInfo::productType() + " " + QSysInfo::kernelType() + " " + QSysInfo::kernelVersion()
+    + " " + QSysInfo::buildAbi() + "\n" + "Flags:" + flags;
 }
 
 } // namespace Version

--- a/version.txt.in
+++ b/version.txt.in
@@ -1,1 +1,0 @@
-${PROJECT_VERSION}.${GIT_HASH} on ${date_for_version_file}


### PR DESCRIPTION
This is mostly for packaging systems like deb & rpm, where the `.git/` and `git` do not exist (because they both were designed when tarballs were popular).

