### PR TITLE
clean: move dict implementations out of headers

### DIFF
--- a/src/dict/forvo.cc
+++ b/src/dict/forvo.cc
@@ -75,6 +75,48 @@ protected:
   void loadIcon() noexcept override;
 };
 
+class ForvoArticleRequest: public Dictionary::DataRequest
+{
+  Q_OBJECT
+
+  struct NetReply
+  {
+    sptr< QNetworkReply > reply;
+    string word;
+    bool finished;
+
+    NetReply( sptr< QNetworkReply > const & reply_, string const & word_ ):
+      reply( reply_ ),
+      word( word_ ),
+      finished( false )
+    {
+    }
+  };
+
+  typedef std::list< NetReply > NetReplies;
+  NetReplies netReplies;
+  QString apiKey, languageCode;
+  string dictionaryId;
+
+public:
+
+  ForvoArticleRequest( wstring const & word,
+                       vector< wstring > const & alts,
+                       QString const & apiKey_,
+                       QString const & languageCode_,
+                       string const & dictionaryId_,
+                       QNetworkAccessManager & mgr );
+
+  virtual void cancel();
+
+private:
+
+  void addQuery( QNetworkAccessManager & mgr, wstring const & word );
+
+private slots:
+  virtual void requestFinished( QNetworkReply * );
+};
+
 sptr< DataRequest >
 ForvoDictionary::getArticle( wstring const & word, vector< wstring > const & alts, wstring const &, bool )
 
@@ -343,4 +385,5 @@ makeDictionaries( Dictionary::Initializing &, Config::Forvo const & forvo, QNetw
   return result;
 }
 
+#include "forvo.moc"
 } // namespace Forvo

--- a/src/dict/forvo.hh
+++ b/src/dict/forvo.hh
@@ -7,61 +7,12 @@
 #include "dictionary.hh"
 #include "config.hh"
 #include <QNetworkAccessManager>
-#include "wstring.hh"
-#include <QNetworkReply>
 
 /// Support for Forvo pronunciations, based on its API.
 namespace Forvo {
 
-using std::vector;
-using std::string;
-using gd::wstring;
-
-vector< sptr< Dictionary::Class > >
+std::vector< sptr< Dictionary::Class > >
 makeDictionaries( Dictionary::Initializing &, Config::Forvo const &, QNetworkAccessManager & );
-
-/// Exposed here for moc
-class ForvoArticleRequest: public Dictionary::DataRequest
-{
-  Q_OBJECT
-
-  struct NetReply
-  {
-    sptr< QNetworkReply > reply;
-    string word;
-    bool finished;
-
-    NetReply( sptr< QNetworkReply > const & reply_, string const & word_ ):
-      reply( reply_ ),
-      word( word_ ),
-      finished( false )
-    {
-    }
-  };
-
-  typedef std::list< NetReply > NetReplies;
-  NetReplies netReplies;
-  QString apiKey, languageCode;
-  string dictionaryId;
-
-public:
-
-  ForvoArticleRequest( wstring const & word,
-                       vector< wstring > const & alts,
-                       QString const & apiKey_,
-                       QString const & languageCode_,
-                       string const & dictionaryId_,
-                       QNetworkAccessManager & mgr );
-
-  virtual void cancel();
-
-private:
-
-  void addQuery( QNetworkAccessManager & mgr, wstring const & word );
-
-private slots:
-  virtual void requestFinished( QNetworkReply * );
-};
 
 } // namespace Forvo
 

--- a/src/dict/lingualibre.cc
+++ b/src/dict/lingualibre.cc
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <utility>
+#include <QNetworkReply>
 
 namespace Lingua {
 
@@ -14,6 +15,47 @@ using namespace Dictionary;
 
 namespace {
 
+class LinguaArticleRequest: public Dictionary::DataRequest
+{
+  Q_OBJECT
+
+  struct NetReply
+  {
+    sptr< QNetworkReply > reply;
+    string word;
+    bool finished;
+
+    NetReply( sptr< QNetworkReply > const & reply_, string const & word_ ):
+      reply( reply_ ),
+      word( word_ ),
+      finished( false )
+    {
+    }
+  };
+
+  typedef std::list< NetReply > NetReplies;
+  NetReplies netReplies;
+  QString languageCode, langWikipediaID;
+  string dictionaryId;
+
+public:
+
+  LinguaArticleRequest( wstring const & word,
+                        vector< wstring > const & alts,
+                        QString const & languageCode_,
+                        QString const & langWikipediaID_,
+                        string const & dictionaryId_,
+                        QNetworkAccessManager & mgr );
+
+  virtual void cancel();
+
+private:
+
+  void addQuery( QNetworkAccessManager & mgr, wstring const & word );
+
+private slots:
+  virtual void requestFinished( QNetworkReply * );
+};
 
 class LinguaDictionary: public Dictionary::Class
 {
@@ -338,5 +380,5 @@ void LinguaArticleRequest::requestFinished( QNetworkReply * r )
   }
 }
 
-
+#include "lingualibre.moc"
 } // end namespace Lingua

--- a/src/dict/lingualibre.hh
+++ b/src/dict/lingualibre.hh
@@ -3,63 +3,12 @@
 
 #include "dictionary.hh"
 #include "config.hh"
