### PR TITLE
experiment: switch from zlib to Zstd for index file

### DIFF
--- a/CMake_Unix.cmake
+++ b/CMake_Unix.cmake
@@ -40,6 +40,7 @@ pkg_check_modules(PKGCONFIG_DEPS IMPORTED_TARGET
         vorbis # .ogg
         vorbisfile
         liblzma
+        libzstd
         xapian-core
 )
 

--- a/goldendict.pro
+++ b/goldendict.pro
@@ -117,7 +117,8 @@ UI_DIR = build
 MOC_DIR = build
 RCC_DIR = build
 LIBS += -lbz2 \
-        -llzo2
+        -llzo2 \
+        -lzstd
 
 win32{
     Debug: LIBS+= -L$$PWD/winlibs/lib/dbg/ -lzlibd

--- a/src/btreeidx.hh
+++ b/src/btreeidx.hh
@@ -30,7 +30,6 @@ using std::vector;
 using std::map;
 
 
-
 enum {
   /// This is to be bumped up each time the internal format changes.
   /// The value isn't used here by itself, it is supposed to be added

--- a/src/btreeidx.hh
+++ b/src/btreeidx.hh
@@ -12,11 +12,12 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include <memory>
 
 #include <QFuture>
-#include <QList>
-#include <QSet>
 #include <QVector>
+
+#include "zstd_wrapper.hh"
 
 
 /// A base for the dictionary which creates a btree index to look up
@@ -28,11 +29,13 @@ using gd::wstring;
 using std::vector;
 using std::map;
 
+
+
 enum {
   /// This is to be bumped up each time the internal format changes.
   /// The value isn't used here by itself, it is supposed to be added
   /// to each dictionary's internal format version.
-  FormatVersion = 4
+  FormatVersion = 5
 };
 
 // These exceptions which might be thrown during the index traversal
@@ -139,6 +142,9 @@ protected:
 
 protected:
 
+  std::unique_ptr< ZSTD_DCtx, ZSTD::deleter > zstd_dctx;
+
+  // Lifetime of 2 var below is not managed by this class.
   QMutex * idxFileMutex;
   File::Class * idxFile;
 

--- a/src/chunkedstorage.hh
+++ b/src/chunkedstorage.hh
@@ -8,7 +8,9 @@
 #include "file.hh"
 
 #include <vector>
-#include <stdint.h>
+#include <memory>
+
+#include "zstd_wrapper.hh"
 
 /// A chunked compression storage. We use this for articles' bodies. The idea
 /// is to store data in a separately-compressed chunks, much like in dictzip,
@@ -66,6 +68,8 @@ private:
   size_t bufferUsed;
 
   void saveCurrentChunk();
+
+  std::unique_ptr< ZSTD_CCtx, ZSTD::deleter > zstd_cctx;
 };
 
 /// This class reads data blocks previously written by Writer.
@@ -83,6 +87,9 @@ public:
   /// Uses the user-provided storage to load the entire chunk, and then to
   /// return a pointer to the requested block inside it.
   char * getBlock( uint32_t address, vector< char > & );
+
+private:
+  std::unique_ptr< ZSTD_DCtx, ZSTD::deleter > zstd_dctx;
 };
 
 } // namespace ChunkedStorage

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -1270,12 +1270,12 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
     string dictId    = Dictionary::makeDictionaryId( dictFiles );
     string indexFile = indicesDir + dictId;
