### PR TITLE
fix: url handler and encoded ACE / Punycode / percent encoded URLs

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -301,6 +301,24 @@ void processCommandLine( QCoreApplication * app, GDOptions * result )
         result->word.chop( 1 );
       }
     }
+
+    // Handle cases where we get encoded URL
+    if ( result->word.startsWith( QStringLiteral( "xn--" ) ) ) {
+      // For `kde-open` or `gio` or others, URL are encoded into ACE or Punycode
+  #if QT_VERSION >= QT_VERSION_CHECK( 6, 3, 0 )
+      result->word = QUrl::fromAce( result->word.toLatin1(), QUrl::IgnoreIDNWhitelist );
+  #else
+      // Old Qt's fromAce only applies to whitelisted domains, so we add .com to bypass this restriction :)
+      // https://bugreports.qt.io/browse/QTBUG-29080
+      result->word.append( QStringLiteral( ".com" ) );
+      result->word = QUrl::fromAce( result->word.toLatin1() );
+      result->word.chop( 4 );
+  #endif
+    }
+    else if ( result->word.startsWith( QStringLiteral( "%" ) ) ) {
+      // For Firefox or other browsers where URL are percent encoded
+      result->word = QUrl::fromPercentEncoding( result->word.toLatin1() );
+    }
 #endif
   }
 }


### PR DESCRIPTION
fix: https://github.com/xiaoyifang/goldendict-ng/issues/1267

To test:
```sh
goldendict goldendict://xn--l8j
goldendict goldendict://%CE%BF%E1%BD%90%CE%B5%CF%84%CE%B5%CF%81%CE%B1%CE%BD%CF%8C%CF%82
```

Or modify the `Exec` of `/usr/share/applications/io.github.xiaoyifang.goldendict_ng.desktop` to new GD's location -> `sudo update-desktop-database`

Then try

```
gio open goldendict://%CE%BF%E1%BD%90%CE%B5%CF%84%CE%B5%CF%81%CE%B1%CE%BD%CF%8C%CF%82
kde-open goldendict://あ.
xdg-open goldendict://οὐετερανός

or open the url in browser.
```