### PR TITLE
fix: CMake problems found by the openBSD package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ cmake_minimum_required(VERSION 3.25) # ubuntu 23.04 Fedora 36
 
 option(WITH_FFMPEG_PLAYER "Enable support for FFMPEG player" ON)
 option(WITH_EPWING_SUPPORT "Enable epwing support" ON)
-option(WITH_XAPIAN "enable Xapian support" ON)
 option(WITH_ZIM "enable zim support" ON)
 option(WITH_TTS "enable QTexttoSpeech support" ON)
 
@@ -36,18 +35,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 #### Qt
 
-find_package(Qt6 REQUIRED COMPONENTS
-        Concurrent
-        Core5Compat
-        LinguistTools
-        Multimedia
-        PrintSupport
-        WebEngineWidgets
-        Widgets
-        Svg
-        Xml
-        TextToSpeech
-        )
+set(GD_QT_COMPONENTS Concurrent Core5Compat LinguistTools Multimedia PrintSupport WebEngineWidgets Widgets Svg Xml)
+
+if (WITH_TTS)
+    list(APPEND GD_QT_COMPONENTS TextToSpeech)
+endif ()
+
+find_package(Qt6 REQUIRED COMPONENTS ${GD_QT_COMPONENTS})
 
 qt_standard_project_setup() # availiable after find_package(Qt6 .... Core
 set(CMAKE_AUTORCC ON) # not included in the qt_standard_project_setup
@@ -130,9 +124,11 @@ target_link_libraries(${GOLDENDICT} PRIVATE
         Qt6::WebEngineWidgets
         Qt6::Widgets
         Qt6::Svg
-        Qt6::TextToSpeech
         )
 
+if (WITH_TTS)
+    target_link_libraries(${GOLDENDICT} PRIVATE Qt6::TextToSpeech)
+endif ()
 
 target_include_directories(${GOLDENDICT} PRIVATE
         ${PROJECT_SOURCE_DIR}/thirdparty/qtsingleapplication/src
@@ -170,11 +166,6 @@ endif()
 
 if (NOT WITH_EPWING_SUPPORT)
     target_compile_definitions(${GOLDENDICT} PUBLIC NO_EPWING_SUPPORT)
-endif ()
-
-
-if (WITH_XAPIAN)
-    target_compile_definitions(${GOLDENDICT} PUBLIC USE_XAPIAN)
 endif ()
 
 if (WITH_ZIM)

--- a/CMake_Unix.cmake
+++ b/CMake_Unix.cmake
@@ -28,12 +28,9 @@ endif ()
 
 ##### Finding packages from package manager
 
-
 find_package(PkgConfig REQUIRED)
-# Provided by Cmake
 find_package(ZLIB REQUIRED)
 find_package(BZip2 REQUIRED)
-
 
 # Consider all PkgConfig dependencies as one
 pkg_check_modules(PKGCONFIG_DEPS IMPORTED_TARGET
@@ -43,7 +40,8 @@ pkg_check_modules(PKGCONFIG_DEPS IMPORTED_TARGET
         vorbis # .ogg
         vorbisfile
         liblzma
-        )
+        xapian-core
+)
 
 target_link_libraries(${GOLDENDICT} PRIVATE
         PkgConfig::PKGCONFIG_DEPS
@@ -69,13 +67,8 @@ if (WITH_FFMPEG_PLAYER)
             libavformat
             libavutil
             libswresample
-            )
+    )
     target_link_libraries(${GOLDENDICT} PRIVATE PkgConfig::FFMPEG)
-endif ()
-
-if (WITH_XAPIAN)
-    find_package(Xapian REQUIRED) # https://github.com/xapian/xapian/tree/master/xapian-core/cmake
-    target_link_libraries(${GOLDENDICT} PRIVATE ${XAPIAN_LIBRARIES})
 endif ()
 
 if (WITH_EPWING_SUPPORT)