-    int t = 20;
-mdxbench:
+    int t            = 20;
+  mdxbench:
     if ( true ) {
       // Building the index
 
-     // gdDebug( "MDict: Building the index for dictionary: %s\n", fileName.c_str() );
+      // gdDebug( "MDict: Building the index for dictionary: %s\n", fileName.c_str() );
       auto index_begin = std::chrono::high_resolution_clock::now();
 
       MdictParser parser;
@@ -1435,9 +1435,10 @@ mdxbench:
       idx.rewind();
       idx.write( &idxHeader, sizeof( idxHeader ) );
 
-      auto index_finish = std::chrono::high_resolution_clock::now();
-      std::chrono::duration<double, std::milli> c = index_finish - index_begin;
-      qDebug() << c;
+      auto index_finish                             = std::chrono::high_resolution_clock::now();
+      std::chrono::duration< double, std::milli > c = index_finish - index_begin;
+      qDebug() << c.count() << "ms";
+      //or qDebug() << c; for qt6.6
 
       t = t - 1;
       if ( t > 0 ) {

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -1270,11 +1270,13 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
     string dictId    = Dictionary::makeDictionaryId( dictFiles );
     string indexFile = indicesDir + dictId;
-
-    if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( dictFiles, indexFile ) ) {
+    int t = 20;
+mdxbench:
+    if ( true ) {
       // Building the index
 
-      gdDebug( "MDict: Building the index for dictionary: %s\n", fileName.c_str() );
+     // gdDebug( "MDict: Building the index for dictionary: %s\n", fileName.c_str() );
+      auto index_begin = std::chrono::high_resolution_clock::now();
 
       MdictParser parser;
       list< sptr< MdictParser > > mddParsers;
@@ -1432,6 +1434,15 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
       idx.rewind();
       idx.write( &idxHeader, sizeof( idxHeader ) );
+
+      auto index_finish = std::chrono::high_resolution_clock::now();
+      std::chrono::duration<double, std::milli> c = index_finish - index_begin;
+      qDebug() << c;
+
+      t = t - 1;
+      if ( t > 0 ) {
+        goto mdxbench;
+      }
     }
 
     dictionaries.push_back( std::make_shared< MdxDictionary >( dictId, indexFile, dictFiles ) );

--- a/src/zstd_wrapper.hh
+++ b/src/zstd_wrapper.hh
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <zstd.h>
+
+namespace ZSTD {
+
+struct deleter
+{
+  void operator()( ZSTD_DCtx * Ctx ) const
+  {
+    ZSTD_freeDCtx( Ctx );
+  }
+
+  void operator()( ZSTD_CCtx * Ctx ) const
+  {
+    ZSTD_freeCCtx( Ctx );
+  }
+};
+
+} // namespace ZSTD


### PR DESCRIPTION
Most chunks in the index file are small, but some formats appear to be slightly large, like mdx, sometimes up to 64Kib for one chunk. The total index file size is usually less than 1 Mib, but sometimes it can go up to 10~15Mib.

Better compression library may lead to obvious improvement in indexing time.

Zstd on its website claims that it is better than zlib in all aspects. Various benchmarks online confirm this.

---

I added a simple time measurement to mdx's index file creation to compare zstd & zlib.

Run GD with a single large MDX dict, then grep `ms` from stdout.

Measured with release build, MacBook Air (M1, 2020), a ~140 mb mdx dictionary.

Both generated index files are ~3.5 mb, the diff is less than 0.2 mb.

Indexing time can be reduced by >10% (note that the measurement time also includes unrelated things like file writing.)

<img width="492" alt="Screenshot 2024-03-24 at 4 45 50 PM" src="https://github.com/xiaoyifang/goldendict-ng/assets/20123683/3daf740c-04ad-4624-8e93-eb86518c479d">

Spreadsheet file used (To download -> top left -> file -> download) https://docs.google.com/spreadsheets/d/1In6Qvpp3M1GmWPN4L6AdLkKnLFnF9MUUwWedDdVG0Ms/edit?usp=sharing

---

An alternative is lz4 which is significantly faster on decompression/compression, but the compression ratio is lower. The cost of having large files, like for slow disks (The benefit of faster compression have to outweigh the cost of larger file writing, I don't know.).

The default compression level of Zstd is 3. 

The default compression level of zlib is 6.

Since in our use case, the size is small, some adjustment may yield a better result.







