### PR TITLE
fix: avoid QFile::readall when loading resources 

### DIFF
--- a/src/common/file.cc
+++ b/src/common/file.cc
@@ -36,9 +36,9 @@ bool tryPossibleZipName( std::string const & name, std::string & copyTo )
 void loadFromFile( std::string const & filename, std::vector< char > & data )
 {
   File::Class f( filename, "rb" );
-  QByteArray byteArray{ f.readall() };
-  data.reserve( byteArray.size() );
-  data = std::vector< char >( byteArray.cbegin(), byteArray.cend() );
+  auto size = f.file().size(); // QFile::size() obtains size via statx on Linux
+  data.resize( size );
+  f.read( data.data(), size );
 }
 
 void Class::open( char const * mode )
@@ -82,10 +82,9 @@ Class::Class( std::string_view filename, char const * mode )
 
 void Class::read( void * buf, qint64 size )
 {
-  qint64 result = f.read( static_cast< char * >( buf ), size );
-
-  if ( result != size )
+  if ( f.read( static_cast< char * >( buf ), size ) != size ) {
     throw exReadError();
+  }
 }
 
 size_t Class::readRecords( void * buf, qint64 size, qint64 count )

--- a/src/common/file.hh
+++ b/src/common/file.hh
@@ -13,7 +13,8 @@
 #include <vector>
 #include <QMutex>
 
-/// A simple wrapper over QFile with some convenient GD specific functions
+/// A wrapper over QFile with some GD specific functions
+/// and exception throwing which are required for older coded to work correctly
 /// Consider the wrapped QFile as private implementation in the `Pimpl Idiom`
 ///
 /// Note: this is used *only* in code related to `Dictionary::CLass` to manage dict files.

--- a/src/stylesheets/article-style.css
+++ b/src/stylesheets/article-style.css
@@ -5,18 +5,9 @@ html {
 }
 
 body {
-  font-family:
-    -apple-system,
-    BlinkMacSystemFont,
-    Tahoma, Verdana, "Lucida Sans Unicode","Palatino Linotype", "Arial Unicode MS",
-    "Segoe UI",
-    Roboto,
-    Oxygen,
-    Ubuntu,
-    Cantarell,
-    "Open Sans",
-    "Helvetica Neue",
-    sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, Tahoma, Verdana,
+    "Lucida Sans Unicode", "Palatino Linotype", "Arial Unicode MS", "Segoe UI",
+    Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
 }
 
 h1,


### PR DESCRIPTION
This should avoid copying from QByteArray to std::vector