### PR TITLE
fix: add timeout for sounddir modification scanning for super large sound dir and/or slow filesystem

### DIFF
--- a/src/dict/sounddir.cc
+++ b/src/dict/sounddir.cc
@@ -447,12 +447,17 @@ vector< sptr< Dictionary::Class > > makeDictionaries( Config::SoundDirs const & 
       QDirIterator it( dir.path(),
                        QDir::AllDirs | QDir::NoDotAndDotDot | QDir::NoSymLinks,
                        QDirIterator::Subdirectories );
-      while ( it.hasNext() ) {
+
+      QDeadlineTimer deadline( 4000 );
+      while ( it.hasNext() && !deadline.hasExpired() ) {
         it.next();
         if ( it.fileInfo().lastModified() > indexFileModifyTime ) {
           soundDirModified = true;
           break;
         }
+      }
+      if ( deadline.hasExpired() ) {
+        qDebug() << "SoundDir modification scanning timed out.";
       }
     }
 


### PR DESCRIPTION
close https://github.com/xiaoyifang/goldendict-ng/issues/1508
related https://github.com/xiaoyifang/goldendict-ng/issues/1417

4 seconds is more than enough unless the soundDir contains 10k-ish folders and obtaining modification time is for some reason slow.

Currently, I don't know how to detect modifications without checking every folder.

Wish we have this to tell that we silently failed https://github.com/xiaoyifang/goldendict-ng/issues/1440

The workaround is just don't have that many folders, put all sound files in one folder.