### PR TITLE
fix: macos build

### DIFF
--- a/.github/workflows/macos-arm-homebrew.yml
+++ b/.github/workflows/macos-arm-homebrew.yml
@@ -47,7 +47,7 @@ jobs:
           brew install autoconf
           brew install libtool
           brew install opencc
-          brew install automake git lame libass libtool shtool texi2html theora wget xvid nasm
+          brew install automake libtool
 
           brew install libiconv
           brew install lzo bzip2

--- a/.github/workflows/macos-homebrew.yml
+++ b/.github/workflows/macos-homebrew.yml
@@ -47,7 +47,7 @@ jobs:
           brew install autoconf
           brew install libtool
           brew install opencc
-          brew install automake git lame libass libtool shtool texi2html theora wget xvid nasm
+          brew install automake libtool
 
           brew install libiconv
           brew install lzo bzip2


### PR DESCRIPTION
github action failed with:

```
==> git
The Tcl/Tk GUIs (e.g. gitk, git-gui) are now in the `git-gui` formula.
Subversion interoperability (git-svn) is now in the `git-svn` formula.

Bash completion has been installed to:
  /usr/local/etc/bash_completion.d
Error: Process completed with exit code 1.
```