### PR TITLE
clean: simplify tabbar double click detect via qt's built-in methods

### DIFF
--- a/src/ui/maintabwidget.cc
+++ b/src/ui/maintabwidget.cc
@@ -42,26 +42,8 @@ void MainTabWidget::updateTabBarVisibility()
   tabBar()->setVisible( !hideSingleTab || tabBar()->count() > 1 );
 }
 
-/*
-void MainTabWidget::mouseDoubleClickEvent ( QMouseEvent * event )
-{
-  (void) event;
-  emit doubleClicked();
-}
-*/
-
 bool MainTabWidget::eventFilter( QObject * obj, QEvent * ev )
 {
-  // mouseDoubleClickEvent don't called under Ubuntu
-  if ( ev->type() == QEvent::MouseButtonDblClick ) {
-    QMouseEvent * mev = static_cast< QMouseEvent * >( ev );
-    if ( mev->y() >= tabBar()->rect().y() && mev->y() <= tabBar()->rect().y() + tabBar()->rect().height()
-         && tabBar()->tabAt( mev->pos() ) == -1 ) {
-      emit doubleClicked();
-      return true;
-    }
-  }
-
   if ( obj == tabBar() && ev->type() == QEvent::MouseButtonPress ) {
     QMouseEvent * mev = static_cast< QMouseEvent * >( ev );
     if ( mev->button() == Qt::MiddleButton ) {

--- a/src/ui/maintabwidget.hh
+++ b/src/ui/maintabwidget.hh
@@ -23,12 +23,6 @@ public:
   }
   void setHideSingleTab( bool hide );
 
-signals:
-  void doubleClicked();
-
-protected:
-  //  virtual void mouseDoubleClickEvent ( QMouseEvent * event );
-
 private:
   virtual void tabInserted( int index );
   virtual void tabRemoved( int index );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -636,13 +636,11 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   connect( &addTab, &QAbstractButton::clicked, this, &MainWindow::addNewTab );
 
-  connect( ui.tabWidget,
-           &MainTabWidget::tabBarDoubleClicked,
-           [this]( const int index ) {
-             if ( -1 == index ) { // empty space at tabbar clicked.
-               this->addNewTab();
-             }
-           } );
+  connect( ui.tabWidget, &MainTabWidget::tabBarDoubleClicked, [ this ]( const int index ) {
+    if ( -1 == index ) { // empty space at tabbar clicked.
+      this->addNewTab();
+    }
+  } );
 
   connect( ui.tabWidget, &QTabWidget::tabCloseRequested, this, &MainWindow::tabCloseRequested );
 

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -636,7 +636,13 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   connect( &addTab, &QAbstractButton::clicked, this, &MainWindow::addNewTab );
 
-  connect( ui.tabWidget, &MainTabWidget::doubleClicked, this, &MainWindow::addNewTab );
+  connect( ui.tabWidget,
+           &MainTabWidget::tabBarDoubleClicked,
+           [this]( const int index ) {
+             if ( -1 == index ) { // empty space at tabbar clicked.
+               this->addNewTab();
+             }
+           } );
 
   connect( ui.tabWidget, &QTabWidget::tabCloseRequested, this, &MainWindow::tabCloseRequested );
 


### PR DESCRIPTION
The signal `doubleClicked` has been in Qt since Qt5.2

Found during https://github.com/xiaoyifang/goldendict-ng/pull/1418

To test: double click empty space at tabbar -> new tab 