### PR TITLE
fix build in freebsd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,11 @@ if (WIN32)
     set(GD_WIN_OUTPUT_DIR ${CMAKE_BINARY_DIR}/${GOLDENDICT})
 endif ()
 
+
+include_directories("/usr/local/include")
+link_directories("/usr/local/lib")
+
+
 #### Sources Files
 
 # auto discovery of ui files https://cmake.org/cmake/help/v3.26/prop_tgt/AUTOUIC_SEARCH_PATHS.html
@@ -260,4 +265,11 @@ if (WIN32)
     #TODO: use CPack to make the output folder as NSIS installer
 endif ()
 
+
+
+target_link_libraries(${GOLDENDICT} PRIVATE X11 iconv)
+
 feature_summary(WHAT ALL DESCRIPTION "Build configuration:")
+
+
+


### PR DESCRIPTION
the build was broken in freebsd, it couldn't compile against xlib and iconv. this commit fixes this by adding a explicit path to the lib directory and by telling cmake to build the executable against iconv and xlib.