### PR TITLE
fix: USE_ALTERNATIVE_NAME + StartupWMClass = No icon

### DIFF
--- a/redist/io.github.xiaoyifang.goldendict_ng.desktop
+++ b/redist/io.github.xiaoyifang.goldendict_ng.desktop
@@ -12,4 +12,4 @@ Keywords[zh_CN]=dict;dictionary;字典;
 Icon=goldendict
 Exec=goldendict %u
 MimeType=x-scheme-handler/goldendict;x-scheme-handler/dict;
-StartupWMClass=goldendict
+StartupWMClass=GoldenDict-ng


### PR DESCRIPTION
amend https://github.com/xiaoyifang/goldendict-ng/pull/1470

xprops shows that

* `WM_CLASS(STRING) = "goldendict-ng", "GoldenDict-ng"` when using `USE_ALTERNATIVE_NAME`.
* `WM_CLASS(STRING) = "goldendict", "GoldenDict-ng"` when not using `USE_ALTERNATIVE_NAME`