### PR TITLE
fix: crash when clicking audio insanely fast.

### DIFF
--- a/src/ffmpegaudio.hh
+++ b/src/ffmpegaudio.hh
@@ -29,7 +29,7 @@ class DecoderThread;
 class AudioService: public QObject
 {
   Q_OBJECT
-  std::shared_ptr< DecoderThread > thread;
+  QScopedPointer< DecoderThread > thread;
 
 public:
   static AudioService & instance();


### PR DESCRIPTION
This can prevent crash of https://github.com/xiaoyifang/goldendict-ng/issues/1423

There are 2 problems

* QThread unfinished before creating a new one.
* audioOutput may fail to construct (???? I don't know how yet. `AudioOutputPrivate` seems to have some special internal). 

This works, but I am not sure how to fix this perfectly yet.

---

I think the original code was to spawn multiple audio simultaneously, which makes no sense to humans as nobody can hear mix audios.

So there will be one and only one working audio thread, right?