### PR TITLE
clean: rename File::Class to what it is really used.

### DIFF
--- a/src/btreeidx.cc
+++ b/src/btreeidx.cc
@@ -50,7 +50,7 @@ string const & BtreeDictionary::ensureInitDone()
   return empty;
 }
 
-void BtreeIndex::openIndex( IndexInfo const & indexInfo, File::Class & file, QMutex & mutex )
+void BtreeIndex::openIndex( IndexInfo const & indexInfo, File::Index & file, QMutex & mutex )
 {
   indexNodeSize = indexInfo.btreeMaxElements;
   rootOffset    = indexInfo.rootOffset;
@@ -754,7 +754,7 @@ void BtreeIndex::antialias( wstring const & str, vector< WordArticleLink > & cha
 /// leaf nodes.
 static uint32_t buildBtreeNode( IndexedWords::const_iterator & nextIndex,
                                 size_t indexSize,
-                                File::Class & file,
+                                File::Index & file,
                                 size_t maxElements,
                                 uint32_t & lastLeafLinkOffset )
 {
@@ -984,7 +984,7 @@ void IndexedWords::addSingleWord( wstring const & index_word, uint32_t articleOf
   operator[]( Utf8::encode( folded ) ).emplace_back( Utf8::encode( word ), articleOffset );
 }
 
-IndexInfo buildIndex( IndexedWords const & indexedWords, File::Class & file )
+IndexInfo buildIndex( IndexedWords const & indexedWords, File::Index & file )
 {
   size_t indexSize = indexedWords.size();
   auto nextIndex   = indexedWords.begin();

--- a/src/btreeidx.hh
+++ b/src/btreeidx.hh
@@ -82,7 +82,7 @@ public:
   /// Opens the index. The file reference is saved to be used for
   /// subsequent lookups.
   /// The mutex is the one to be locked when working with the file.
-  void openIndex( IndexInfo const &, File::Class &, QMutex & );
+  void openIndex( IndexInfo const &, File::Index &, QMutex & );
 
   /// Finds articles that match the given string. A case-insensitive search
   /// is performed.
@@ -140,7 +140,7 @@ protected:
 protected:
 
   QMutex * idxFileMutex;
-  File::Class * idxFile;
+  File::Index * idxFile;
 
 private:
 
@@ -276,7 +276,7 @@ struct IndexedWords: public map< string, vector< WordArticleLink > >
 /// Builds the index, as a compressed btree. Returns IndexInfo.
 /// All the data is stored to the given file, beginning from its current
 /// position.
-IndexInfo buildIndex( IndexedWords const &, File::Class & file );
+IndexInfo buildIndex( IndexedWords const &, File::Index & file );
 
 } // namespace BtreeIndexing
 

--- a/src/chunkedstorage.cc
+++ b/src/chunkedstorage.cc
@@ -14,7 +14,7 @@ enum {
   ChunkMaxSize = 65536 // Can't be more since it would overflow the address
 };
 
-Writer::Writer( File::Class & f ):
+Writer::Writer( File::Index & f ):
   file( f ),
   chunkStarted( false ),
   bufferUsed( 0 )
@@ -115,7 +115,7 @@ uint32_t Writer::finish()
   return offset;
 }
 
-Reader::Reader( File::Class & f, uint32_t offset ):
+Reader::Reader( File::Index & f, uint32_t offset ):
   file( f )
 {
   file.seek( offset );

--- a/src/chunkedstorage.hh
+++ b/src/chunkedstorage.hh
@@ -31,11 +31,11 @@ DEF_EX( mapFailed, "Failed to map/unmap the file", Ex )
 class Writer
 {
   vector< uint32_t > offsets;
-  File::Class & file;
+  File::Index & file;
   size_t scratchPadOffset, scratchPadSize;
 
 public:
-  explicit Writer( File::Class & );
+  explicit Writer( File::Index & );
 
   /// Starts new block. Returns its address.
   uint32_t startNewBlock();
@@ -72,12 +72,12 @@ private:
 class Reader
 {
   vector< uint32_t > offsets;
-  File::Class & file;
+  File::Index & file;
 
 public:
   /// Creates reader by giving it a file to read from and the offset returned
   /// by Writer::finish().
-  Reader( File::Class &, uint32_t );
+  Reader( File::Index &, uint32_t );
 
   /// Reads the block previously written by Writer, identified by its address.
   /// Uses the user-provided storage to load the entire chunk, and then to

--- a/src/common/file.cc
+++ b/src/common/file.cc
@@ -35,13 +35,13 @@ bool tryPossibleZipName( std::string const & name, std::string & copyTo )
 
 void loadFromFile( std::string const & filename, std::vector< char > & data )
 {
-  File::Class f( filename, "rb" );
+  File::Index f( filename, "rb" );
   auto size = f.file().size(); // QFile::size() obtains size via statx on Linux
   data.resize( size );
   f.read( data.data(), size );
 }
 
-void Class::open( char const * mode )
+void Index::open( char const * mode )
 {
   QFile::OpenMode openMode = QIODevice::Text;
 
@@ -74,26 +74,26 @@ void Class::open( char const * mode )
     throw exCantOpen( f.fileName().toStdString() + ": " + f.errorString().toUtf8().data() );
 }
 
-Class::Class( std::string_view filename, char const * mode )
+Index::Index( std::string_view filename, char const * mode )
 {
   f.setFileName( QString::fromUtf8( filename.data(), filename.size() ) );
   open( mode );
 }
 
-void Class::read( void * buf, qint64 size )
+void Index::read( void * buf, qint64 size )
 {
   if ( f.read( static_cast< char * >( buf ), size ) != size ) {
     throw exReadError();
   }
 }
 
-size_t Class::readRecords( void * buf, qint64 size, qint64 count )
+size_t Index::readRecords( void * buf, qint64 size, qint64 count )
 {
   qint64 result = f.read( static_cast< char * >( buf ), size * count );
   return result < 0 ? result : result / size;
 }
 
-void Class::write( void const * buf, qint64 size )
+void Index::write( void const * buf, qint64 size )
 {
   if ( 0 == size ) {
     return;
@@ -106,13 +106,13 @@ void Class::write( void const * buf, qint64 size )
   f.write( static_cast< char const * >( buf ), size );
 }
 
-size_t Class::writeRecords( void const * buf, qint64 size, qint64 count )
+size_t Index::writeRecords( void const * buf, qint64 size, qint64 count )
 {
   qint64 result = f.write( static_cast< const char * >( buf ), size * count );
   return result < 0 ? result : result / size;
 }
 
-char * Class::gets( char * s, int size, bool stripNl )
+char * Index::gets( char * s, int size, bool stripNl )
 {
   qint64 len    = f.readLine( s, size );
   char * result = len > 0 ? s : nullptr;
@@ -134,7 +134,7 @@ char * Class::gets( char * s, int size, bool stripNl )
   return result;
 }
 
-std::string Class::gets( bool stripNl )
+std::string Index::gets( bool stripNl )
 {
   char buf[ 1024 ];
 
@@ -144,61 +144,61 @@ std::string Class::gets( bool stripNl )
   return { buf };
 }
 
-QByteArray Class::readall()
+QByteArray Index::readall()
 {
   return f.readAll();
 };
 
 
-void Class::seek( qint64 offset )
+void Index::seek( qint64 offset )
 {
   if ( !f.seek( offset ) )
     throw exSeekError();
 }
 
-uchar * Class::map( qint64 offset, qint64 size )
+uchar * Index::map( qint64 offset, qint64 size )
 {
   return f.map( offset, size );
 }
 
-bool Class::unmap( uchar * address )
+bool Index::unmap( uchar * address )
 {
   return f.unmap( address );
 }
 
 
-void Class::seekEnd()
+void Index::seekEnd()
 {
   if ( !f.seek( f.size() ) )
     throw exSeekError();
 }
 
-void Class::rewind()
+void Index::rewind()
 {
   seek( 0 );
 }
 
-qint64 Class::tell()
+qint64 Index::tell()
 {
   return f.pos();
 }
 
-bool Class::eof() const
+bool Index::eof() const
 {
   return f.atEnd();
 }
 
-QFile & Class::file()
+QFile & Index::file()
 {
   return f;
 }
 
-void Class::close()
+void Index::close()
 {
   f.close();
 }
 
-Class::~Class() noexcept
+Index::~Index() noexcept
 {
   f.close();
 }

--- a/src/common/file.hh
+++ b/src/common/file.hh
@@ -13,12 +13,7 @@
 #include <vector>
 #include <QMutex>
 
-/// A wrapper over QFile with some GD specific functions
-/// and exception throwing which are required for older coded to work correctly
-/// Consider the wrapped QFile as private implementation in the `Pimpl Idiom`
-///
-/// Note: this is used *only* in code related to `Dictionary::CLass` to manage dict files.
-/// In other places, just use QFile directly.
+/// File utilities
 namespace File {
 
 DEF_EX( Ex, "File exception", std::exception )
@@ -40,7 +35,8 @@ inline bool exists( std::string_view filename ) noexcept
   return QFileInfo::exists( QString::fromUtf8( filename.data(), filename.size() ) );
 };
 
-class Class
+/// Exclusivly used for processing GD's index files
+class Index
 {
   QFile f;
 
@@ -48,7 +44,7 @@ public:
   QMutex lock;
 
   // Create QFile Object and open() it.
-  Class( std::string_view filename, char const * mode );
+  Index( std::string_view filename, char const * mode );
 
   /// QFile::read  & QFile::write , but with exception throwing
   void read( void * buf, qint64 size );
@@ -115,7 +111,7 @@ public:
   /// Closes the file. No further operations are valid.
   void close();
 
-  ~Class() noexcept;
+  ~Index() noexcept;
 
 private:
   // QFile::open but with fopen-like mode settings.

--- a/src/dict/aard.cc
+++ b/src/dict/aard.cc
@@ -119,7 +119,7 @@ __attribute__( ( packed ) )
 
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Class idx( indexFile, "rb" );
+  File::Index idx( indexFile, "rb" );
 
   IdxHeader header;
 
@@ -214,10 +214,10 @@ class AardDictionary: public BtreeIndexing::BtreeDictionary
 {
   QMutex idxMutex;
   QMutex aardMutex;
-  File::Class idx;
+  File::Index idx;
   IdxHeader idxHeader;
   ChunkedStorage::Reader chunks;
-  File::Class df;
+  File::Index df;
 
 public:
 
@@ -774,7 +774,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
           }
         }
 
-        File::Class df( fileName, "rb" );
+        File::Index df( fileName, "rb" );
 
         AAR_header dictHeader;
 
@@ -839,7 +839,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         initializing.indexingDictionary( dictName );
 
-        File::Class idx( indexFile, "wb" );
+        File::Index idx( indexFile, "wb" );
         IdxHeader idxHeader;
         memset( &idxHeader, 0, sizeof( idxHeader ) );
 

--- a/src/dict/bgl.cc
+++ b/src/dict/bgl.cc
@@ -91,7 +91,7 @@ __attribute__( ( packed ) )
 
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Class idx( indexFile, "rb" );
+  File::Index idx( indexFile, "rb" );
 
   IdxHeader header;
 
@@ -175,7 +175,7 @@ DEF_EX( exChunkIndexOutOfRange, "Chunk index is out of range", Dictionary::Ex )
 class BglDictionary: public BtreeIndexing::BtreeDictionary
 {
   QMutex idxMutex;
-  File::Class idx;
+  File::Index idx;
   IdxHeader idxHeader;
   ChunkedStorage::Reader chunks;
 
@@ -809,7 +809,7 @@ class BglResourceRequest: public Dictionary::DataRequest
 {
 
   QMutex & idxMutex;
-  File::Class & idx;
+  File::Index & idx;
   uint32_t resourceListOffset, resourcesCount;
   string name;
 
@@ -819,7 +819,7 @@ class BglResourceRequest: public Dictionary::DataRequest
 public:
 
   BglResourceRequest( QMutex & idxMutex_,
-                      File::Class & idx_,
+                      File::Index & idx_,
                       uint32_t resourceListOffset_,
                       uint32_t resourcesCount_,
                       string const & name_ ):
@@ -953,12 +953,12 @@ void BglDictionary::replaceCharsetEntities( string & text )
 
 class ResourceHandler: public Babylon::ResourceHandler
 {
-  File::Class & idxFile;
+  File::Index & idxFile;
   list< pair< string, uint32_t > > resources;
 
 public:
 
-  ResourceHandler( File::Class & idxFile_ ):
+  ResourceHandler( File::Index & idxFile_ ):
     idxFile( idxFile_ )
   {
   }
@@ -1048,7 +1048,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         initializing.indexingDictionary( b.title() );
 
-        File::Class idx( indexFile, "wb" );
+        File::Index idx( indexFile, "wb" );
 
         IdxHeader idxHeader;
 

--- a/src/dict/dictdfiles.cc
+++ b/src/dict/dictdfiles.cc
@@ -73,7 +73,7 @@ __attribute__( ( packed ) )
 
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Class idx( indexFile, "rb" );
+  File::Index idx( indexFile, "rb" );
 
   IdxHeader header;
 
@@ -84,7 +84,7 @@ bool indexIsOldOrBad( string const & indexFile )
 class DictdDictionary: public BtreeIndexing::BtreeDictionary
 {
   QMutex idxMutex;
-  File::Class idx, indexFile; // The later is .index file
+  File::Index idx, indexFile; // The later is .index file
   IdxHeader idxHeader;
   dictData * dz;
   QMutex indexFileMutex, dzMutex;
@@ -579,7 +579,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         initializing.indexingDictionary( dictionaryName );
 
-        File::Class idx( indexFile, "wb" );
+        File::Index idx( indexFile, "wb" );
 
         IdxHeader idxHeader;
 
@@ -592,7 +592,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         IndexedWords indexedWords;
 
-        File::Class indexFile( dictFiles[ 0 ], "rb" );
+        File::Index indexFile( dictFiles[ 0 ], "rb" );
 
         // Read words from index until none's left.
 

--- a/src/dict/dsl.cc
+++ b/src/dict/dsl.cc
@@ -131,7 +131,7 @@ struct InsidedCard
 
 bool indexIsOldOrBad( string const & indexFile, bool hasZipFile )
 {
-  File::Class idx( indexFile, "rb" );
+  File::Index idx( indexFile, "rb" );
 
   IdxHeader header;
 
@@ -143,7 +143,7 @@ bool indexIsOldOrBad( string const & indexFile, bool hasZipFile )
 class DslDictionary: public BtreeIndexing::BtreeDictionary
 {
   QMutex idxMutex;
-  File::Class idx;
+  File::Index idx;
   IdxHeader idxHeader;
   sptr< ChunkedStorage::Reader > chunks;
   string preferredSoundDictionary;
@@ -1718,7 +1718,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
           gdDebug( "Dsl: Building the index for dictionary: %s\n",
                    QString::fromStdU32String( scanner.getDictionaryName() ).toUtf8().data() );
 
-          File::Class idx( indexFile, "wb" );
+          File::Index idx( indexFile, "wb" );
 
           IdxHeader idxHeader;
 

--- a/src/dict/epwing.cc
+++ b/src/dict/epwing.cc
@@ -70,7 +70,7 @@ __attribute__( ( packed ) )
 
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Class idx( indexFile, "rb" );
+  File::Index idx( indexFile, "rb" );
 
   IdxHeader header;
 
@@ -84,7 +84,7 @@ class EpwingDictionary: public BtreeIndexing::BtreeDictionary
   Q_DECLARE_TR_FUNCTIONS( Epwing::EpwingDictionary )
 
   QMutex idxMutex;
-  File::Class idx;
+  File::Index idx;
   IdxHeader idxHeader;
   string bookName;
   ChunkedStorage::Reader chunks;
@@ -1201,7 +1201,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
           QByteArray nameData = str.toUtf8();
           initializing.indexingDictionary( nameData.data() );
 
-          File::Class idx( indexFile, "wb" );
+          File::Index idx( indexFile, "wb" );
 
           IdxHeader idxHeader{};
 

--- a/src/dict/gls.cc
+++ b/src/dict/gls.cc
@@ -332,7 +332,7 @@ __attribute__( ( packed ) )
 
 bool indexIsOldOrBad( string const & indexFile, bool hasZipFile )
 {
-  File::Class idx( indexFile, "rb" );
+  File::Index idx( indexFile, "rb" );
 
   IdxHeader header;
 
@@ -344,7 +344,7 @@ bool indexIsOldOrBad( string const & indexFile, bool hasZipFile )
 class GlsDictionary: public BtreeIndexing::BtreeDictionary
 {
   QMutex idxMutex;
-  File::Class idx;
+  File::Index idx;
   IdxHeader idxHeader;
   dictData * dz;
   ChunkedStorage::Reader chunks;
@@ -1233,7 +1233,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
           gdDebug( "Gls: Building the index for dictionary: %s\n",
                    QString::fromStdU32String( scanner.getDictionaryName() ).toUtf8().data() );
 
-          File::Class idx( indexFile, "wb" );
+          File::Index idx( indexFile, "wb" );
 
           IdxHeader idxHeader;
 

--- a/src/dict/lsa.cc
+++ b/src/dict/lsa.cc
@@ -65,7 +65,7 @@ __attribute__( ( packed ) )
 
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Class idx( indexFile, "rb" );
+  File::Index idx( indexFile, "rb" );
 
   IdxHeader header;
 
@@ -91,10 +91,10 @@ struct Entry
 public:
 
   // Reads an entry from the file's current position
-  Entry( File::Class & f );
+  Entry( File::Index & f );
 };
 
-Entry::Entry( File::Class & f )
+Entry::Entry( File::Index & f )
 {
   bool firstEntry = ( f.tell() == 13 );
   // Read the entry's filename
@@ -147,7 +147,7 @@ Entry::Entry( File::Class & f )
 class LsaDictionary: public BtreeIndexing::BtreeDictionary
 {
   QMutex idxMutex;
-  File::Class idx;
+  File::Index idx;
   IdxHeader idxHeader;
 
 public:
@@ -390,7 +390,7 @@ sptr< Dictionary::DataRequest > LsaDictionary::getResource( string const & name 
   if ( chain.empty() )
     return std::make_shared< Dictionary::DataRequestInstant >( false ); // No such resource
 
-  File::Class f( getDictionaryFilenames()[ 0 ], "rb" );
+  File::Index f( getDictionaryFilenames()[ 0 ], "rb" );
 
   f.seek( chain[ 0 ].articleOffset );
   Entry e( f );
@@ -503,7 +503,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
       continue;
 
     try {
-      File::Class f( *i, "rb" );
+      File::Index f( *i, "rb" );
 
       /// Check the signature
 
@@ -528,7 +528,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         initializing.indexingDictionary( Utils::Fs::basename( *i ) );
 
-        File::Class idx( indexFile, "wb" );
+        File::Index idx( indexFile, "wb" );
 
         IdxHeader idxHeader;
 

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -191,7 +191,7 @@ public:
 class MdxDictionary: public BtreeIndexing::BtreeDictionary
 {
   QMutex idxMutex;
-  File::Class idx;
+  File::Index idx;
   string idxFileName;
   IdxHeader idxHeader;
   string encoding;
@@ -1220,7 +1220,7 @@ private:
 
 static bool indexIsOldOrBad( vector< string > const & dictFiles, string const & indexFile )
 {
-  File::Class idx( indexFile, "rb" );
+  File::Index idx( indexFile, "rb" );
   IdxHeader header;
 
   return idx.readRecords( &header, sizeof( header ), 1 ) != 1 || header.signature != kSignature
@@ -1296,7 +1296,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
         }
       }
 
-      File::Class idx( indexFile, "wb" );
+      File::Index idx( indexFile, "wb" );
       IdxHeader idxHeader;
       memset( &idxHeader, 0, sizeof( idxHeader ) );
       // We write a dummy header first. At the end of the process the header

--- a/src/dict/sdict.cc
+++ b/src/dict/sdict.cc
@@ -112,7 +112,7 @@ __attribute__( ( packed ) )
 
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Class idx( indexFile, "rb" );
+  File::Index idx( indexFile, "rb" );
 
   IdxHeader header;
 
@@ -123,10 +123,10 @@ bool indexIsOldOrBad( string const & indexFile )
 class SdictDictionary: public BtreeIndexing::BtreeDictionary
 {
   QMutex idxMutex, sdictMutex;
-  File::Class idx;
+  File::Index idx;
   IdxHeader idxHeader;
   ChunkedStorage::Reader chunks;
-  File::Class df;
+  File::Index df; // Not an index, uses this type for legacy reasons.
 
 public:
 
@@ -676,7 +676,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
       try {
         gdDebug( "SDict: Building the index for dictionary: %s\n", fileName.c_str() );
 
-        File::Class df( fileName, "rb" );
+        File::Index df( fileName, "rb" );
 
         DCT_header dictHeader;
 
@@ -706,7 +706,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         initializing.indexingDictionary( dictName );
 
-        File::Class idx( indexFile, "wb" );
+        File::Index idx( indexFile, "wb" );
         IdxHeader idxHeader;
         memset( &idxHeader, 0, sizeof( idxHeader ) );
 

--- a/src/dict/slob.cc
+++ b/src/dict/slob.cc
@@ -103,7 +103,7 @@ struct RefEntry
 
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Class idx( indexFile, "rb" );
+  File::Index idx( indexFile, "rb" );
 
   IdxHeader header;
 
@@ -575,7 +575,7 @@ class SlobDictionary: public BtreeIndexing::BtreeDictionary
 {
   QMutex idxMutex;
   QMutex slobMutex, idxResourceMutex;
-  File::Class idx;
+  File::Index idx;
   BtreeIndex resourceIndex;
   IdxHeader idxHeader;
   SlobFile sf;
@@ -1387,7 +1387,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         initializing.indexingDictionary( sf.getDictionaryName().toUtf8().constData() );
 
-        File::Class idx( indexFile, "wb" );
+        File::Index idx( indexFile, "wb" );
         IdxHeader idxHeader;
         memset( &idxHeader, 0, sizeof( idxHeader ) );
 

--- a/src/dict/sounddir.cc
+++ b/src/dict/sounddir.cc
@@ -53,7 +53,7 @@ __attribute__( ( packed ) )
 
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Class idx( indexFile, "rb" );
+  File::Index idx( indexFile, "rb" );
 
   IdxHeader header;
 
@@ -65,7 +65,7 @@ class SoundDirDictionary: public BtreeIndexing::BtreeDictionary
 {
   string name;
   QMutex idxMutex;
-  File::Class idx;
+  File::Index idx;
   IdxHeader idxHeader;
   ChunkedStorage::Reader chunks;
   QString iconFilename;
@@ -362,7 +362,7 @@ sptr< Dictionary::DataRequest > SoundDirDictionary::getResource( string const & 
   // Now try loading that file
 
   try {
-    File::Class f( fileName.toStdString(), "rb" );
+    File::Index f( fileName.toStdString(), "rb" );
 
     sptr< Dictionary::DataRequestInstant > dr = std::make_shared< Dictionary::DataRequestInstant >( true );
 
@@ -463,7 +463,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( Config::SoundDirs const & 
 
       initializing.indexingDictionary( soundDir.name.toUtf8().data() );
 
-      File::Class idx( indexFile, "wb" );
+      File::Index idx( indexFile, "wb" );
 
       IdxHeader idxHeader;
 

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -90,7 +90,7 @@ struct Ifo
   string sametypesequence, dicttype, description;
   string copyright, author, email, website, date;
 
-  explicit Ifo( File::Class & );
+  explicit Ifo( File::Index & );
 };
 
 enum {
@@ -123,7 +123,7 @@ __attribute__( ( packed ) )
 
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Class idx( indexFile, "rb" );
+  File::Index idx( indexFile, "rb" );
 
   IdxHeader header;
 
@@ -134,7 +134,7 @@ bool indexIsOldOrBad( string const & indexFile )
 class StardictDictionary: public BtreeIndexing::BtreeDictionary
 {
   QMutex idxMutex;
-  File::Class idx;
+  File::Index idx;
   IdxHeader idxHeader;
   string bookName;
   string sameTypeSequence;
@@ -1039,7 +1039,7 @@ QString const & StardictDictionary::getDescription()
   if ( !dictionaryDescription.isEmpty() )
     return dictionaryDescription;
 
-  File::Class ifoFile( getDictionaryFilenames()[ 0 ], "r" );
+  File::Index ifoFile( getDictionaryFilenames()[ 0 ], "r" );
   Ifo ifo( ifoFile );
 
   if ( !ifo.copyright.empty() ) {
@@ -1402,7 +1402,7 @@ static char const * beginsWith( char const * substr, char const * str )
   return strncmp( str, substr, len ) == 0 ? str + len : 0;
 }
 
-Ifo::Ifo( File::Class & f ):
+Ifo::Ifo( File::Index & f ):
   wordcount( 0 ),
   synwordcount( 0 ),
   idxfilesize( 0 ),
@@ -1809,7 +1809,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
       if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile ) ) {
         // Building the index
 
-        File::Class ifoFile( fileName, "r" );
+        File::Index ifoFile( fileName, "r" );
 
         Ifo ifo( ifoFile );
 
@@ -1840,7 +1840,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         initializing.indexingDictionary( ifo.bookname );
 
-        File::Class idx( indexFile, "wb" );
+        File::Index idx( indexFile, "wb" );
 
         IdxHeader idxHeader;
 

--- a/src/dict/xdxf.cc
+++ b/src/dict/xdxf.cc
@@ -129,7 +129,7 @@ __attribute__( ( packed ) )
 
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Class idx( indexFile, "rb" );
+  File::Index idx( indexFile, "rb" );
 
   IdxHeader header;
 
@@ -141,7 +141,7 @@ bool indexIsOldOrBad( string const & indexFile )
 class XdxfDictionary: public BtreeIndexing::BtreeDictionary
 {
   QMutex idxMutex;
-  File::Class idx;
+  File::Index idx;
   IdxHeader idxHeader;
   sptr< ChunkedStorage::Reader > chunks;
   QMutex dzMutex;
@@ -1040,7 +1040,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         //initializing.indexingDictionary( nameFromFileName( dictFiles[ 0 ] ) );
 
-        File::Class idx( indexFile, "wb" );
+        File::Index idx( indexFile, "wb" );
 
         IdxHeader idxHeader;
         map< string, string > abrv;

--- a/src/dict/zim.cc
+++ b/src/dict/zim.cc
@@ -98,7 +98,7 @@ __attribute__( ( packed ) )
 // Some supporting functions
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Class idx( indexFile, "rb" );
+  File::Index idx( indexFile, "rb" );
 
   IdxHeader header;
 
@@ -162,7 +162,7 @@ class ZimDictionary: public BtreeIndexing::BtreeDictionary
 {
   QMutex idxMutex;
   QMutex zimMutex;
-  File::Class idx;
+  File::Index idx;
   IdxHeader idxHeader;
   ZimFile df;
   set< quint32 > articlesIndexedForFTS;
@@ -842,7 +842,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
           initializing.indexingDictionary( firstName.mid( n + 1 ).toUtf8().constData() );
         }
 
-        File::Class idx( indexFile, "wb" );
+        File::Index idx( indexFile, "wb" );
         IdxHeader idxHeader;
         memset( &idxHeader, 0, sizeof( idxHeader ) );
         idxHeader.namePtr        = 0xFFFFFFFF;

--- a/src/dict/zipsounds.cc
+++ b/src/dict/zipsounds.cc
@@ -61,7 +61,7 @@ __attribute__( ( packed ) )
 
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Class idx( indexFile, "rb" );
+  File::Index idx( indexFile, "rb" );
 
   IdxHeader header;
 
@@ -98,7 +98,7 @@ wstring stripExtension( string const & str )
 class ZipSoundsDictionary: public BtreeIndexing::BtreeDictionary
 {
   QMutex idxMutex;
-  File::Class idx;
+  File::Index idx;
   IdxHeader idxHeader;
   sptr< ChunkedStorage::Reader > chunks;
   IndexedZip zipsFile;
@@ -394,7 +394,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
       if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile ) ) {
         gdDebug( "Zips: Building the index for dictionary: %s\n", fileName.c_str() );
 
-        File::Class idx( indexFile, "wb" );
+        File::Index idx( indexFile, "wb" );
         IdxHeader idxHeader;
 
         memset( &idxHeader, 0, sizeof( idxHeader ) );


### PR DESCRIPTION
This https://github.com/xiaoyifang/goldendict-ng/pull/1435 , but done right.

I finally understand why the hell there is a `File::Class` when `QFile` already exists and being used.

All existence of File::Class are created for Index files.

It exists because the original authors feel like there is a need to put common staff related to index file process. They didn't explicitly realize this, so only some common code is here and others are duplications scattered around.
