### PR TITLE
fix: tray icon <-> toggleMainWindow connected twice

### DIFF
--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1382,10 +1382,6 @@ void MainWindow::TrayIconUpdateOrInit()
       trayIcon->setContextMenu( &trayIconMenu );
       trayIcon->setToolTip( QApplication::applicationName() );
       trayIcon->show();
-
-      if ( !trayIcon->disconnect() ) {
-        qDebug() << "Tray icon failed to disconnect signals.";
-      };
       connect( trayIcon, &QSystemTrayIcon::activated, this, &MainWindow::trayIconActivated );
     }
     // Update the icon to reflect the scanning mode

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1380,6 +1380,7 @@ void MainWindow::TrayIconUpdateOrInit()
       trayIcon =
         new QSystemTrayIcon( QIcon::fromTheme( "goldendict-tray", QIcon( ":/icons/programicon_old.png" ) ), this );
       trayIcon->setContextMenu( &trayIconMenu );
+      trayIcon->setToolTip( QApplication::applicationName() );
       trayIcon->show();
 
       if ( !trayIcon->disconnect() ) {

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1386,12 +1386,11 @@ void MainWindow::TrayIconUpdateOrInit()
         qDebug() << "Tray icon failed to disconnect signals.";
       };
       connect( trayIcon, &QSystemTrayIcon::activated, this, &MainWindow::trayIconActivated );
-
     }
     // Update the icon to reflect the scanning mode
     trayIcon->setIcon( enableScanningAction->isChecked() ?
-      QIcon::fromTheme( "goldendict-scan-tray", QIcon( ":/icons/programicon_scan.png" ) ) :
-      QIcon::fromTheme( "goldendict-tray", QIcon( ":/icons/programicon_old.png" ) ) );
+                         QIcon::fromTheme( "goldendict-scan-tray", QIcon( ":/icons/programicon_scan.png" ) ) :
+                         QIcon::fromTheme( "goldendict-tray", QIcon( ":/icons/programicon_old.png" ) ) );
   }
 
   // The 'Close to tray' action is associated with the tray icon, so we hide

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -837,7 +837,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 #endif
 
     installHotKeys();
-    TrayIconUpdateOrInit();
+    trayIconUpdateOrInit();
   } );
 
   if ( cfg.preferences.startWithScanPopupOn ) {
@@ -847,7 +847,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   updateSearchPaneAndBar( cfg.preferences.searchInDock );
   ui.searchPane->setVisible( cfg.preferences.searchInDock );
 
-  TrayIconUpdateOrInit();
+  trayIconUpdateOrInit();
 
   // Update zoomers
   adjustCurrentZoomFactor();
@@ -1367,7 +1367,7 @@ void MainWindow::updateAppearances( QString const & addonStyle,
   }
 }
 
-void MainWindow::TrayIconUpdateOrInit()
+void MainWindow::trayIconUpdateOrInit()
 {
   if ( !cfg.preferences.enableTrayIcon ) {
     if ( trayIcon ) {
@@ -1381,12 +1381,12 @@ void MainWindow::TrayIconUpdateOrInit()
       trayIcon->setContextMenu( &trayIconMenu );
       trayIcon->setToolTip( QApplication::applicationName() );
       connect( trayIcon, &QSystemTrayIcon::activated, this, &MainWindow::trayIconActivated );
+      trayIcon->show();
     }
     // Update the icon to reflect the scanning mode
     trayIcon->setIcon( enableScanningAction->isChecked() ?
                          QIcon::fromTheme( "goldendict-scan-tray", QIcon( ":/icons/programicon_scan.png" ) ) :
                          QIcon::fromTheme( "goldendict-tray", QIcon( ":/icons/programicon_old.png" ) ) );
-    trayIcon->show();
   }
 
   // The 'Close to tray' action is associated with the tray icon, so we hide
@@ -2254,7 +2254,7 @@ void MainWindow::editPreferences()
 
     audioPlayerFactory.setPreferences( cfg.preferences );
 
-    TrayIconUpdateOrInit();
+    trayIconUpdateOrInit();
     applyProxySettings();
 
     ui.tabWidget->setHideSingleTab( cfg.preferences.hideSingleTab );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1380,13 +1380,13 @@ void MainWindow::TrayIconUpdateOrInit()
       trayIcon = new QSystemTrayIcon( this );
       trayIcon->setContextMenu( &trayIconMenu );
       trayIcon->setToolTip( QApplication::applicationName() );
-      trayIcon->show();
       connect( trayIcon, &QSystemTrayIcon::activated, this, &MainWindow::trayIconActivated );
     }
-    // Init or Update the icon to reflect the scanning mode
+    // Update the icon to reflect the scanning mode
     trayIcon->setIcon( enableScanningAction->isChecked() ?
                          QIcon::fromTheme( "goldendict-scan-tray", QIcon( ":/icons/programicon_scan.png" ) ) :
                          QIcon::fromTheme( "goldendict-tray", QIcon( ":/icons/programicon_old.png" ) ) );
+    trayIcon->show();
   }
 
   // The 'Close to tray' action is associated with the tray icon, so we hide

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1377,14 +1377,13 @@ void MainWindow::TrayIconUpdateOrInit()
   }
   else {
     if ( !trayIcon ) {
-      trayIcon =
-        new QSystemTrayIcon( QIcon::fromTheme( "goldendict-tray", QIcon( ":/icons/programicon_old.png" ) ), this );
+      trayIcon = new QSystemTrayIcon( this );
       trayIcon->setContextMenu( &trayIconMenu );
       trayIcon->setToolTip( QApplication::applicationName() );
       trayIcon->show();
       connect( trayIcon, &QSystemTrayIcon::activated, this, &MainWindow::trayIconActivated );
     }
-    // Update the icon to reflect the scanning mode
+    // Init or Update the icon to reflect the scanning mode
     trayIcon->setIcon( enableScanningAction->isChecked() ?
                          QIcon::fromTheme( "goldendict-scan-tray", QIcon( ":/icons/programicon_scan.png" ) ) :
                          QIcon::fromTheme( "goldendict-tray", QIcon( ":/icons/programicon_old.png" ) ) );

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -195,7 +195,7 @@ private:
 
   /// Creates, destroys or otherwise updates tray icon, according to the
   /// current configuration and situation.
-  void TrayIconUpdateOrInit();
+  void trayIconUpdateOrInit();
 
   void wheelEvent( QWheelEvent * );
   void closeEvent( QCloseEvent * );

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -195,7 +195,7 @@ private:
 
   /// Creates, destroys or otherwise updates tray icon, according to the
   /// current configuration and situation.
-  void updateTrayIcon();
+  void TrayIconUpdateOrInit();
 
   void wheelEvent( QWheelEvent * );
   void closeEvent( QCloseEvent * );


### PR DESCRIPTION
resolve https://github.com/xiaoyifang/goldendict-ng/issues/1518

Rename the method to what it really is.

Delete legacy & duplications.

The `connect` only happens in `trayIcon`'s init, and thus it will be unique.
