### PR TITLE
Add default font style for phonetic symbols

### DIFF
--- a/src/stylesheets/article-style.css
+++ b/src/stylesheets/article-style.css
@@ -10,8 +10,15 @@ body {
     Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
 }
 
-.ipa, .phon, .phone, .pron, .audio-gb, .audio-us {
-  font-family: 'Segoe UI', 'Lucida Grande', 'Lucida Sans', 'Droid Sans Mono', 'Droid Sans', 'Arial Unicode MS', "Charis SIL", 'Open Sans', Roboto, Helvetica, Arial, normal;
+.ipa,
+.phon,
+.phone,
+.pron,
+.audio-gb,
+.audio-us {
+  font-family: "Segoe UI", "Lucida Grande", "Lucida Sans", "Droid Sans Mono",
+    "Droid Sans", "Arial Unicode MS", "Charis SIL", "Open Sans", Roboto,
+    Helvetica, Arial, normal;
 }
 
 h1,

--- a/src/stylesheets/article-style.css
+++ b/src/stylesheets/article-style.css
@@ -10,6 +10,10 @@ body {
     Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
 }
 
+.ipa, .phon, .phone, .pron, .audio-gb, .audio-us {
+  font-family: 'Segoe UI', 'Lucida Grande', 'Lucida Sans', 'Droid Sans Mono', 'Droid Sans', 'Arial Unicode MS', "Charis SIL", 'Open Sans', Roboto, Helvetica, Arial, normal;
+}
+
 h1,
 h2,
 h3,


### PR DESCRIPTION
Add default font style for phonetic symbols, fix some dictionaries that display phonetic symbols abnormally due to missing style files