### PR TITLE
opt: add the language variant option for wikipedia dictionaries

### DIFF
--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -2755,6 +2755,10 @@ To find &apos;*&apos;, &apos;?&apos;, &apos;[&apos;, &apos;]&apos; symbols use &
         <source>Icon</source>
         <translation>图标</translation>
     </message>
+    <message>
+        <source>Language Variant</source>
+        <translation>语言变体</translation>
+    </message>
 </context>
 <context>
     <name>MultimediaAudioPlayer</name>

--- a/src/config.cc
+++ b/src/config.cc
@@ -356,13 +356,13 @@ MediaWikis makeDefaultMediaWikis( bool enable )
     MediaWiki( "5d45232075d06e002dea72fe3e137da1", "Greek Wiktionary", "https://el.wiktionary.org/w", false, "" ) );
   mw.push_back( MediaWiki( "c015d60c4949ad75b5b7069c2ff6dc2c",
                            "traditional Chinese Wikipedia",
-                           "http://zh.wikipedia.org/w",
+                           "https://zh.wikipedia.org/w",
                            false,
                            "",
                            "zh-hant" ) );
   mw.push_back( MediaWiki( "d50828ad6e115bc9d3421b6821543108",
                            "traditional Chinese Wiktionary",
-                           "http://zh.wiktionary.org/w",
+                           "https://zh.wiktionary.org/w",
                            false,
                            "",
                            "zh-hant" ) );

--- a/src/config.cc
+++ b/src/config.cc
@@ -354,14 +354,30 @@ MediaWikis makeDefaultMediaWikis( bool enable )
     MediaWiki( "f3b4ec8531e52ddf5b10d21e4577a7a2", "Greek Wikipedia", "https://el.wikipedia.org/w", false, "" ) );
   mw.push_back(
     MediaWiki( "5d45232075d06e002dea72fe3e137da1", "Greek Wiktionary", "https://el.wiktionary.org/w", false, "" ) );
-  mw.push_back(
-    MediaWiki( "c015d60c4949ad75b5b7069c2ff6dc2c", "traditional Chinese Wikipedia", "http://zh.wikipedia.org/w", false, "" , "zh-hant" ) );
-  mw.push_back(
-    MediaWiki( "d50828ad6e115bc9d3421b6821543108", "traditional Chinese Wiktionary", "http://zh.wiktionary.org/w", false, "" , "zh-hant" ) );
-  mw.push_back(
-    MediaWiki( "438b17b48cbda1a22d317fea37ec3110", "Simplified Chinese Wikipedia", "https://zh.wikipedia.org/w", false, "" , "zh-hans" ) );
-  mw.push_back(
-    MediaWiki( "b68b9fb71b5a8c766cc7a5ea8237fc6b", "Simplified Chinese Wiktionary", "https://zh.wiktionary.org/w", false, "" , "zh-hans" ) );
+  mw.push_back( MediaWiki( "c015d60c4949ad75b5b7069c2ff6dc2c",
+                           "traditional Chinese Wikipedia",
+                           "http://zh.wikipedia.org/w",
+                           false,
+                           "",
+                           "zh-hant" ) );
+  mw.push_back( MediaWiki( "d50828ad6e115bc9d3421b6821543108",
+                           "traditional Chinese Wiktionary",
+                           "http://zh.wiktionary.org/w",
+                           false,
+                           "",
+                           "zh-hant" ) );
+  mw.push_back( MediaWiki( "438b17b48cbda1a22d317fea37ec3110",
+                           "Simplified Chinese Wikipedia",
+                           "https://zh.wikipedia.org/w",
+                           false,
+                           "",
+                           "zh-hans" ) );
+  mw.push_back( MediaWiki( "b68b9fb71b5a8c766cc7a5ea8237fc6b",
+                           "Simplified Chinese Wiktionary",
+                           "https://zh.wiktionary.org/w",
+                           false,
+                           "",
+                           "zh-hans" ) );
 
   return mw;
 }

