### PR TITLE
Add StartupWMClass to the application's ".desktop" file

### DIFF
--- a/redist/io.github.xiaoyifang.goldendict_ng.desktop
+++ b/redist/io.github.xiaoyifang.goldendict_ng.desktop
@@ -12,3 +12,4 @@ Keywords[zh_CN]=dict;dictionary;字典;
 Icon=goldendict
 Exec=goldendict %u
 MimeType=x-scheme-handler/goldendict;x-scheme-handler/dict;
+StartupWMClass=goldendict


### PR DESCRIPTION
When you pin the app to KDE's Icons-Only Task Manager and launch it, a new icon is created next to the app's icon. I.e. KDE doesn't recognize that the pinned launcher icon and the running app is the same app. 

![image](https://github.com/xiaoyifang/goldendict-ng/assets/426992/dd1c694a-8913-497b-ab87-261f7034c381)

To fix that in Wayland I had to do this:

1. Run qdbus org.kde.KWin /KWin queryWindowInfo
3. Copy the value from resourceName: goldendict
4. Append it to the .desktop file like this:
```
X-Flatpak=io.github.xiaoyifang.goldendict_ng
StartupWMClass=goldendict <---- HERE
```

The fix should address [this issue](https://github.com/xiaoyifang/goldendict-ng/issues/1467) and probably also [this one](https://github.com/xiaoyifang/goldendict-ng/issues/1160).