### PR TITLE
fix: uses plaintext for DSL description display and HTML for all others

### DIFF
--- a/src/ui/dictinfo.cc
+++ b/src/ui/dictinfo.cc
@@ -48,9 +48,15 @@ void DictInfo::showInfo( sptr< Dictionary::Class > dict )
   ui.dictionaryFileList->setPlainText( filenamesText );
 
   if ( QString info = dict->getDescription(); !info.isEmpty() && info.compare( "NONE" ) != 0 ) {
-    //qtbug QTBUG-112020
-    info.remove( QRegularExpression( R"(<link[^>]*>)", QRegularExpression::CaseInsensitiveOption ) );
-    ui.infoLabel->setHtml( info );
+    // Uses HTML dispaly becuase some formats uses HTML tags for formatting.
+    if ( dict->getMainFilename().contains( ".dsl", Qt::CaseInsensitive ) ) {
+      ui.infoLabel->setPlainText( info );
+    }
+    else {
+      //qtbug QTBUG-112020
+      info.remove( QRegularExpression( R"(<link[^>]*>)", QRegularExpression::CaseInsensitiveOption ) );
+      ui.infoLabel->setHtml( info );
+    }
   }
   else
     ui.infoLabel->clear();


### PR DESCRIPTION
amend https://github.com/xiaoyifang/goldendict-ng/pull/398
fix https://github.com/xiaoyifang/goldendict-ng/issues/1548

Alternative fix -> https://github.com/xiaoyifang/goldendict-ng/pull/1550

Maybe instead of excluding DSL format only, we should only use HTML display for mdx only? (No idea if other formats also uses html tags in descriptions.)

In HTML, line change in `<p>` won't change line.