### PR TITLE
clean: replace deprecated mouse pos related qt functions

### DIFF
--- a/src/ui/maintabwidget.cc
+++ b/src/ui/maintabwidget.cc
@@ -42,21 +42,13 @@ void MainTabWidget::updateTabBarVisibility()
   tabBar()->setVisible( !hideSingleTab || tabBar()->count() > 1 );
 }
 
-/*
-void MainTabWidget::mouseDoubleClickEvent ( QMouseEvent * event )
-{
-  (void) event;
-  emit doubleClicked();
-}
-*/
-
 bool MainTabWidget::eventFilter( QObject * obj, QEvent * ev )
 {
-  // mouseDoubleClickEvent don't called under Ubuntu
+  // QTabBar::mouseDoubleClickEvent is different from QWidget::mouseDoubleClickEvent
+  // The former only got emitted when an actual tab is clicked, here we want to detect click on empty sapce of the tabbar
   if ( ev->type() == QEvent::MouseButtonDblClick ) {
     QMouseEvent * mev = static_cast< QMouseEvent * >( ev );
-    if ( mev->y() >= tabBar()->rect().y() && mev->y() <= tabBar()->rect().y() + tabBar()->rect().height()
-         && tabBar()->tabAt( mev->pos() ) == -1 ) {
+    if ( tabBar()->rect().contains( mev->position().toPoint() ) && tabBar()->tabAt( mev->position().toPoint() ) == -1 ) {
       emit doubleClicked();
       return true;
     }

--- a/src/ui/maintabwidget.cc
+++ b/src/ui/maintabwidget.cc
@@ -48,7 +48,8 @@ bool MainTabWidget::eventFilter( QObject * obj, QEvent * ev )
   // The former only got emitted when an actual tab is clicked, here we want to detect click on empty sapce of the tabbar
   if ( ev->type() == QEvent::MouseButtonDblClick ) {
     QMouseEvent * mev = static_cast< QMouseEvent * >( ev );
-    if ( tabBar()->rect().contains( mev->position().toPoint() ) && tabBar()->tabAt( mev->position().toPoint() ) == -1 ) {
+    if ( tabBar()->rect().contains( mev->position().toPoint() )
+         && tabBar()->tabAt( mev->position().toPoint() ) == -1 ) {
       emit doubleClicked();
       return true;
     }

--- a/src/ui/maintabwidget.hh
+++ b/src/ui/maintabwidget.hh
@@ -26,9 +26,6 @@ public:
 signals:
   void doubleClicked();
 
-protected:
-  //  virtual void mouseDoubleClickEvent ( QMouseEvent * event );
-
 private:
   virtual void tabInserted( int index );
   virtual void tabRemoved( int index );

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -3,9 +3,6 @@
 
 #include "scanpopup.hh"
 #include "folding.hh"
-#include <QCursor>
-#include <QPixmap>
-#include <QBitmap>
 #include <QMenu>
 #include <QMouseEvent>
 #if ( QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 ) )
@@ -709,7 +706,7 @@ bool ScanPopup::eventFilter( QObject * watched, QEvent * event )
 
     if ( event->type() == QEvent::MouseMove ) {
       QMouseEvent * mouseEvent = (QMouseEvent *)event;
-      reactOnMouseMove( mouseEvent->globalPos() );
+      reactOnMouseMove( mouseEvent->globalPosition().toPoint() );
     }
   }
 
@@ -773,14 +770,14 @@ void ScanPopup::mousePressEvent( QMouseEvent * ev )
   // With mouse grabs, the press can occur anywhere on the screen, which
   // might mean hiding the window.
 
-  if ( !frameGeometry().contains( ev->globalPos() ) ) {
+  if ( !frameGeometry().contains( ev->globalPosition().toPoint() ) ) {
     hideWindow();
 
     return;
   }
 
   if ( ev->button() == Qt::LeftButton ) {
-    startPos = ev->globalPos();
+    startPos = ev->globalPosition().toPoint();
     setCursor( Qt::ClosedHandCursor );
   }
 
@@ -790,7 +787,7 @@ void ScanPopup::mousePressEvent( QMouseEvent * ev )
 void ScanPopup::mouseMoveEvent( QMouseEvent * event )
 {
   if ( event->buttons() && cursor().shape() == Qt::ClosedHandCursor ) {
-    QPoint newPos = event->globalPos();
+    QPoint newPos = event->globalPosition().toPoint();
 
     QPoint delta = newPos - startPos;
 


### PR DESCRIPTION
Those methods are deleted in qt6's doc.

Also, correct an old comment. It is an undocumented detail rather than a bug.