--- a/src/config.cc
+++ b/src/config.cc
@@ -332,28 +332,36 @@ MediaWikis makeDefaultMediaWikis( bool enable )
   MediaWikis mw;
 
   mw.push_back(
-    MediaWiki( "ae6f89aac7151829681b85f035d54e48", "English Wikipedia", "https://en.wikipedia.org/w", enable, "" ) );
+    MediaWiki( "ae6f89aac7151829681b85f035d54e48", "English Wikipedia", "https://en.wikipedia.org/w", enable, "", "" ) );
   mw.push_back(
-    MediaWiki( "affcf9678e7bfe701c9b071f97eccba3", "English Wiktionary", "https://en.wiktionary.org/w", enable, "" ) );
+    MediaWiki( "affcf9678e7bfe701c9b071f97eccba3", "English Wiktionary", "https://en.wiktionary.org/w", enable, "", "" ) );
   mw.push_back(
-    MediaWiki( "8e0c1c2b6821dab8bdba8eb869ca7176", "Russian Wikipedia", "https://ru.wikipedia.org/w", false, "" ) );
+    MediaWiki( "8e0c1c2b6821dab8bdba8eb869ca7176", "Russian Wikipedia", "https://ru.wikipedia.org/w", false, "", "" ) );
   mw.push_back(
-    MediaWiki( "b09947600ae3902654f8ad4567ae8567", "Russian Wiktionary", "https://ru.wiktionary.org/w", false, "" ) );
+    MediaWiki( "b09947600ae3902654f8ad4567ae8567", "Russian Wiktionary", "https://ru.wiktionary.org/w", false, "", "" ) );
   mw.push_back(
-    MediaWiki( "a8a66331a1242ca2aeb0b4aed361c41d", "German Wikipedia", "https://de.wikipedia.org/w", false, "" ) );
+    MediaWiki( "a8a66331a1242ca2aeb0b4aed361c41d", "German Wikipedia", "https://de.wikipedia.org/w", false, "", "" ) );
   mw.push_back(
-    MediaWiki( "21c64bca5ec10ba17ff19f3066bc962a", "German Wiktionary", "https://de.wiktionary.org/w", false, "" ) );
+    MediaWiki( "21c64bca5ec10ba17ff19f3066bc962a", "German Wiktionary", "https://de.wiktionary.org/w", false, "", "" ) );
   mw.push_back(
-    MediaWiki( "96957cb2ad73a20c7a1d561fc83c253a", "Portuguese Wikipedia", "https://pt.wikipedia.org/w", false, "" ) );
+    MediaWiki( "96957cb2ad73a20c7a1d561fc83c253a", "Portuguese Wikipedia", "https://pt.wikipedia.org/w", false, "", "" ) );
   mw.push_back( MediaWiki( "ed4c3929196afdd93cc08b9a903aad6a",
                            "Portuguese Wiktionary",
                            "https://pt.wiktionary.org/w",
                            false,
-                           "" ) );
+                           "", "" ) );
   mw.push_back(
-    MediaWiki( "f3b4ec8531e52ddf5b10d21e4577a7a2", "Greek Wikipedia", "https://el.wikipedia.org/w", false, "" ) );
+    MediaWiki( "f3b4ec8531e52ddf5b10d21e4577a7a2", "Greek Wikipedia", "https://el.wikipedia.org/w", false, "" , "" ) );
   mw.push_back(
-    MediaWiki( "5d45232075d06e002dea72fe3e137da1", "Greek Wiktionary", "https://el.wiktionary.org/w", false, "" ) );
+    MediaWiki( "5d45232075d06e002dea72fe3e137da1", "Greek Wiktionary", "https://el.wiktionary.org/w", false, "" , "" ) );
+  mw.push_back(
+    MediaWiki( "c015d60c4949ad75b5b7069c2ff6dc2c", "traditional Chinese Wikipedia", "http://zh.wikipedia.org/w", false, "" , "zh-hant" ) );
+  mw.push_back(
+    MediaWiki( "d50828ad6e115bc9d3421b6821543108", "traditional Chinese Wiktionary", "http://zh.wiktionary.org/w", false, "" , "zh-hant" ) );
+  mw.push_back(
+    MediaWiki( "438b17b48cbda1a22d317fea37ec3110", "Simplified Chinese Wikipedia", "https://zh.wikipedia.org/w", false, "" , "zh-hans" ) );
+  mw.push_back(
+    MediaWiki( "b68b9fb71b5a8c766cc7a5ea8237fc6b", "Simplified Chinese Wiktionary", "https://zh.wiktionary.org/w", false, "" , "zh-hans" ) );
 
   return mw;
 }
@@ -760,6 +768,7 @@ Class load()
       w.url     = mw.attribute( "url" );
       w.enabled = ( mw.attribute( "enabled" ) == "1" );
       w.icon    = mw.attribute( "icon" );
+      w.lang    = mw.attribute( "lang" );
 
       c.mediawikis.push_back( w );
     }
@@ -1527,6 +1536,10 @@ void save( Class const & c )
       QDomAttr icon = dd.createAttribute( "icon" );
       icon.setValue( mediawiki.icon );
       mw.setAttributeNode( icon );
