### PR TITLE
opt: add translation windows when invoked from console 

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -221,13 +221,16 @@ void processCommandLine( QCoreApplication * app, GDOptions * result )
                                            QObject::tr( "Change the group of popup." ),
                                            "popupGroupName" );
 
-  QCommandLineOption windowOption( QStringList() << "w"
-                                                         << "window",
-                                           QObject::tr( "Translate the word in popup or main window" ),
-                                           "window","main|popup" );
+  QCommandLineOption window_popupOption( QStringList() << "s"
+                                         << "scanpopup",
+                                         QObject::tr( "Force the word to be translated in scanpopup" ) );
+
+  QCommandLineOption window_mainWindowOption( QStringList() << "m"
+                                              << "main-window",
+                                              QObject::tr( "Force the word to be translated in the mainwindow" ) );
 
   QCommandLineOption togglePopupOption( QStringList() << "t"
-                                                      << "toggle-scan-popup",
+                                        << "toggle-scan-popup",
                                         QObject::tr( "Toggle scan popup." ) );
 
   QCommandLineOption printVersion( QStringList() << "v"
@@ -237,7 +240,8 @@ void processCommandLine( QCoreApplication * app, GDOptions * result )
   qcmd.addOption( logFileOption );
   qcmd.addOption( groupNameOption );
   qcmd.addOption( popupGroupNameOption );
-  qcmd.addOption( windowOption );
+  qcmd.addOption( window_popupOption );
+  qcmd.addOption( window_mainWindowOption );
   qcmd.addOption( togglePopupOption );
   qcmd.addOption( notts );
   qcmd.addOption( resetState );
@@ -260,8 +264,11 @@ void processCommandLine( QCoreApplication * app, GDOptions * result )
   if ( qcmd.isSet( popupGroupNameOption ) ) {
     result->popupGroupName = qcmd.value( popupGroupNameOption );
   }
-  if ( qcmd.isSet( windowOption ) ) {
-    result->window = qcmd.value( windowOption );
+  if ( qcmd.isSet( window_popupOption ) ) {
+    result->window = "popup";
+  }
+  if ( qcmd.isSet( window_mainWindowOption ) ) {
+    result->window = "main";
   }
   if ( qcmd.isSet( togglePopupOption ) ) {
     result->togglePopup = true;

--- a/src/main.cc
+++ b/src/main.cc
@@ -222,15 +222,15 @@ void processCommandLine( QCoreApplication * app, GDOptions * result )
                                            "popupGroupName" );
 
   QCommandLineOption window_popupOption( QStringList() << "s"
-                                         << "scanpopup",
+                                                       << "scanpopup",
                                          QObject::tr( "Force the word to be translated in scanpopup" ) );
 
   QCommandLineOption window_mainWindowOption( QStringList() << "m"
-                                              << "main-window",
+                                                            << "main-window",
                                               QObject::tr( "Force the word to be translated in the mainwindow" ) );
 
   QCommandLineOption togglePopupOption( QStringList() << "t"
-                                        << "toggle-scan-popup",
+                                                      << "toggle-scan-popup",
                                         QObject::tr( "Toggle scan popup." ) );
 
   QCommandLineOption printVersion( QStringList() << "v"

--- a/src/main.cc
+++ b/src/main.cc
@@ -148,6 +148,7 @@ struct GDOptions
   bool logFile     = false;
   bool togglePopup = false;
   QString word, groupName, popupGroupName;
+  QString window;
 
   inline bool needSetGroup() const
   {
@@ -220,6 +221,11 @@ void processCommandLine( QCoreApplication * app, GDOptions * result )
                                            QObject::tr( "Change the group of popup." ),
                                            "popupGroupName" );
 
+  QCommandLineOption windowOption( QStringList() << "w"
+                                                         << "window",
+                                           QObject::tr( "Translate the word in popup or main window" ),
+                                           "window","main|popup" );
+
   QCommandLineOption togglePopupOption( QStringList() << "t"
                                                       << "toggle-scan-popup",
                                         QObject::tr( "Toggle scan popup." ) );
@@ -231,6 +237,7 @@ void processCommandLine( QCoreApplication * app, GDOptions * result )
   qcmd.addOption( logFileOption );
   qcmd.addOption( groupNameOption );
   qcmd.addOption( popupGroupNameOption );
+  qcmd.addOption( windowOption );
   qcmd.addOption( togglePopupOption );
   qcmd.addOption( notts );
   qcmd.addOption( resetState );
@@ -253,7 +260,9 @@ void processCommandLine( QCoreApplication * app, GDOptions * result )
   if ( qcmd.isSet( popupGroupNameOption ) ) {
     result->popupGroupName = qcmd.value( popupGroupNameOption );
   }
-
+  if ( qcmd.isSet( windowOption ) ) {
+    result->window = qcmd.value( windowOption );
+  }
   if ( qcmd.isSet( togglePopupOption ) ) {
     result->togglePopup = true;
   }
@@ -414,6 +423,7 @@ int main( int argc, char ** argv )
   if ( app.isRunning() ) {
     bool wasMessage = false;
 
+    //TODO .all the following messages can be combined into one.
     if ( gdcl.needSetGroup() ) {
       app.sendMessage( QString( "setGroup: " ) + gdcl.getGroupName() );
       wasMessage = true;
@@ -421,6 +431,11 @@ int main( int argc, char ** argv )
 
     if ( gdcl.needSetPopupGroup() ) {
       app.sendMessage( QString( "setPopupGroup: " ) + gdcl.getPopupGroupName() );
+      wasMessage = true;
+    }
+
+    if ( !gdcl.window.isEmpty() ) {
+      app.sendMessage( QString( "window:" ) + gdcl.window );
       wasMessage = true;
     }
 

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -3548,11 +3548,18 @@ void MainWindow::messageFromAnotherInstanceReceived( QString const & message )
     return;
   }
 
+  QString prefix = "window:";
+  if ( message.left( prefix.size() ) == prefix ) {
+    consoleWindowOnce = message.mid( prefix.size() );
+  }
+
   if ( message.left( 15 ) == "translateWord: " ) {
-    if ( scanPopup )
+    if ( (consoleWindowOnce == "popup") && scanPopup )
       scanPopup->translateWord( message.mid( 15 ) );
     else
       wordReceived( message.mid( 15 ) );
+
+    consoleWindowOnce.clear();
   }
   else if ( message.left( 10 ) == "setGroup: " ) {
     setGroupByName( message.mid( 10 ), true );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -3554,10 +3554,20 @@ void MainWindow::messageFromAnotherInstanceReceived( QString const & message )
   }
 
   if ( message.left( 15 ) == "translateWord: " ) {
-    if ( (consoleWindowOnce == "popup") && scanPopup )
-      scanPopup->translateWord( message.mid( 15 ) );
-    else
-      wordReceived( message.mid( 15 ) );
+    auto word = message.mid( 15 );
+    if ( ( consoleWindowOnce == "popup" ) && scanPopup ) {
+      scanPopup->translateWord( word );
+    }
+    else if ( consoleWindowOnce == "main" ) {
+      wordReceived( word );
+    }
+    else {
+      //default logic
+      if ( scanPopup && enableScanningAction->isChecked() )
+        scanPopup->translateWord( word );
+      else
+        wordReceived( word );
+    }
 
     consoleWindowOnce.clear();
   }

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -149,6 +149,9 @@ private:
 
   ScanPopup * scanPopup = nullptr;
 
+  //only used once, when used ,reset to empty.
+  QString consoleWindowOnce;
+
   sptr< HotkeyWrapper > hotkeyWrapper;
 
   sptr< QPrinter > printer; // The printer we use for all printing operations


### PR DESCRIPTION
show the translation in popup

```
goldendict -s [word]
```

show the translation in main windows

```
goldendict -m [word]
```

Without the above argument, the logic will follow the logic:
if 💡 checked, use popup ,or use mainwindow.