### PR TITLE
fix: correctly use CMake's FindX11

### DIFF
--- a/CMake_Unix.cmake
+++ b/CMake_Unix.cmake
@@ -12,9 +12,13 @@ target_include_directories(${GOLDENDICT} PRIVATE
 
 if (LINUX OR BSD)
     find_package(X11 REQUIRED)
-    pkg_check_modules(LIBXTST IMPORTED_TARGET xtst)
-    target_compile_definitions(${GOLDENDICT} PUBLIC HAVE_X11)
-    target_link_libraries(${GOLDENDICT} PRIVATE X11 PkgConfig::LIBXTST)
+    if (X11_FOUND AND X11_Xtst_FOUND)
+        target_compile_definitions(${GOLDENDICT} PUBLIC HAVE_X11)
+        target_link_libraries(${GOLDENDICT} PRIVATE ${X11_LIBRARIES} ${X11_Xtst_LIB})
+        target_include_directories(${GOLDENDICT} PRIVATE ${X11_INCLUDE_DIR} ${X11_Xtst_INCLUDE_PATH})
+    else ()
+        message(FATAL_ERROR "Cannot find X11 and libXtst!")
+    endif ()
 endif ()
 
 if (APPLE)


### PR DESCRIPTION
I was thinking about how would this line in https://github.com/xiaoyifang/goldendict-ng/pull/1369 fixes any problem.

![image](https://github.com/xiaoyifang/goldendict-ng/assets/20123683/daf72d1d-62bd-49f5-8a15-9c6c3af78d05)

The weird thing is that we already linked against X11

https://github.com/xiaoyifang/goldendict-ng/blob/c15cbbf607d7b13bcbf766835de8d19db35ed7c5/CMake_Unix.cmake#L14-L17

Combined with this comment https://github.com/xiaoyifang/goldendict-ng/pull/1292#issuecomment-1817733658 , I came to realize a stupid mistake I made:

The `FindX11.cmake` will define `X11_LIBRARIES` and `X11_INCLUDE_DIR` but not `X11`

https://cmake.org/cmake/help/latest/module/FindX11.html

The working of ` target_link_libraries(${GOLDENDICT} PRIVATE X11 ` is pure accident because `X11` will be translated into `-lX11` :sweat_smile: 

This PR thanks to @KonstantinDjairo & @Canvis-Me