### PR TITLE
feat: utilize CMake for macOS `.app` and `.dmg` creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,8 @@ project(goldendict-ng
         VERSION 24.02.16
         LANGUAGES CXX C)
 
-if (NOT USE_ALTERNATIVE_NAME)
-    set(GOLDENDICT "goldendict") # binary/executable name
-else ()
+set(GOLDENDICT "goldendict") # binary/executable name
+if (USE_ALTERNATIVE_NAME OR APPLE)
     set(GOLDENDICT "goldendict-ng")
 endif ()
 
@@ -80,6 +79,9 @@ file(GLOB_RECURSE ALL_SOURCE_FILES CONFIGURE_DEPENDS src/*.cc src/*.hh src/*.c)
 
 if (APPLE)
     file(GLOB_RECURSE MACOS_SOURCE_FILES CONFIGURE_DEPENDS src/macos/*.mm)
+
+    set(MACOS_APP_ICON ${CMAKE_SOURCE_DIR}/icons/macicon.icns)
+    set_source_files_properties(${MACOS_APP_ICON} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
 endif ()
 
 if (WIN32)
@@ -102,6 +104,7 @@ target_sources(${GOLDENDICT} PRIVATE
         src/stylesheets/css.qrc
         ${ALL_SOURCE_FILES}
         ${MACOS_SOURCE_FILES}
+        ${MACOS_APP_ICON}
         ${QSINGLEAPP_SOURCE_FILES}
         ${WINDOWS_ICON_RC}
 )
@@ -198,12 +201,51 @@ qt_add_translations(${GOLDENDICT} TS_FILES ${TRANS_FILES}
 #### installation or assemble redistribution
 
 if (APPLE)
+    set(PLIST_FILE "${CMAKE_BINARY_DIR}/info_generated.plist")
+    configure_file("${CMAKE_SOURCE_DIR}/redist/mac_info_plist_template_cmake.plist" "${PLIST_FILE}" @ONLY)
+
     set_target_properties(${GOLDENDICT} PROPERTIES
-            MACOSX_BUNDLE_GUI_IDENTIFIER my.example.com
-            MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
-            MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
             MACOSX_BUNDLE TRUE
-            )
+            MACOSX_BUNDLE_INFO_PLIST "${PLIST_FILE}"
+    )
+
+    set(Assembling_Dir "${CMAKE_BINARY_DIR}/redist")
+    set(Redistributable_APP "${Assembling_Dir}/${GOLDENDICT}.app")
+    qt_generate_deploy_script(
+            TARGET ${GOLDENDICT}
+            OUTPUT_SCRIPT deploy_script
+            CONTENT "qt_deploy_runtime_dependencies(
+                        EXECUTABLE \"${Redistributable_APP}\"
+                        GENERATE_QT_CONF
+                        NO_APP_STORE_COMPLIANCE
+                )"
+    )
+
+    install(TARGETS ${GOLDENDICT} BUNDLE DESTINATION "${Assembling_Dir}")
+    install(FILES ${qm_files} DESTINATION "${Redistributable_APP}/Contents/MacOS/locale")
+    install(DIRECTORY "${CMAKE_SOURCE_DIR}/opencc" DESTINATION "${Redistributable_APP}/Contents/MacOS")
+
+    install(SCRIPT ${deploy_script})
+
+    install(CODE "execute_process(COMMAND codesign --force --deep -s - ${Redistributable_APP})")
+
+    find_program(CREATE-DMG "create-dmg")
+    if (CREATE-DMG)
+        install(CODE "
+        execute_process(COMMAND ${CREATE-DMG} \
+            --skip-jenkins \
+            --format \"ULMO\"
+            --volname ${CMAKE_PROJECT_NAME}-${CMAKE_PROJECT_VERSION}-${CMAKE_SYSTEM_PROCESSOR} \
+            --volicon ${CMAKE_SOURCE_DIR}/icons/macicon.icns \
+            --icon \"goldendict-ng.app\" 100 100
+            --app-drop-link 300 100 \
+            \"${CMAKE_PROJECT_NAME}-${CMAKE_PROJECT_VERSION}-${CMAKE_SYSTEM_PROCESSOR}.dmg\" \
+            \"${Assembling_Dir}\")"
+        )
+    else ()
+        message(WARNING "create-dmg not found. No .dmg will be created")
+    endif ()
+
 endif ()
 
 if (LINUX OR BSD)

--- a/CMake_Unix.cmake
+++ b/CMake_Unix.cmake
@@ -1,8 +1,12 @@
-#### Include Paths
+#### Various workarounds
 
 if (APPLE)
     # old & new homebrew's include paths
     target_include_directories(${GOLDENDICT} PRIVATE /usr/local/include /opt/homebrew/include)
+
+    # libzim depends on ICU, but the ICU from homebrew is "key-only", we need to manually prioritize it
+    # See `brew info icu4c` if this no longer works
+    set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:/usr/local/opt/icu4c/lib/pkgconfig:/opt/homebrew/opt/icu4c/lib/pkgconfig")
 endif ()
 
 target_include_directories(${GOLDENDICT} PRIVATE

--- a/redist/mac_info_plist_template_cmake.plist
+++ b/redist/mac_info_plist_template_cmake.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist SYSTEM "file://localhost/System/Library/DTDs/PropertyList.dtd">
+<plist version="0.9">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>@GOLDENDICT@</string>
+	<key>CFBundleIconFile</key>
+	<string>macicon.icns</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>@CMAKE_PROJECT_VERSION@</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.xiaoyifang</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/website/docs/howto/build_from_source.md
+++ b/website/docs/howto/build_from_source.md
@@ -37,6 +37,8 @@ And a few compression libraries:
 
 ## CMake Build
 
+Basically, you need those commands:
+
 ```shell
 cd goldendict-ng && mkdir build_dir
 # config step
@@ -80,13 +82,13 @@ Use`windeployqt.exe {your_build_dir}/goldendict.exe` which will copy the qt rela
 
 ### macOS
 
-Similar to Linux build, but need `macdeployqt ./goldendict.app` to copy necessary dependencies to the app bundle.
+If you build in an IDE, then the created `goldendict-ng.app`  will be runnable from the IDE which set up necessary magics for you.
+
+To make the `.app` runnable elsewhere, you can run `cmake --install build_dir/` which will invoke macdeployqt, ad-hoc code signing and various other things. The produced app will end up in `build_dir/redist/goldendict-ng.app`
+
+To create `.dmg` installer, you have to have [create-dmg](https://github.com/create-dmg/create-dmg) installed on your machine, then also `cmake --install build_dir/`.
 
 ## Qmake
-
-```shell
-git clone https://github.com/xiaoyifang/goldendict-ng.git
-```
 
 ### Build Steps
 


### PR DESCRIPTION
This PR encompasses various improvements:

* Makes creating `.dmg` or `.app` locally possible (by removing the need to run macdeployqt, otool, codesign after build)
* Ultimately fix, https://github.com/xiaoyifang/goldendict-ng/issues/814 and fix, https://github.com/xiaoyifang/goldendict-ng/issues/1472
* Rename .app & .dmg so that we may submit to homebrew's cask https://github.com/xiaoyifang/goldendict-ng/issues/1141

And less important ones,
* One more step closer to removing `qmake`
* Remove outdated keys from `.plist` file
* Reduce .dmg size for by switching compression method. (macOS 10.15+)
* ...

Known issue:

The Homebrew Qt and macdeployqt's rpath bug is still not fixed, so we still have to use Qt's installer.

Known alternatives:

CMake's CPack's Drag&Drop generator is 💩💩💩. Lacks basic features and obscure to use.

So we still uses `brew install create-dmg` to create dmg installer.
