### PR TITLE
doc: codify minimum supported OS / versioning / releasing

### DIFF
--- a/.github/workflows/cmake build check.yml
+++ b/.github/workflows/cmake build check.yml
@@ -27,11 +27,10 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
         with:
-          version: 6.6.3
+          # Qt6.4 for testing ubuntu LTS
+          version: 6.4.3
           arch: gcc_64
-          
-          #serialport linuxdeploy need serialport to work.
-          modules: qtwebengine qtwebchannel qtpositioning qt5compat qtmultimedia qtimageformats qtspeech qtserialport
+          modules: qtwebengine qtwebchannel qtpositioning qt5compat qtmultimedia qtimageformats qtspeech
           setup-python: 'false'
           
       - name: ubuntu install thirdparty dependencies

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ dictionaries.
 |--|--|--|
 | [<img src="website/docs/img/linux_genshin.webp" width="500"/>](https://xiaoyifang.github.io/goldendict-ng/) | [<img src="website/docs/img/windows_white.webp" width="500"/>](https://xiaoyifang.github.io/goldendict-ng/) | [<img src="website/docs/img/mac_black.webp" width="500"/>](https://xiaoyifang.github.io/goldendict-ng/) |
 
+[Download & Install](https://xiaoyifang.github.io/goldendict-ng/install/)
+
+[Documentation](https://xiaoyifang.github.io/goldendict-ng/)
+
+[Bug reporting in issue tracker](https://github.com/xiaoyifang/goldendict-ng/issues)
+
+[General discussions](https://github.com/xiaoyifang/goldendict-ng/discussions)
+
 # Some significant features of this fork
 
 - webengine with latest html/css feature support
@@ -26,10 +34,6 @@ dictionaries.
 - daily auto release support
 - lots of bug fixes and improvements
 
-## Installation
-
-<https://xiaoyifang.github.io/goldendict-ng/install/>
-
 ## Help GoldenDict's Development
 
 GoldenDict is developed by volunteers.
@@ -39,16 +43,6 @@ All kinds of help like answering questions, bug reporting, testing, translation 
 To translate the interface, you can use the Crowdin <https://crowdin.com/project/goldendict-ng>
 
 To start development, check out [developer guide](https://xiaoyifang.github.io/goldendict-ng/developer/)
-
-## Build from source
-
-<https://xiaoyifang.github.io/goldendict-ng/howto/build_from_source/>
-
-## Support
-
-Bug reporting: [GoldenDict issue tracker](https://github.com/xiaoyifang/goldendict-ng/issues)
-
-General discussions: [discussions](https://github.com/xiaoyifang/goldendict-ng/discussions)
 
 
 ## License

--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -4,11 +4,12 @@
 
 ## Download
 
+Goldendict-ng is available pre-built for Windows and macOS. It is available in a few Linux/Unix repos and FlatHub.
+
 * [Latest stable version](https://github.com/xiaoyifang/goldendict/releases/latest) 
-* [Daily pre-release builds](https://github.com/xiaoyifang/goldendict/releases).
+* [Pre-release test builds](https://github.com/xiaoyifang/goldendict/releases).
 
-Both Qt5 and Qt6 builds are provided.
-
+Because it is open source, you can always [build it for yourself](howto/build_from_source.md).
 
 ## Windows 
 
@@ -17,7 +18,9 @@ Choose either
 * `****-installer.exe ` for traditional installer experience
 * `****.zip` for simply unzip and run experience
 
-If Qt's version is not changed, you can also download a single `goldendict.exe` and drop it into previous installation's folder.
+If Qt's version is not changed, you can also download a single `goldendict.exe` and drop it into previous installation's folder (If uncertain, don't do this).
+
+Requires Windows 10 (1809 or later).
 
 ## Linux
 
@@ -29,6 +32,16 @@ If Qt's version is not changed, you can also download a single `goldendict.exe` 
 * Pre-built binary is also available from [archlinuxcn's repo](https://github.com/archlinuxcn/repo/tree/master/archlinuxcn/goldendict-ng-git).
 * [Gentoo package from PG_Overlay](https://gitlab.com/Perfect_Gentleman/PG_Overlay/-/blob/master/app-text/goldendict/goldendict-9999-r6.ebuild)
 
+Minimum supported "Linux" versions is supposedly the current Ubuntu LTS or Debian's old stable or Qt6.4.
+
 ## macOS
 
-One of the `.dmg` installers.
+Uses one of the `.dmg` installers in the [Download](#download).
+
+Requires at least macOS 12.
+
+## Versioning and Releasing
+
+This project uses Calendar Versioning: `YY.MM.Patch`.
+
+Releases will tentatively be done twice a year, considering factors like the major releases of Qt and the package freeze dates of Linux distros like Ubuntu.


### PR DESCRIPTION
This is more of a discussion than changing doc. Motivated by https://github.com/xiaoyifang/goldendict-ng/issues/1523#issuecomment-2143856188

---

First, I propose we change the versioning from `YY.MM.DD` into `YY.MM.Patch` because most people only uses formal releases, and could easily expose problems. Issues like https://github.com/xiaoyifang/goldendict-ng/issues/1506 cannot be easily tested (I simply don't use Windows regularly.) or environment changes like https://github.com/xiaoyifang/goldendict-ng/issues/1523 or simply bump minor qt version. Corrections are needed.

For example, `24.08.0` will be a release and `24.08.1` will be its correction.

---

Minimum supported “Linux” versions are just words, not the actual code. Older Linux and qt versions also work (As of now, qt5 also works).

However, we will set the CI's version to Qt6.4 which is the one in the current Ubuntu LTS & Debian's oldstable. (This version will be changed maybe in 2029. I don't care, not today's problem 😅)

---

I think we want to update Windows/macOS binaries with Qt releases, so I propose to release bi-yearly even with only minor changes.

 