### PR TITLE
fix: [macos] disable ffmpeg to solve the #1144 issue

### DIFF
--- a/.github/workflows/macos-homebrew.yml
+++ b/.github/workflows/macos-homebrew.yml
@@ -97,7 +97,7 @@ jobs:
           
       - name: compile
         run: |          
-          qmake CONFIG+=release CONFIG+=no_macos_universal CONFIG+=zim_support CONFIG+=use_xapian
+          qmake CONFIG+=release CONFIG+=no_macos_universal CONFIG+=zim_support CONFIG+=use_xapian CONFIG+=no_ffmpeg_player
           make -j8
           
       - name: package


### PR DESCRIPTION
This is a workaround to Fix #1144

ffmpeg include too much library ,and each update will have the chance to make the dmg does not work .

I intend to disable ffmpeg on Macos ,   

Without ffmpeg ,some speex audio file can not be played.

Users can choose to use external player to bypass this.