### PR TITLE
CMakeLists.txt: Enforce UTC in timestamp generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ set(CMAKE_AUTORCC ON) # not included in the qt_standard_project_setup
 #### Things required during configuration
 
 block() # generate version.txt
-    string(TIMESTAMP build_time)
+    string(TIMESTAMP build_time UTC)
     find_package(Git)
     if (EXISTS "${CMAKE_SOURCE_DIR}/.git" AND GIT_FOUND)
         execute_process(


### PR DESCRIPTION
As discussed in the Debian bug report [2], the current timestamp generation may not be reproducible due to not enforcing the time zone. This patch enforces UTC as time zone information, which will satisfy the reproducible-builds[1] requirement.

[1] https://reproducible-builds.org/
[2] https://bugs.debian.org/1068176