-#include "wstring.hh"
 #include <QNetworkAccessManager>
-#include <QNetworkReply>
-
 
 namespace Lingua {
 
-using std::vector;
-using std::string;
-using gd::wstring;
-
-vector< sptr< Dictionary::Class > >
+std::vector< sptr< Dictionary::Class > >
 makeDictionaries( Dictionary::Initializing &, Config::Lingua const &, QNetworkAccessManager & );
-
-
-/// Exposed here for moc
-class LinguaArticleRequest: public Dictionary::DataRequest
-{
-  Q_OBJECT
-
-  struct NetReply
-  {
-    sptr< QNetworkReply > reply;
-    string word;
-    bool finished;
-
-    NetReply( sptr< QNetworkReply > const & reply_, string const & word_ ):
-      reply( reply_ ),
-      word( word_ ),
-      finished( false )
-    {
-    }
-  };
-
-  typedef std::list< NetReply > NetReplies;
-  NetReplies netReplies;
-  QString languageCode, langWikipediaID;
-  string dictionaryId;
-
-public:
-
-  LinguaArticleRequest( wstring const & word,
-                        vector< wstring > const & alts,
-                        QString const & languageCode_,
-                        QString const & langWikipediaID_,
-                        string const & dictionaryId_,
-                        QNetworkAccessManager & mgr );
-
-  virtual void cancel();
-
-private:
-
-  void addQuery( QNetworkAccessManager & mgr, wstring const & word );
-
-private slots:
-  virtual void requestFinished( QNetworkReply * );
-};
 
 } // namespace Lingua
 

--- a/src/dict/mediawiki.cc
+++ b/src/dict/mediawiki.cc
@@ -88,6 +88,24 @@ protected:
   void loadIcon() noexcept override;
 };
 
+class MediaWikiWordSearchRequestSlots: public Dictionary::WordSearchRequest
+{
+  Q_OBJECT
+
+protected slots:
+
+  virtual void downloadFinished() {}
+};
+
+class MediaWikiDataRequestSlots: public Dictionary::DataRequest
+{
+  Q_OBJECT
+
+protected slots:
+
+  virtual void requestFinished( QNetworkReply * ) {}
+};
+
 void MediaWikiDictionary::loadIcon() noexcept
 {
   if ( dictionaryIconLoaded )
@@ -708,4 +726,5 @@ makeDictionaries( Dictionary::Initializing &, Config::MediaWikis const & wikis, 
   return result;
 }
 
+#include "mediawiki.moc"
 } // namespace MediaWiki

--- a/src/dict/mediawiki.hh
+++ b/src/dict/mediawiki.hh
@@ -12,30 +12,10 @@
 namespace MediaWiki {
 
 using std::vector;
-using std::string;
 
 vector< sptr< Dictionary::Class > >
 makeDictionaries( Dictionary::Initializing &, Config::MediaWikis const & wikis, QNetworkAccessManager & );
 
-/// Exposed here for moc
-class MediaWikiWordSearchRequestSlots: public Dictionary::WordSearchRequest
-{
-  Q_OBJECT
-
-protected slots:
-
-  virtual void downloadFinished() {}
-};
-
-/// Exposed here for moc
-class MediaWikiDataRequestSlots: public Dictionary::DataRequest
-{
-  Q_OBJECT
-
-protected slots:
-
-  virtual void requestFinished( QNetworkReply * ) {}
-};
 
 } // namespace MediaWiki
 

--- a/src/dict/website.cc
+++ b/src/dict/website.cc
@@ -86,6 +86,15 @@ protected:
   void loadIcon() noexcept override;
 };
 
+class WebSiteDataRequestSlots: public Dictionary::DataRequest
+{
+  Q_OBJECT
+
+protected slots:
+
+  virtual void requestFinished( QNetworkReply * ) {}
+};
+
 sptr< WordSearchRequest > WebSiteDictionary::prefixMatch( wstring const & /*word*/, unsigned long )
 {
   sptr< WordSearchRequestInstant > sr = std::make_shared< WordSearchRequestInstant >();
@@ -517,4 +526,5 @@ vector< sptr< Dictionary::Class > > makeDictionaries( Config::WebSites const & w
   return result;
 }
 
+#include "website.moc"
 } // namespace WebSite

--- a/src/dict/website.hh
+++ b/src/dict/website.hh
@@ -6,26 +6,15 @@
 
 #include "dictionary.hh"
 #include "config.hh"
-#include <QNetworkAccessManager>
 #include <QNetworkReply>
 
 /// Support for any web sites via a templated url.
 namespace WebSite {
 
 using std::vector;
-using std::string;
 
 vector< sptr< Dictionary::Class > > makeDictionaries( Config::WebSites const &, QNetworkAccessManager & );
 
-/// Exposed here for moc
-class WebSiteDataRequestSlots: public Dictionary::DataRequest
-{
-  Q_OBJECT
-
-protected slots:
-
-  virtual void requestFinished( QNetworkReply * ) {}
-};
 
 } // namespace WebSite
 


### PR DESCRIPTION
class with Q_OBJECT can be defined .cpp file by including .moc explicitly

inspired by https://github.com/xiaoyifang/goldendict-ng/pull/1313