### PR TITLE
fix: set macOS deployment version to 12.0

### DIFF
--- a/.github/workflows/macos-homebrew.yml
+++ b/.github/workflows/macos-homebrew.yml
@@ -73,7 +73,7 @@ jobs:
       - name: compile
         run: |
           mkdir build_dir
-          cmake -S . -B build_dir -G Ninja -DWITH_FFMPEG_PLAYER=OFF -DWITH_TTS=OFF -DCMAKE_BUILD_TYPE=Release -D-DCMAKE_OSX_DEPLOYMENT_TARGET="12.0"
+          cmake -S . -B build_dir -G Ninja -DWITH_FFMPEG_PLAYER=OFF -DWITH_TTS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET="12.0"
           cmake --build build_dir
           
       - name: package

--- a/.github/workflows/macos-homebrew.yml
+++ b/.github/workflows/macos-homebrew.yml
@@ -73,7 +73,7 @@ jobs:
       - name: compile
         run: |
           mkdir build_dir
-          cmake -S . -B build_dir -G Ninja -DWITH_FFMPEG_PLAYER=OFF -DWITH_TTS=OFF -DCMAKE_BUILD_TYPE=Release
+          cmake -S . -B build_dir -G Ninja -DWITH_FFMPEG_PLAYER=OFF -DWITH_TTS=OFF -DCMAKE_BUILD_TYPE=Release -D-DCMAKE_OSX_DEPLOYMENT_TARGET="12.0"
           cmake --build build_dir
           
       - name: package


### PR DESCRIPTION
fix https://github.com/xiaoyifang/goldendict-ng/issues/1510

The minimum possible supported version is bound by Qt -> macOS 11, but it no longer gets updates from Apple.

https://doc.qt.io/qt-6/supported-platforms.html