### PR TITLE
fix: `srcset` of `<img>` in mdx format won't show image

### DIFF
--- a/src/common/globalregex.cc
+++ b/src/common/globalregex.cc
@@ -55,6 +55,8 @@ QRegularExpression Mdx::srcRe(
 QRegularExpression Mdx::srcRe2(
   R"(([\s"'](?:src|srcset)\s*=)\s*(?![\s"']|\b(?:(?:bres|https?|ftp)://|(?:data|javascript):))(?:file://)?[\x00-\x1f\x7f]*\.*/?([^\s">]+))",
   QRegularExpression::CaseInsensitiveOption );
+QRegularExpression Mdx::srcSetRe( R"(([\s\"'](?:srcset)\s*=)\s*([\"'])[\x00-\x1f\x7f]*\.*/?([^\">]+)\2)",
+                                  QRegularExpression::CaseInsensitiveOption );
 
 QRegularExpression Mdx::links( R"(url\(\s*(['"]?)([^'"]*)(['"]?)\s*\))", QRegularExpression::CaseInsensitiveOption );
 

--- a/src/common/globalregex.hh
+++ b/src/common/globalregex.hh
@@ -38,6 +38,7 @@ public:
   static QRegularExpression closeScriptTagRe;
   static QRegularExpression srcRe;
   static QRegularExpression srcRe2;
+  static QRegularExpression srcSetRe;
 
   static QRegularExpression links;
   static QRegularExpression fontFace;


### PR DESCRIPTION
See the analysis here https://forum.freemdict.com/t/topic/28984

Proof of concept(💩). The code contains bugs and has various problems to be addressed. 

Don't merge yet. (The surrounding code needs cleanup too.)

### Outcome

This dictionary https://forum.freemdict.com/t/topic/28984/4

Will now be converted into

<img width="400" src="https://github.com/xiaoyifang/goldendict-ng/assets/20123683/54fb7d32-d4bf-4982-82b1-59aa198c240a">

### Root problem

The "originating URL" (no idea about the official name) of the article is `gdlookup://localhost/....`. 

`srcset` will convert the `<img>`'s `srcset` to the  `gdlookup://localhost/{img's srcset's url}`

### Previous code doesn't work

The previous regex match in `QRegularExpression Mdx::srcRe` contains `srcset`, but it does nothing because `RX::Mdx::srcRe.match( linkTxt );` only matches a single time, and it stops after matching `<img src="..." -> the rest part is ignored`.

### True fix in future

Maybe we should fix `gdlookup://...` instead, if detected an image, return binary data?

Again, this fix is probably better, simply stop doing custom protocols -> https://github.com/xiaoyifang/goldendict-ng/issues/229



