### PR TITLE
fix: font missing cause phonetic symbols can not displayed correctly

### DIFF
--- a/src/stylesheets/article-style.css
+++ b/src/stylesheets/article-style.css
@@ -9,6 +9,7 @@ body {
     system-ui,
     -apple-system,
     BlinkMacSystemFont,
+    Tahoma, Verdana, "Lucida Sans Unicode","Palatino Linotype", "Arial Unicode MS",
     "Segoe UI",
     Roboto,
     Oxygen,


### PR DESCRIPTION
fix #1180 