### PR TITLE
fix: makeFTSIndex crash at startup when indexed articleCount is zero

### DIFF
--- a/src/ftshelpers.cc
+++ b/src/ftshelpers.cc
@@ -78,7 +78,7 @@ void makeFTSIndex( BtreeIndexing::BtreeDictionary * dict, QAtomicInt & isCancell
 
     QVector< uint32_t > offsets;
     offsets.resize( setOfOffsets.size() );
-    uint32_t * ptr = &offsets.front();
+    uint32_t * ptr = offsets.data();
 
     for ( QSet< uint32_t >::ConstIterator it = setOfOffsets.constBegin(); it != setOfOffsets.constEnd(); ++it ) {
       *ptr = *it;

--- a/src/stylesheets/article-style.css
+++ b/src/stylesheets/article-style.css
@@ -5,18 +5,9 @@ html {
 }
 
 body {
-  font-family:
-    -apple-system,
-    BlinkMacSystemFont,
-    Tahoma, Verdana, "Lucida Sans Unicode","Palatino Linotype", "Arial Unicode MS",
-    "Segoe UI",
-    Roboto,
-    Oxygen,
-    Ubuntu,
-    Cantarell,
-    "Open Sans",
-    "Helvetica Neue",
-    sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, Tahoma, Verdana,
+    "Lucida Sans Unicode", "Palatino Linotype", "Arial Unicode MS", "Segoe UI",
+    Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
 }
 
 h1,


### PR DESCRIPTION
The behaviour of `&QList::front()` is undefined if the size is 0 https://doc.qt.io/qt-6/qlist.html#first

I don't fully understand the context, this may reveal other bugs if the offsets' size is not supposed to be 0.

![image](https://github.com/xiaoyifang/goldendict-ng/assets/20123683/158ae56a-0317-4e8c-a0e1-5f2a9e703547)
