### PR TITLE
fix: disable Qt6.7's dark mode and force Fusion style no matter what

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -31,6 +31,7 @@
 
 #include "gddebug.hh"
 #include <QMutex>
+#include <QStyleFactory>
 
 #if defined( USE_BREAKPAD )
   #if defined( Q_OS_MAC )
@@ -351,6 +352,8 @@ int main( int argc, char ** argv )
     freopen( "CON", "w", stderr );
   }
 
+  qputenv( "QT_QPA_PLATFORM","windows:darkmode=1" );
+
 #endif
 
 
@@ -367,6 +370,12 @@ int main( int argc, char ** argv )
   QHotkeyApplication::setApplicationName( "GoldenDict-ng" );
   QHotkeyApplication::setOrganizationDomain( "https://github.com/xiaoyifang/goldendict-ng" );
   QHotkeyApplication::setWindowIcon( QIcon( ":/icons/programicon.png" ) );
+
+#ifdef Q_OS_WIN
+  // TODO: Force fusion because Qt6.7's "ModernStyle"'s dark theme have problems, need to test / reconsider in future
+  QHotkeyApplication::setStyle( QStyleFactory::create( "Fusion" ) );
+#endif
+
 
 #if defined( USE_BREAKPAD )
   QString appDirPath = Config::getConfigDir() + "crash";

--- a/src/main.cc
+++ b/src/main.cc
@@ -352,7 +352,7 @@ int main( int argc, char ** argv )
     freopen( "CON", "w", stderr );
   }
 
-  qputenv( "QT_QPA_PLATFORM","windows:darkmode=1" );
+  qputenv( "QT_QPA_PLATFORM", "windows:darkmode=1" );
 
 #endif
 

--- a/src/stylesheets/qt-lingoes-blue.css
+++ b/src/stylesheets/qt-lingoes-blue.css
@@ -1,4 +1,6 @@
-MainWindow {
+MainWindow,
+QToolBar
+{
   background-color: #cfddf0;
 }
 

--- a/src/stylesheets/qt-lingoes-blue.css
+++ b/src/stylesheets/qt-lingoes-blue.css
@@ -1,6 +1,5 @@
 MainWindow,
-QToolBar
-{
+QToolBar {
   background-color: #cfddf0;
 }
 

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1305,9 +1305,7 @@ void MainWindow::updateAppearances( QString const & addonStyle,
 #ifdef Q_OS_WIN32
   if ( darkMode ) {
   //https://forum.qt.io/topic/101391/windows-10-dark-theme
-  #ifdef Q_OS_WIN32
-    qApp->setStyle( QStyleFactory::create( "Fusion" ) );
-  #endif
+
     QPalette darkPalette;
     QColor darkColor     = QColor( 45, 45, 45 );
     QColor disabledColor = QColor( 127, 127, 127 );
@@ -1334,7 +1332,6 @@ void MainWindow::updateAppearances( QString const & addonStyle,
     qApp->setPalette( darkPalette );
   }
   else {
-    qApp->setStyle( new QProxyStyle() );
     qApp->setPalette( QPalette() );
   }
 #endif


### PR DESCRIPTION
close https://github.com/xiaoyifang/goldendict-ng/issues/1506

We cannot do "follow the system" now because it conflicts with the existing qt style sheets.

"popup menu turns black", as shown in https://github.com/xiaoyifang/goldendict-ng/issues/1506#issuecomment-2105654604, is unfixable as of Qt6.7.0

Also, all frames are lost in the new "ModernWindows" when the built-in dark mode is not enabled, but Windows's dark mode is enabled. 

![image](https://github.com/xiaoyifang/goldendict-ng/assets/20123683/96bd8a36-3c2f-4f9d-9030-ef648ffde929)
