### PR TITLE
Make appicon work on Windows when built by CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,11 @@ set(QSINGLEAPP_SOURCE_FILES
         thirdparty/qtsingleapplication/src/qtsingleapplication.h
         )
 
-qt_add_executable(${GOLDENDICT} MANUAL_FINALIZATION)
+if(WIN32)
+    qt_add_executable(${GOLDENDICT} WIN32 MANUAL_FINALIZATION icons/programicon.rc)
+else()
+    qt_add_executable(${GOLDENDICT} MANUAL_FINALIZATION)
+endif()
 
 target_sources(${GOLDENDICT} PRIVATE
         icons/flags.qrc

--- a/icons/programicon.rc
+++ b/icons/programicon.rc
@@ -1,0 +1,1 @@
+IDI_ICON1               ICON    DISCARDABLE     "programicon.ico"


### PR DESCRIPTION
The original cmake build of GD is console application with a console on startup and no icon attached with the executable. This commit makes it a GUI application and add icon.