### PR TITLE
opt: experimental changes, resource performance, support gdvideo

### DIFF
--- a/src/article_netmgr.cc
+++ b/src/article_netmgr.cc
@@ -260,9 +260,10 @@ sptr< Dictionary::DataRequest > ArticleNetworkAccessManager::getResource( QUrl c
 
   if ( ( url.scheme() == "bres" || url.scheme() == "gdau" || url.scheme() == "gdvideo" || url.scheme() == "gico" )
        && url.path().size() ) {
-    //GD_DPRINTF( "Get %s\n", req.url().host().toLocal8Bit().data() );
-    //GD_DPRINTF( "Get %s\n", req.url().path().toLocal8Bit().data() );
 
+
+    QMimeType mineType = db.mimeTypeForUrl( url );
+    contentType        = mineType.name();
     string id = url.host().toStdString();
 
     bool search = ( id == "search" );

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -976,17 +976,17 @@ void MdxDictionary::replaceLinks( QString & id, QString & article )
         match = RX::Mdx::srcRe.match( linkTxt );
         if ( match.hasMatch() ) {
           QString newText;
-          if ( linkType.at( 1 ) == 'o' ) // "source" tag
-          {
-            QString filename = match.captured( 3 );
-            QString newName  = getCachedFileName( filename );
-            newName.replace( '\\', '/' );
-            newText = match.captured( 1 ) + match.captured( 2 ) + "file:///" + newName + match.captured( 2 );
+          QString scheme;
+          // "source" tag
+          if ( linkType.compare( "source" ) == 0 ) {
+            scheme = "gdvideo://";
           }
           else {
-            newText = match.captured( 1 ) + match.captured( 2 ) + "bres://" + id + "/" + match.captured( 3 )
-              + match.captured( 2 );
+            scheme = "bres://";
           }
+          newText =
+            match.captured( 1 ) + match.captured( 2 ) + scheme + id + "/" + match.captured( 3 ) + match.captured( 2 );
+
           newLink = linkTxt.replace( match.capturedStart(), match.capturedLength(), newText );
         }
         else

--- a/src/resourceschemehandler.cc
+++ b/src/resourceschemehandler.cc
@@ -7,26 +7,46 @@ ResourceSchemeHandler::ResourceSchemeHandler( ArticleNetworkAccessManager & arti
 }
 void ResourceSchemeHandler::requestStarted( QWebEngineUrlRequestJob * requestJob )
 {
-  QUrl url = requestJob->requestUrl();
+  const QUrl url = requestJob->requestUrl();
+  QString content_type;
+  const QMimeType mineType                    = db.mimeTypeForUrl( url );
+  const sptr< Dictionary::DataRequest > reply = this->mManager.getResource( url, content_type );
+  content_type                                = mineType.name();
+  if ( reply->isFinished() ) {
+    replyJob( reply, requestJob, content_type );
+  }
+  else
+    connect( reply.get(), &Dictionary::DataRequest::finished, requestJob, [ = ]() {
+      replyJob( reply, requestJob, content_type );
+    } );
+}
 
-  QNetworkRequest request;
-  request.setUrl( url );
-  request.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache );
-  QNetworkReply * reply = this->mManager.getArticleReply( request );
-  connect( reply, &QNetworkReply::finished, requestJob, [ = ]() {
-    if ( reply->error() == QNetworkReply::ContentNotFoundError ) {
-      requestJob->fail( QWebEngineUrlRequestJob::UrlNotFound );
-      return;
-    }
-    if ( reply->error() != QNetworkReply::NoError ) {
-      qDebug() << "resource handler failed:" << reply->error() << ":" << reply->request().url();
-      requestJob->fail( QWebEngineUrlRequestJob::RequestFailed );
-      return;
-    }
-    QMimeType mineType  = db.mimeTypeForUrl( url );
-    QString contentType = mineType.name();
-    // Reply segment
-    requestJob->reply( contentType.toLatin1(), reply );
+
+void ResourceSchemeHandler::replyJob( sptr< Dictionary::DataRequest > reply,
+                                      QWebEngineUrlRequestJob * requestJob,
+                                      QString content_type )
+{
+  if ( !reply.get() ) {
+    requestJob->fail( QWebEngineUrlRequestJob::UrlNotFound );
+    return;
+  }
+  const auto & data = reply->getFullData();
+  if ( data.empty() ) {
+    requestJob->fail( QWebEngineUrlRequestJob::UrlNotFound );
+    return;
+  }
+  QByteArray * ba  = new QByteArray( data.data(), data.size() );
+  QBuffer * buffer = new QBuffer( ba );
+  buffer->open( QBuffer::ReadOnly );
+  buffer->seek( 0 );
+
+  // Reply segment
+  requestJob->reply( content_type.toLatin1(), buffer );
+
+  connect( requestJob, &QObject::destroyed, buffer, [ = ]() {
+    buffer->close();
+    ba->clear();
+    delete ba;
+    buffer->deleteLater();
   } );
-  connect( requestJob, &QObject::destroyed, reply, &QObject::deleteLater );
 }

--- a/src/resourceschemehandler.hh
+++ b/src/resourceschemehandler.hh
@@ -12,6 +12,7 @@ public:
   void requestStarted( QWebEngineUrlRequestJob * requestJob );
 
 protected:
+  void replyJob( sptr< Dictionary::DataRequest > reply, QWebEngineUrlRequestJob * requestJob, QString content_type );
 
 private:
   ArticleNetworkAccessManager & mManager;


### PR DESCRIPTION
One benefit of this PR is that ,when changed the mdx's video url to gdvideo:// ,the video can be dragged around.

While the original implementation is not support such feature when the url is gdvideo://.
(it support drag around when the url is file:/// alike).

The only concern is that the video maybe too big .

Test Dictionary
[t.zip](https://github.com/xiaoyifang/goldendict-ng/files/12846133/t.zip)

Search `video`

https://github.com/xiaoyifang/goldendict-ng/assets/105986/784a81d3-1199-4ce9-bd20-b41b351dbc2c

