### PR TITLE
fix: uses libc iconv on FreeBSD

### DIFF
--- a/CMake_Unix.cmake
+++ b/CMake_Unix.cmake
@@ -29,7 +29,6 @@ find_package(PkgConfig REQUIRED)
 # Provided by Cmake
 find_package(ZLIB REQUIRED)
 find_package(BZip2 REQUIRED)
-find_package(Iconv REQUIRED)
 
 
 # Consider all PkgConfig dependencies as one
@@ -46,8 +45,19 @@ target_link_libraries(${GOLDENDICT} PRIVATE
         PkgConfig::PKGCONFIG_DEPS
         BZip2::BZip2
         ZLIB::ZLIB
-        Iconv::Iconv
-        )
+)
+
+# On FreeBSD, there are two iconv, libc iconv & GNU libiconv.
+# The system one is good enough, the following is a workaround to use libc iconv on freeBSD.
+if (BSD STREQUAL "FreeBSD")
+    # Simply do nothing. libc includes iconv on freeBSD.
+    # LIBICONV_PLUG is a magic word to turn /usr/include/local/inconv.h, which belong to GNU libiconv, into normal iconv.h
+    # Same hack used by SDL https://github.com/libsdl-org/SDL/blob/d6ebbc2fa4abdbe0bd53d0ce8804a492ecb042b9/src/stdlib/SDL_iconv.c#L27-L28
+    target_compile_definitions(${GOLDENDICT} PUBLIC LIBICONV_PLUG)
+else ()
+    find_package(Iconv REQUIRED)
+    target_link_libraries(${GOLDENDICT} PRIVATE Iconv::Iconv)
+endif ()
 
 if (WITH_FFMPEG_PLAYER)
     pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET


### PR DESCRIPTION
The GNU libiconv has this thing that rename `iconv_open` to `libiconv_open` when `LIBICONV_PLUG` not defined.

![image](https://github.com/xiaoyifang/goldendict-ng/assets/20123683/d5c9c8c3-e13b-4a86-9546-fbdf999b7a48)

The flag `LIBICONV_PLUG` effectively turns GNU libiconv's header to the base system's iconv header. This might be abuse, but SDL also does this.

https://github.com/libsdl-org/SDL/blob/d6ebbc2fa4abdbe0bd53d0ce8804a492ecb042b9/src/stdlib/SDL_iconv.c#L27-L28

Combined with https://github.com/xiaoyifang/goldendict-ng/pull/1380 should close https://github.com/xiaoyifang/goldendict-ng/pull/1369

## Is FreeBSD's libc iconv good enough?

Based on the early design doc of FreeBSD's Iconv, it supports a similar dynamic loading mechanism to GNU libconv so encoding supports should not be a problem.

http://citrus.bsdclub.org/

> One can add new locale and encoding without recompiling system libraries by dynamic linking.