### PR TITLE
clean: remove macOS unused code related to gestures

### DIFF
--- a/src/gestures.cc
+++ b/src/gestures.cc
@@ -1,6 +1,6 @@
 /* This file is (c) 2014 Abs62
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
-
+#ifndef __APPLE__
 #include <QTouchEvent>
 #include <QSwipeGesture>
 #include <QVariant>
@@ -351,3 +351,5 @@ void unregisterRecognizers()
 }
 
 } // namespace Gestures
+
+#endif

--- a/src/gestures.cc
+++ b/src/gestures.cc
@@ -1,12 +1,12 @@
 /* This file is (c) 2014 Abs62
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 #ifndef __APPLE__
-#include <QTouchEvent>
-#include <QSwipeGesture>
-#include <QVariant>
-#include <math.h>
-#include "ui/articleview.hh"
-#include "gestures.hh"
+  #include <QTouchEvent>
+  #include <QSwipeGesture>
+  #include <QVariant>
+  #include <math.h>
+  #include "ui/articleview.hh"
+  #include "gestures.hh"
 
 namespace Gestures {
 

--- a/src/gestures.hh
+++ b/src/gestures.hh
@@ -1,6 +1,6 @@
-#ifndef __GESTURES_HH_INCLUDED__
-#define __GESTURES_HH_INCLUDED__
+#pragma once
 
+#ifndef __APPLE__
 #include <QGestureRecognizer>
 #include <QGesture>
 #include <QTimer>
@@ -120,4 +120,5 @@ bool handleGestureEvent( QObject * obj, QEvent * event, GestureResult & result, 
 
 } // namespace Gestures
 
-#endif // __GESTURES_HH_INCLUDED__
+
+#endif

--- a/src/gestures.hh
+++ b/src/gestures.hh
@@ -1,11 +1,11 @@
 #pragma once
 
 #ifndef __APPLE__
-#include <QGestureRecognizer>
-#include <QGesture>
-#include <QTimer>
-#include <QEvent>
-#include <QAction>
+  #include <QGestureRecognizer>
+  #include <QGesture>
+  #include <QTimer>
+  #include <QEvent>
+  #include <QAction>
 
 namespace Gestures {
 

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -250,10 +250,10 @@ ArticleView::ArticleView( QWidget * parent,
   webview->setHtml( QString::fromStdString( html ) );
 
   expandOptionalParts = cfg.preferences.alwaysExpandOptionalParts;
-
+#ifndef Q_OS_MACOS
   webview->grabGesture( Gestures::GDPinchGestureType );
   webview->grabGesture( Gestures::GDSwipeGestureType );
-
+#endif
   // Variable name for store current selection range
   rangeVarName = QString( "sr_%1" ).arg( QString::number( (quint64)this, 16 ) );
 
@@ -300,8 +300,10 @@ ArticleView::~ArticleView()
   cleanupTemp();
   audioPlayer->stop();
   //channel->deregisterObject(this);
+#ifndef Q_OS_MACOS
   webview->ungrabGesture( Gestures::GDPinchGestureType );
   webview->ungrabGesture( Gestures::GDSwipeGestureType );
+#endif
 }
 
 void ArticleView::showDefinition( QString const & word,
@@ -724,7 +726,6 @@ bool ArticleView::eventFilter( QObject * obj, QEvent * ev )
 
     return handled;
   }
-#endif
 
   if ( ev->type() == QEvent::MouseMove ) {
     if ( Gestures::isFewTouchPointsPresented() ) {
@@ -732,6 +733,7 @@ bool ArticleView::eventFilter( QObject * obj, QEvent * ev )
       return true;
     }
   }
+#endif
 
   if ( handleF3( obj, ev ) ) {
     return true;

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -905,9 +905,10 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   wasMaximized = isMaximized();
 
   history.setSaveInterval( cfg.preferences.historyStoreInterval );
-
+#ifndef Q_OS_MACOS
   ui.centralWidget->grabGesture( Gestures::GDPinchGestureType );
   ui.centralWidget->grabGesture( Gestures::GDSwipeGestureType );
+#endif
 
   if ( layoutDirection() == Qt::RightToLeft ) {
     // Adjust button icons for Right-To-Left layout
@@ -1158,9 +1159,10 @@ MainWindow::~MainWindow()
   closeHeadwordsDialog();
 
   ftsIndexing.stopIndexing();
-
+#ifndef Q_OS_MACOS
   ui.centralWidget->ungrabGesture( Gestures::GDPinchGestureType );
   ui.centralWidget->ungrabGesture( Gestures::GDSwipeGestureType );
+#endif
   //  Gestures::unregisterRecognizers();
 
   // Close all tabs -- they should be destroyed before network managers

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -251,8 +251,10 @@ ScanPopup::ScanPopup( QWidget * parent,
   ui.goBackButton->setEnabled( false );
   ui.goForwardButton->setEnabled( false );
 
+#ifndef Q_OS_MACOS
   grabGesture( Gestures::GDPinchGestureType );
   grabGesture( Gestures::GDSwipeGestureType );
+#endif
 
 #ifdef HAVE_X11
   scanFlag = new ScanFlag( this );
@@ -303,9 +305,10 @@ void ScanPopup::refresh()
 ScanPopup::~ScanPopup()
 {
   saveConfigData();
-
+#ifndef Q_OS_MACOS
   ungrabGesture( Gestures::GDPinchGestureType );
   ungrabGesture( Gestures::GDSwipeGestureType );
+#endif
 }
 
 void ScanPopup::saveConfigData() const


### PR DESCRIPTION
There were various complaints about the interference between gestures.cc and QtWebEngine's native gestures on macOS.

Someone else disabled gesture.cc on macOS a long time ago https://github.com/xiaoyifang/goldendict-ng/pull/35

This PR removes useless code and disables compilation of gesture.cc on macOS.

Previously, https://github.com/xiaoyifang/goldendict-ng/pull/1407