+
+      QDomAttr lang = dd.createAttribute( "lang" );
+      lang.setValue( mediawiki.lang );
+      mw.setAttributeNode( lang );
     }
   }
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -332,28 +332,28 @@ MediaWikis makeDefaultMediaWikis( bool enable )
   MediaWikis mw;
 
   mw.push_back(
-    MediaWiki( "ae6f89aac7151829681b85f035d54e48", "English Wikipedia", "https://en.wikipedia.org/w", enable, "", "" ) );
+    MediaWiki( "ae6f89aac7151829681b85f035d54e48", "English Wikipedia", "https://en.wikipedia.org/w", enable, "" ) );
   mw.push_back(
-    MediaWiki( "affcf9678e7bfe701c9b071f97eccba3", "English Wiktionary", "https://en.wiktionary.org/w", enable, "", "" ) );
+    MediaWiki( "affcf9678e7bfe701c9b071f97eccba3", "English Wiktionary", "https://en.wiktionary.org/w", enable, "" ) );
   mw.push_back(
-    MediaWiki( "8e0c1c2b6821dab8bdba8eb869ca7176", "Russian Wikipedia", "https://ru.wikipedia.org/w", false, "", "" ) );
+    MediaWiki( "8e0c1c2b6821dab8bdba8eb869ca7176", "Russian Wikipedia", "https://ru.wikipedia.org/w", false, "" ) );
   mw.push_back(
-    MediaWiki( "b09947600ae3902654f8ad4567ae8567", "Russian Wiktionary", "https://ru.wiktionary.org/w", false, "", "" ) );
+    MediaWiki( "b09947600ae3902654f8ad4567ae8567", "Russian Wiktionary", "https://ru.wiktionary.org/w", false, "" ) );
   mw.push_back(
-    MediaWiki( "a8a66331a1242ca2aeb0b4aed361c41d", "German Wikipedia", "https://de.wikipedia.org/w", false, "", "" ) );
+    MediaWiki( "a8a66331a1242ca2aeb0b4aed361c41d", "German Wikipedia", "https://de.wikipedia.org/w", false, "" ) );
   mw.push_back(
-    MediaWiki( "21c64bca5ec10ba17ff19f3066bc962a", "German Wiktionary", "https://de.wiktionary.org/w", false, "", "" ) );
+    MediaWiki( "21c64bca5ec10ba17ff19f3066bc962a", "German Wiktionary", "https://de.wiktionary.org/w", false, "" ) );
   mw.push_back(
-    MediaWiki( "96957cb2ad73a20c7a1d561fc83c253a", "Portuguese Wikipedia", "https://pt.wikipedia.org/w", false, "", "" ) );
+    MediaWiki( "96957cb2ad73a20c7a1d561fc83c253a", "Portuguese Wikipedia", "https://pt.wikipedia.org/w", false, "" ) );
   mw.push_back( MediaWiki( "ed4c3929196afdd93cc08b9a903aad6a",
                            "Portuguese Wiktionary",
                            "https://pt.wiktionary.org/w",
                            false,
-                           "", "" ) );
+                           "" ) );
   mw.push_back(
-    MediaWiki( "f3b4ec8531e52ddf5b10d21e4577a7a2", "Greek Wikipedia", "https://el.wikipedia.org/w", false, "" , "" ) );
+    MediaWiki( "f3b4ec8531e52ddf5b10d21e4577a7a2", "Greek Wikipedia", "https://el.wikipedia.org/w", false, "" ) );
   mw.push_back(
-    MediaWiki( "5d45232075d06e002dea72fe3e137da1", "Greek Wiktionary", "https://el.wiktionary.org/w", false, "" , "" ) );
+    MediaWiki( "5d45232075d06e002dea72fe3e137da1", "Greek Wiktionary", "https://el.wiktionary.org/w", false, "" ) );
   mw.push_back(
     MediaWiki( "c015d60c4949ad75b5b7069c2ff6dc2c", "traditional Chinese Wikipedia", "http://zh.wikipedia.org/w", false, "" , "zh-hant" ) );
   mw.push_back(

--- a/src/config.hh
+++ b/src/config.hh
@@ -462,7 +462,7 @@ struct MediaWiki
   {
   }
 
-  MediaWiki( QString const & id_, QString const & name_, QString const & url_, bool enabled_, QString const & icon_, QString const & lang_ ):
+  MediaWiki( QString const & id_, QString const & name_, QString const & url_, bool enabled_, QString const & icon_, QString const & lang_ = "" ):
     id( id_ ),
     name( name_ ),
     url( url_ ),

--- a/src/config.hh
+++ b/src/config.hh
@@ -462,7 +462,12 @@ struct MediaWiki
   {
   }
 
-  MediaWiki( QString const & id_, QString const & name_, QString const & url_, bool enabled_, QString const & icon_, QString const & lang_ = "" ):
+  MediaWiki( QString const & id_,
+             QString const & name_,
+             QString const & url_,
+             bool enabled_,
+             QString const & icon_,
+             QString const & lang_ = "" ):
     id( id_ ),
     name( name_ ),
     url( url_ ),
@@ -474,7 +479,8 @@ struct MediaWiki
 
   bool operator==( MediaWiki const & other ) const
   {
-    return id == other.id && name == other.name && url == other.url && enabled == other.enabled && icon == other.icon && lang == other.lang;
+    return id == other.id && name == other.name && url == other.url && enabled == other.enabled && icon == other.icon
+      && lang == other.lang;
   }
 };
 

