### PR TITLE
opt: reduce the network stall time

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -409,6 +409,7 @@ int main( int argc, char ** argv )
 
   for ( const auto & localScheme : localSchemes ) {
     QWebEngineUrlScheme webUiScheme( localScheme.toLatin1() );
+    webUiScheme.setSyntax( QWebEngineUrlScheme::Syntax::Host );
     webUiScheme.setFlags( QWebEngineUrlScheme::SecureScheme | QWebEngineUrlScheme::LocalScheme
                           | QWebEngineUrlScheme::LocalAccessAllowed | QWebEngineUrlScheme::CorsEnabled );
     QWebEngineUrlScheme::registerScheme( webUiScheme );


### PR DESCRIPTION
Before:
![image](https://github.com/xiaoyifang/goldendict-ng/assets/105986/b773ce13-219e-4191-b508-922a0d0812db)
After（disable cache）:

![image](https://github.com/xiaoyifang/goldendict-ng/assets/105986/9fd364b4-a72f-4381-87b0-4dc512cbe441)


One unexpected benefit:
the memory cache takes effect now.
![image](https://github.com/xiaoyifang/goldendict-ng/assets/105986/7d3486e6-a9ef-40eb-a195-b9905958e863)
