### PR TITLE
force qt 6.7.0+ to use VistaStyle instead of win11 style.

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -8,6 +8,7 @@
 #include <QWebEngineProfile>
 #include "hotkeywrapper.hh"
 #include "version.hh"
+#include <QStyleFactory>
 #ifdef HAVE_X11
   #include <fixx11h.h>
 #endif
@@ -367,6 +368,10 @@ int main( int argc, char ** argv )
   QHotkeyApplication::setApplicationName( "GoldenDict-ng" );
   QHotkeyApplication::setOrganizationDomain( "https://github.com/xiaoyifang/goldendict-ng" );
   QHotkeyApplication::setWindowIcon( QIcon( ":/icons/programicon.png" ) );
+
+#ifdef Q_OS_WIN32
+  QApplication::setStyle( QStyleFactory::create("WindowsVista") );
+#endif
 
 #if defined( USE_BREAKPAD )
   QString appDirPath = Config::getConfigDir() + "crash";

--- a/src/main.cc
+++ b/src/main.cc
@@ -370,7 +370,7 @@ int main( int argc, char ** argv )
   QHotkeyApplication::setWindowIcon( QIcon( ":/icons/programicon.png" ) );
 
 #ifdef Q_OS_WIN32
-  QApplication::setStyle( QStyleFactory::create("WindowsVista") );
+  QApplication::setStyle( QStyleFactory::create( "WindowsVista" ) );
 #endif
 
 #if defined( USE_BREAKPAD )


### PR DESCRIPTION
The new default style in 6.7.0 on win11 looks like that:

![newStyle](https://forumcdn.freemdict.com/uploads/default/original/3X/f/4/f459c99f760841551c312bdd8e4ad918796daae8.png)

If you think [setting a enviornment variable](https://forum.freemdict.com/t/topic/11495/3202?u=atauzki) is a better solution, just close this PR.