### PR TITLE
fix: a crash when qrcx:// fails.

### DIFF
--- a/src/resourceschemehandler.cc
+++ b/src/resourceschemehandler.cc
@@ -12,7 +12,12 @@ void ResourceSchemeHandler::requestStarted( QWebEngineUrlRequestJob * requestJob
   const QMimeType mineType                    = db.mimeTypeForUrl( url );
   const sptr< Dictionary::DataRequest > reply = this->mManager.getResource( url, content_type );
   content_type                                = mineType.name();
-  if ( reply->isFinished() ) {
+
+  if ( reply == nullptr ) {
+    qDebug() << "Resource failed to load: " << url.toString();
+    requestJob->fail( QWebEngineUrlRequestJob::RequestFailed );
+  }
+  else if ( reply->isFinished() ) {
     replyJob( reply, requestJob, content_type );
   }
   else


### PR DESCRIPTION
Fix https://forum.freemdict.com/t/topic/11495/3175

The crash related code can also be found at https://github.com/yozhic/GoldenDict-Full-Dark-Theme/blob/54b1cf8b8c744f8aae7479995ce9538d5761ab91/GoldenDict/styles/Dark-Deep/article-style.css#L422-L437

A few lines above  `this->mManager.getResource( url, content_type )`may return `{}`.

Crash stack trace:

![image](https://github.com/xiaoyifang/goldendict-ng/assets/20123683/725e2c78-a93a-47a1-906a-061222b82ed1)