### PR TITLE
opt: remove outline of dictionary name in classic style

### DIFF
--- a/src/stylesheets/article-style-st-classic.css
+++ b/src/stylesheets/article-style-st-classic.css
@@ -34,14 +34,14 @@ pre {
 
 /* Dictionary's name heading */
 .gddictname {
-  border: 1px dotted black;
+  /* border: 1px dotted black;
   padding: 0.2em;
   padding-left: 0.5em;
   margin-top: 1.2em;
   margin-bottom: 9px;
   font-weight: bold;
   font-size: 14px;
-  /*background: #ffffdd;*/
+  background: #ffffdd; */
 }
 
 .gddicttitle {


### PR DESCRIPTION
![image](https://github.com/xiaoyifang/goldendict-ng/assets/105986/387a91e4-92d9-4e7a-aad6-ed02b35dbd4f)


vs

![image](https://github.com/xiaoyifang/goldendict-ng/assets/105986/0552a5d3-bc25-4812-a814-c39f3f1827cc)
