### PR TITLE
fix: reduce darkreader mode white flash further by using QWebEnginePage::setBackgroundColor() (for Qt6.6.3+)

### DIFF
--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -155,6 +155,8 @@ ArticleView::ArticleView( QWidget * parent,
 
   webview->setUp( const_cast< Config::Class * >( &cfg ) );
 
+  syncBackgroundColorWithCfgDarkReader();
+
   goBackAction.setShortcut( QKeySequence( "Alt+Left" ) );
   webview->addAction( &goBackAction );
   connect( &goBackAction, &QAction::triggered, this, &ArticleView::back );
@@ -1359,6 +1361,20 @@ void ArticleView::setDelayedHighlightText( QString const & text )
 {
   delayedHighlightText = text;
 }
+
+void ArticleView::syncBackgroundColorWithCfgDarkReader() const
+{
+  // Only works Qt6.6.3+ https://bugreports.qt.io/browse/QTBUG-112013
+  #if QT_VERSION >= QT_VERSION_CHECK( 6, 6, 3 )
+  if ( cfg.preferences.darkReaderMode ) {
+    webview->page()->setBackgroundColor( Qt::black );
+  }
+  else {
+    webview->page()->setBackgroundColor( Qt::white );
+  }
+  #endif
+}
+
 
 void ArticleView::back()
 {

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -1364,15 +1364,15 @@ void ArticleView::setDelayedHighlightText( QString const & text )
 
 void ArticleView::syncBackgroundColorWithCfgDarkReader() const
 {
-  // Only works Qt6.6.3+ https://bugreports.qt.io/browse/QTBUG-112013
-  #if QT_VERSION >= QT_VERSION_CHECK( 6, 6, 3 )
+// Only works Qt6.6.3+ https://bugreports.qt.io/browse/QTBUG-112013
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 6, 3 )
   if ( cfg.preferences.darkReaderMode ) {
     webview->page()->setBackgroundColor( Qt::black );
   }
   else {
     webview->page()->setBackgroundColor( Qt::white );
   }
-  #endif
+#endif
 }
 
 

--- a/src/ui/articleview.hh
+++ b/src/ui/articleview.hh
@@ -172,6 +172,9 @@ public:
 
   void setDelayedHighlightText( QString const & text );
 
+  /// \brief Set background as black if darkreader mode is enabled.
+  void syncBackgroundColorWithCfgDarkReader() const;
+
 private:
   // widgets
   ArticleWebView * webview;

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -2270,7 +2270,7 @@ void MainWindow::editPreferences()
       ArticleView & view = dynamic_cast< ArticleView & >( *( ui.tabWidget->widget( x ) ) );
 
       view.setSelectionBySingleClick( p.selectWordBySingleClick );
-
+      view.syncBackgroundColorWithCfgDarkReader();
       if ( needReload ) {
         view.reload();
       }

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -291,6 +291,8 @@ void ScanPopup::refresh()
 
   updateDictionaryBar();
 
+  definition->syncBackgroundColorWithCfgDarkReader();
+
   connect( ui.groupList, &GroupComboBox::currentIndexChanged, this, &ScanPopup::currentGroupChanged );
 #ifdef HAVE_X11
   selectionDelayTimer.setInterval( cfg.preferences.selectionChangeDelayTimer );


### PR DESCRIPTION
This bug is finally fixed
https://bugreports.qt.io/browse/QTBUG-112013
https://github.com/qt/qtwebengine/commit/85bfaa5274b5d47437d6e0634746f70a6646bd4e

This should ultimately eliminate the white flash in dark reader mode.

Related https://github.com/xiaoyifang/goldendict-ng/issues/357

(BTW, I am not sure what you did to reduce white flash previously at https://github.com/xiaoyifang/goldendict-ng/issues/357#issuecomment-1769828055 which does work, but the bug still exists in Qt6.6.2 evidenced by my small demo https://github.com/SourceReviver/qtwebengine_bg_not_work .

Maybe the previous workarounds will be duplicated with this? Or they cover different phases of white flash. I don't know.)