--- a/src/config.cc
+++ b/src/config.cc
@@ -845,7 +845,7 @@ Class load()
     // Upgrading
     c.dictServers = makeDefaultDictServers();
   }
-
+#ifndef NO_TTS_SUPPORT
   QDomNode ves = root.namedItem( "voiceEngines" );
 
   if ( !ves.isNull() ) {
@@ -872,6 +872,7 @@ Class load()
       c.voiceEngines.push_back( v );
     }
   }
+#endif
 
   c.mutedDictionaries      = loadMutedDictionaries( root.namedItem( "mutedDictionaries" ) );
   c.popupMutedDictionaries = loadMutedDictionaries( root.namedItem( "popupMutedDictionaries" ) );
@@ -1664,7 +1665,7 @@ void save( Class const & c )
       p.setAttributeNode( icon );
     }
   }
-
+#ifndef NO_TTS_SUPPORT
   {
     QDomNode ves = dd.createElement( "voiceEngines" );
     root.appendChild( ves );
@@ -1706,6 +1707,7 @@ void save( Class const & c )
       v.setAttributeNode( rate );
     }
   }
+#endif
 
   {
     QDomElement muted = dd.createElement( "mutedDictionaries" );

--- a/src/config.hh
+++ b/src/config.hh
@@ -779,6 +779,7 @@ struct Program
 
 typedef QVector< Program > Programs;
 
+#ifndef NO_TTS_SUPPORT
 struct VoiceEngine
 {
   bool enabled;
@@ -823,6 +824,7 @@ struct VoiceEngine
 };
 
 typedef QVector< VoiceEngine > VoiceEngines;
+#endif
 
 struct HeadwordsDialog
 {
@@ -856,7 +858,9 @@ struct Class
   Lingua lingua;
   Forvo forvo;
   Programs programs;
+#ifndef NO_TTS_SUPPORT
   VoiceEngines voiceEngines;
+#endif
 
   unsigned lastMainGroupId;  // Last used group in main window
   unsigned lastPopupGroupId; // Last used group in popup window

--- a/src/dict/loaddictionaries.cc
+++ b/src/dict/loaddictionaries.cc
@@ -269,7 +269,9 @@ void loadDictionaries( QWidget * parent,
   addDicts( Forvo::makeDictionaries( loadDicts, cfg.forvo, dictNetMgr ) );
   addDicts( Lingua::makeDictionaries( loadDicts, cfg.lingua, dictNetMgr ) );
   addDicts( Programs::makeDictionaries( cfg.programs ) );
+#ifndef NO_TTS_SUPPORT
   addDicts( VoiceEngines::makeDictionaries( cfg.voiceEngines ) );
+#endif
   addDicts( DictServer::makeDictionaries( cfg.dictServers ) );
 
 

--- a/src/dict/sources.cc
+++ b/src/dict/sources.cc
@@ -16,7 +16,9 @@ Sources::Sources( QWidget * parent, Config::Class const & cfg ):
 #ifdef MAKE_CHINESE_CONVERSION_SUPPORT
   chineseConversion( new ChineseConversion( this, cfg.transliteration.chinese ) ),
 #endif
+#ifndef NO_TTS_SUPPORT
   textToSpeechSource( nullptr ),
+#endif
   itemDelegate( new QItemDelegate( this ) ),
   itemEditorFactory( new QItemEditorFactory() ),
   mediawikisModel( this, cfg.mediawikis ),
@@ -317,12 +319,14 @@ void Sources::on_removeProgram_clicked()
     programsModel.removeProgram( current.row() );
 }
 
+#ifndef NO_TTS_SUPPORT
 Config::VoiceEngines Sources::getVoiceEngines() const
 {
   if ( !textToSpeechSource )
     return Config::VoiceEngines();
   return textToSpeechSource->getVoiceEnginesModel().getCurrentVoiceEngines();
 }
+#endif
 
 Config::Hunspell Sources::getHunspell() const
 {

--- a/src/dict/sources.hh
+++ b/src/dict/sources.hh
@@ -296,9 +296,9 @@ public:
   {
     return programsModel.getCurrentPrograms();
   }
-
+#ifndef NO_TTS_SUPPORT
   Config::VoiceEngines getVoiceEngines() const;
-
+#endif
   Config::Hunspell getHunspell() const;
 
   Config::Transliteration getTransliteration() const;
@@ -318,9 +318,9 @@ private:
 #ifdef MAKE_CHINESE_CONVERSION_SUPPORT
   ChineseConversion * chineseConversion;
 #endif
-
+#ifndef NO_TTS_SUPPORT
   TextToSpeechSource * textToSpeechSource;
-
+#endif
   QItemDelegate * itemDelegate;
   QScopedPointer< QItemEditorFactory > itemEditorFactory;
 

--- a/src/dict/voiceengines.cc
+++ b/src/dict/voiceengines.cc
@@ -1,5 +1,6 @@
 /* This file is (c) 2013 Timon Wong <timon86.wang@gmail.com>
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
+#ifndef NO_TTS_SUPPORT
 
 #include "voiceengines.hh"
 #include "audiolink.hh"
@@ -137,3 +138,5 @@ vector< sptr< Dictionary::Class > > makeDictionaries( Config::VoiceEngines const
 }
 
 } // namespace VoiceEngines
+
+#endif

--- a/src/dict/voiceengines.cc
+++ b/src/dict/voiceengines.cc
@@ -2,20 +2,20 @@
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 #ifndef NO_TTS_SUPPORT
 
-#include "voiceengines.hh"
-#include "audiolink.hh"
-#include "htmlescape.hh"
-#include "utf8.hh"
-#include "wstring_qt.hh"
+  #include "voiceengines.hh"
+  #include "audiolink.hh"
+  #include "htmlescape.hh"
+  #include "utf8.hh"
+  #include "wstring_qt.hh"
 
-#include <string>
-#include <map>
+  #include <string>
+  #include <map>
 
-#include <QDir>
-#include <QFileInfo>
-#include <QCryptographicHash>
+  #include <QDir>
+  #include <QFileInfo>
+  #include <QCryptographicHash>
 
-#include "utils.hh"
+  #include "utils.hh"
 
 namespace VoiceEngines {
 

--- a/src/dict/voiceengines.hh
+++ b/src/dict/voiceengines.hh
@@ -1,8 +1,7 @@
 /* This file is (c) 2013 Timon Wong <timon86.wang@gmail.com>
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
-
-#ifndef __VOICEENGINES_HH_INCLUDED__
-#define __VOICEENGINES_HH_INCLUDED__
+#pragma once
+#ifndef NO_TTS_SUPPORT
 
 #include "dictionary.hh"
 #include "config.hh"

--- a/src/dict/voiceengines.hh
+++ b/src/dict/voiceengines.hh
@@ -3,11 +3,11 @@
 #pragma once
 #ifndef NO_TTS_SUPPORT
 
-#include "dictionary.hh"
-#include "config.hh"
-#include "wstring.hh"
+  #include "dictionary.hh"
+  #include "config.hh"
+  #include "wstring.hh"
 
-#include <QCryptographicHash>
+  #include <QCryptographicHash>
 
 
 namespace VoiceEngines {

--- a/src/main.cc
+++ b/src/main.cc
@@ -488,7 +488,9 @@ int main( int argc, char ** argv )
 
   if ( gdcl.notts ) {
     cfg.notts = true;
+#ifndef NO_TTS_SUPPORT
     cfg.voiceEngines.clear();
+#endif
   }
 
   cfg.resetState = gdcl.resetState;

--- a/src/speechclient.cc
+++ b/src/speechclient.cc
@@ -1,10 +1,10 @@
 #ifndef NO_TTS_SUPPORT
 
-#include "speechclient.hh"
+  #include "speechclient.hh"
 
-#include <QtCore>
-#include <QLocale>
-#include <QDebug>
+  #include <QtCore>
+  #include <QLocale>
+  #include <QDebug>
 SpeechClient::SpeechClient( Config::VoiceEngine const & e, QObject * parent ):
   QObject( parent ),
   internalData( new InternalData( e ) )

--- a/src/speechclient.cc
+++ b/src/speechclient.cc
@@ -1,3 +1,5 @@
+#ifndef NO_TTS_SUPPORT
+
 #include "speechclient.hh"
 
 #include <QtCore>
@@ -67,3 +69,5 @@ bool SpeechClient::tell( QString const & text ) const
 {
   return tell( text, internalData->engine.volume, internalData->engine.rate );
 }
+
+#endif

--- a/src/speechclient.hh
+++ b/src/speechclient.hh
@@ -1,5 +1,5 @@
-#ifndef __SPEECHCLIENT_HH_INCLUDED__
-#define __SPEECHCLIENT_HH_INCLUDED__
+#pragma once
+#ifndef NO_TTS_SUPPORT
 
 #include <QObject>
 #include "config.hh"
@@ -81,4 +81,4 @@ private:
   QSharedPointer< InternalData > internalData;
 };
 
-#endif // __SPEECHCLIENT_HH_INCLUDED__
+#endif

--- a/src/speechclient.hh
+++ b/src/speechclient.hh
@@ -1,12 +1,12 @@
 #pragma once
 #ifndef NO_TTS_SUPPORT
 
-#include <QObject>
-#include "config.hh"
-#include <QTextToSpeech>
-#include <memory>
-#include <QDebug>
-#include <QSharedPointer>
+  #include <QObject>
+  #include "config.hh"
+  #include <QTextToSpeech>
+  #include <memory>
+  #include <QDebug>
+  #include <QSharedPointer>
 
 class SpeechClient: public QObject
 {

--- a/src/texttospeechsource.cc
+++ b/src/texttospeechsource.cc
@@ -1,5 +1,6 @@
 /* This file is (c) 2013 Timon Wong <timon86.wang@gmail.com>
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
+#ifndef NO_TTS_SUPPORT
 
 #include "texttospeechsource.hh"
 #include <QVariant>
@@ -431,3 +432,5 @@ void VoiceEngineItemDelegate::setModelData( QWidget * uncastedEditor,
   model->setData( engineIdIndex, editor->engineId() );
   model->setData( engineNameIndex, editor->engineName() );
 }
+
+#endif

--- a/src/texttospeechsource.cc
+++ b/src/texttospeechsource.cc
@@ -2,10 +2,10 @@
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 #ifndef NO_TTS_SUPPORT
 
-#include "texttospeechsource.hh"
-#include <QVariant>
-#include <QMessageBox>
-#include <memory>
+  #include "texttospeechsource.hh"
+  #include <QVariant>
+  #include <QMessageBox>
+  #include <memory>
 
 TextToSpeechSource::TextToSpeechSource( QWidget * parent, Config::VoiceEngines voiceEngines ):
   QWidget( parent ),

--- a/src/texttospeechsource.hh
+++ b/src/texttospeechsource.hh
@@ -1,8 +1,9 @@
 /* This file is (c) 2013 Timon Wong <timon86.wang@gmail.com>
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
-#ifndef __TEXTTOSPEECHSOURCE_HH_INCLUDED__
-#define __TEXTTOSPEECHSOURCE_HH_INCLUDED__
+#pragma once
+
+#ifndef NO_TTS_SUPPORT
 
 #include "ui_texttospeechsource.h"
 #include "config.hh"
@@ -116,4 +117,4 @@ private:
   void adjustSliders();
 };
 
-#endif // __TEXTTOSPEECHSOURCE_HH_INCLUDED__
+#endif

--- a/src/texttospeechsource.hh
+++ b/src/texttospeechsource.hh
@@ -5,12 +5,12 @@
 
 #ifndef NO_TTS_SUPPORT
 
-#include "ui_texttospeechsource.h"
-#include "config.hh"
-#include "speechclient.hh"
+  #include "ui_texttospeechsource.h"
+  #include "config.hh"
+  #include "speechclient.hh"
 
-#include <QComboBox>
-#include <QStyledItemDelegate>
+  #include <QComboBox>
+  #include <QStyledItemDelegate>
 
 /// A model to be projected into the text to speech view, according to Qt's MVC model
 class VoiceEnginesModel: public QAbstractItemModel

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -1182,6 +1182,7 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref, QString const & 
     QMessageBox::critical( this, "GoldenDict", tr( "The referenced audio program doesn't exist." ) );
   }
   else if ( url.scheme() == "gdtts" ) {
+#ifndef NO_TTS_SUPPORT
     // Text to speech
     QString md5Id = Utils::Url::queryItemValue( url, "engine" );
     QString text( url.path().mid( 1 ) );
@@ -1197,7 +1198,11 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref, QString const & 
         break;
       }
     }
+#else
+    qDebug() << "gdtts:// is not supported due to missing TTS support";
+#endif
   }
+
   else if ( Utils::isExternalLink( url ) ) {
     // Use the system handler for the conventional external links
     QDesktopServices::openUrl( url );

--- a/src/ui/editdictionaries.cc
+++ b/src/ui/editdictionaries.cc
@@ -175,7 +175,7 @@ bool EditDictionaries::isSourcesChanged() const
 #ifndef NO_TTS_SUPPORT
     || sources.getVoiceEngines() != cfg.voiceEngines
 #endif
-  ;
+    ;
 }
 
 void EditDictionaries::acceptChangedSources( bool rebuildGroups )

--- a/src/ui/editdictionaries.cc
+++ b/src/ui/editdictionaries.cc
@@ -171,7 +171,11 @@ bool EditDictionaries::isSourcesChanged() const
     || sources.getHunspell() != cfg.hunspell || sources.getTransliteration() != cfg.transliteration
     || sources.getLingua() != cfg.lingua || sources.getForvo() != cfg.forvo || sources.getMediaWikis() != cfg.mediawikis
     || sources.getWebSites() != cfg.webSites || sources.getDictServers() != cfg.dictServers
-    || sources.getPrograms() != cfg.programs || sources.getVoiceEngines() != cfg.voiceEngines;
+    || sources.getPrograms() != cfg.programs
+#ifndef NO_TTS_SUPPORT
+    || sources.getVoiceEngines() != cfg.voiceEngines
+#endif
+  ;
 }
 
 void EditDictionaries::acceptChangedSources( bool rebuildGroups )
@@ -192,8 +196,9 @@ void EditDictionaries::acceptChangedSources( bool rebuildGroups )
   cfg.webSites        = sources.getWebSites();
   cfg.dictServers     = sources.getDictServers();
   cfg.programs        = sources.getPrograms();
+#ifndef NO_TTS_SUPPORT
   cfg.voiceEngines    = sources.getVoiceEngines();
-
+#endif
   ui.tabs->setUpdatesEnabled( false );
   // Those hold pointers to dictionaries, we need to free them.
   groupInstances.clear();

--- a/src/version.hh
+++ b/src/version.hh
@@ -5,7 +5,6 @@
 namespace Version {
 
 const QLatin1String flags = QLatin1String(
-  "USE_XAPIAN"
 #ifdef MAKE_ZIM_SUPPORT
   " MAKE_ZIM_SUPPORT"
 #endif


### PR DESCRIPTION
* remove unused WITH_XAPIAN option
* don't link Qt TTS if not requested

Also disable some code that does useless things when Qt TTS is not enabled.

See the comments here: https://github.com/openbsd/ports/blob/971a335e5114e2b952d8f491af87b97c897914d7/textproc/goldendict-ng/Makefile#L55-L63 by @klemensn (sorry for unnecessary troubles.)
