### PR TITLE
fix: "Open Image in System Viewer" doesn't work on macOS

### DIFF
--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -1792,11 +1792,11 @@ void ArticleView::contextMenuRequested( QPoint const & pos )
 
         if ( !handler->isEmpty() ) {
           connect( handler, &ResourceToSaveHandler::done, this, [ fileName ]() {
-            QDesktopServices::openUrl( fileName );
+            QDesktopServices::openUrl( QUrl::fromLocalFile( fileName ) );
           } );
         }
         else {
-          QDesktopServices::openUrl( fileName );
+          QDesktopServices::openUrl( QUrl::fromLocalFile( fileName ) );
         }
       }
     }


### PR DESCRIPTION
fix: https://forum.freemdict.com/t/topic/11495/3118

macOS doesn't consider `/path/a.jpg` as a URL. Only `file:///path/a.jpg` is valid.

---

The parameter of `QDesktopServices::openUrl` is `QUrl`, the old code implicitly converts the path String to QUrl. 

https://github.com/xiaoyifang/goldendict-ng/assets/20123683/fe36ea53-b597-44e7-80e8-0115e1db33ff



