### PR TITLE
clean: remove unnecessary passing of openSearchAction to ArticleView's ctor

### DIFF
--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -94,7 +94,6 @@ ArticleView::ArticleView( QWidget * parent,
                           Instances::Groups const & groups_,
                           bool popupView_,
                           Config::Class const & cfg_,
-                          QAction & openSearchAction_,
                           QLineEdit const * translateLine_,
                           QAction * dictionaryBarToggled_,
                           GroupComboBox const * groupComboBox_ ):
@@ -113,7 +112,6 @@ ArticleView::ArticleView( QWidget * parent,
   selectCurrentArticleAction( this ),
   copyAsTextAction( this ),
   inspectAction( this ),
-  openSearchAction( openSearchAction_ ),
   searchIsOpened( false ),
   dictionaryBarToggled( dictionaryBarToggled_ ),
   groupComboBox( groupComboBox_ ),
@@ -200,9 +198,6 @@ ArticleView::ArticleView( QWidget * parent,
   articleDownAction.setShortcut( QKeySequence( "Alt+Down" ) );
   webview->addAction( &articleDownAction );
   connect( &articleDownAction, &QAction::triggered, this, &ArticleView::moveOneArticleDown );
-
-  webview->addAction( &openSearchAction );
-  connect( &openSearchAction, &QAction::triggered, this, &ArticleView::openSearch );
 
   selectCurrentArticleAction.setShortcut( QKeySequence( "Ctrl+Shift+A" ) );
   selectCurrentArticleAction.setText( tr( "Select Current Article" ) );

--- a/src/ui/articleview.hh
+++ b/src/ui/articleview.hh
@@ -49,7 +49,6 @@ class ArticleView: public QWidget
 
   QAction pasteAction, articleUpAction, articleDownAction, goBackAction, goForwardAction, selectCurrentArticleAction,
     copyAsTextAction, inspectAction;
-  QAction & openSearchAction;
   bool searchIsOpened;
   bool expandOptionalParts;
   QString rangeVarName;
@@ -105,7 +104,6 @@ public:
                Instances::Groups const &,
                bool popupView,
                Config::Class const & cfg,
-               QAction & openSearchAction_,
                QLineEdit const * translateLine,
                QAction * dictionaryBarToggled      = nullptr,
                GroupComboBox const * groupComboBox = nullptr );
@@ -319,6 +317,9 @@ signals:
 
 public slots:
 
+  /// Opens the search (Ctrl+F)
+  void openSearch();
+
   void on_searchPrevious_clicked();
   void on_searchNext_clicked();
 
@@ -360,9 +361,6 @@ private slots:
 
   /// Nagivates to the next article relative to the active one.
   void moveOneArticleDown();
-
-  /// Opens the search area
-  void openSearch();
 
   void on_searchText_textEdited();
   void on_searchText_returnPressed();

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1783,7 +1783,6 @@ ArticleView * MainWindow::createNewTab( bool switchToIt, QString const & name )
                                         groupInstances,
                                         false,
                                         cfg,
-                                        *ui.searchInPageAction,
                                         translateLine,
                                         dictionaryBar.toggleViewAction(),
                                         groupList );
@@ -1822,6 +1821,8 @@ ArticleView * MainWindow::createNewTab( bool switchToIt, QString const & name )
 
   connect( view, &ArticleView::zoomOut, this, &MainWindow::zoomout );
   connect( view, &ArticleView::saveBookmarkSignal, this, &MainWindow::addBookmarkToFavorite );
+
+  connect( ui.searchInPageAction, &QAction::triggered, view, &ArticleView::openSearch );
 
   view->setSelectionBySingleClick( cfg.preferences.selectWordBySingleClick );
 

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -85,8 +85,6 @@ ScanPopup::ScanPopup( QWidget * parent,
 {
   ui.setupUi( this );
 
-  openSearchAction.setShortcut( QKeySequence( "Ctrl+F" ) );
-
   if ( layoutDirection() == Qt::RightToLeft ) {
     // Adjust button icons for Right-To-Left layout
     ui.goBackButton->setIcon( QIcon( ":/icons/next.svg" ) );
@@ -104,7 +102,6 @@ ScanPopup::ScanPopup( QWidget * parent,
                                 groups,
                                 true,
                                 cfg,
-                                openSearchAction,
                                 ui.translateBox->translateLine(),
                                 dictionaryBar.toggleViewAction() );
 
@@ -113,6 +110,9 @@ ScanPopup::ScanPopup( QWidget * parent,
   connect( this, &ScanPopup::closeMenu, definition, &ArticleView::closePopupMenu );
   connect( definition, &ArticleView::sendWordToHistory, this, &ScanPopup::sendWordToHistory );
   connect( definition, &ArticleView::typingEvent, this, &ScanPopup::typingEvent );
+
+  openSearchAction.setShortcut( QKeySequence( "Ctrl+F" ) );
+  connect( &openSearchAction, &QAction::triggered, definition, &ArticleView::openSearch );
 
   wordListDefaultFont      = ui.translateBox->completerWidget()->font();
   translateLineDefaultFont = ui.translateBox->font();


### PR DESCRIPTION
The original code had to inject `openSearchAction` into `ArticleView` and keep a reference is because the `openSearch` slot was private.

Just connect, rather than inject and connect.