### PR TITLE
fix: epwing dictionary index twice

### DIFF
--- a/src/dict/epwing.cc
+++ b/src/dict/epwing.cc
@@ -1183,9 +1183,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
         QFileInfo info( fontSubName );
         if ( info.exists() && info.isFile() )
           dictFiles.push_back( fontSubName.toStdString() );
-        else{
+        else {
           //to make the subbook in different index.
-          dictFiles.push_back(QString::number( sb ).toStdString());
+          dictFiles.push_back( QString::number( sb ).toStdString() );
         }
 
         // Check if we need to rebuid the index

--- a/src/dict/epwing.cc
+++ b/src/dict/epwing.cc
@@ -1183,6 +1183,10 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
         QFileInfo info( fontSubName );
         if ( info.exists() && info.isFile() )
           dictFiles.push_back( fontSubName.toStdString() );
+        else{
+          //to make the subbook in different index.
+          dictFiles.push_back(QString::number( sb ).toStdString());
+        }
 
         // Check if we need to rebuid the index
 


### PR DESCRIPTION
If epwing dictionary contain >1 subbooks, the following subbook will overwrite the previous index which will cause a "duplicateId" warning and the dictionary can be be queried.

fix #1082