--- a/src/config.hh
+++ b/src/config.hh
@@ -455,24 +455,26 @@ struct MediaWiki
   QString id, name, url;
   bool enabled;
   QString icon;
+  QString lang;
 
   MediaWiki():
     enabled( false )
   {
   }
 
-  MediaWiki( QString const & id_, QString const & name_, QString const & url_, bool enabled_, QString const & icon_ ):
+  MediaWiki( QString const & id_, QString const & name_, QString const & url_, bool enabled_, QString const & icon_, QString const & lang_ ):
     id( id_ ),
     name( name_ ),
     url( url_ ),
     enabled( enabled_ ),
-    icon( icon_ )
+    icon( icon_ ),
+    lang( lang_ )
   {
   }
 
   bool operator==( MediaWiki const & other ) const
   {
-    return id == other.id && name == other.name && url == other.url && enabled == other.enabled && icon == other.icon;
+    return id == other.id && name == other.name && url == other.url && enabled == other.enabled && icon == other.icon && lang == other.lang;
   }
 };
 

--- a/src/dict/sources.cc
+++ b/src/dict/sources.cc
@@ -49,6 +49,7 @@ Sources::Sources( QWidget * parent, Config::Class const & cfg ):
   ui.mediaWikis->resizeColumnToContents( 1 );
   ui.mediaWikis->resizeColumnToContents( 2 );
   ui.mediaWikis->resizeColumnToContents( 3 );
+  ui.mediaWikis->resizeColumnToContents( 4 );
 
   ui.webSites->setTabKeyNavigation( true );
   ui.webSites->setModel( &webSitesModel );
@@ -429,6 +430,8 @@ void MediaWikisModel::addNewWiki()
 
   w.url = "http://";
 
+  w.lang = "";
+
   beginInsertRows( QModelIndex(), mediawikis.size(), mediawikis.size() );
   mediawikis.push_back( w );
   endInsertRows();
@@ -471,7 +474,7 @@ int MediaWikisModel::columnCount( QModelIndex const & parent ) const
   if ( parent.isValid() )
     return 0;
   else
-    return 4;
+    return 5;
 }
 
 QVariant MediaWikisModel::headerData( int section, Qt::Orientation /*orientation*/, int role ) const
@@ -486,6 +489,8 @@ QVariant MediaWikisModel::headerData( int section, Qt::Orientation /*orientation
         return tr( "Address" );
       case 3:
         return tr( "Icon" );
+      case 4:
+        return tr( "Language Variant" );
       default:
         return QVariant();
     }
@@ -506,6 +511,8 @@ QVariant MediaWikisModel::data( QModelIndex const & index, int role ) const
         return mediawikis[ index.row() ].url;
       case 3:
         return mediawikis[ index.row() ].icon;
+      case 4:
+        return mediawikis[ index.row() ].lang;
       default:
         return QVariant();
     }
@@ -545,6 +552,10 @@ bool MediaWikisModel::setData( QModelIndex const & index, const QVariant & value
         return true;
       case 3:
         mediawikis[ index.row() ].icon = value.toString();
+        dataChanged( index, index );
+        return true;
+      case 4:
+        mediawikis[ index.row() ].lang = value.toString();
         dataChanged( index, index );
         return true;
       default:


### PR DESCRIPTION
![2024-01-24_876x583](https://github.com/xiaoyifang/goldendict-ng/assets/237124/a1a8950f-a03e-4024-a86f-b851a41f41ee)

If the base language supports variant conversion, users can set their preferred variant of the language.

