### PR TITLE
fix: convert DSL description line ends to <br> for HTML display.

### DIFF
--- a/src/dict/dsl.cc
+++ b/src/dict/dsl.cc
@@ -1003,7 +1003,9 @@ QString const & DslDictionary::getDescription()
   if ( !dictionaryDescription.isEmpty() )
     return dictionaryDescription;
 
-  dictionaryDescription = "NONE";
+  QString none = QStringLiteral( "NONE" );
+
+  dictionaryDescription = none;
 
   QString fileName = QDir::fromNativeSeparators( getDictionaryFilenames()[ 0 ].c_str() );
 
@@ -1055,6 +1057,9 @@ QString const & DslDictionary::getDescription()
           break;
       }
     }
+  }
+  if ( dictionaryDescription != none ) {
+    dictionaryDescription.replace( QRegularExpression( R"(\R)" ), R"(<br>)" );
   }
   return dictionaryDescription;
 }


### PR DESCRIPTION
amend https://github.com/xiaoyifang/goldendict-ng/pull/398
fix https://github.com/xiaoyifang/goldendict-ng/issues/1548

Alternative fix -> https://github.com/xiaoyifang/goldendict-ng/pull/1549

Compared to https://github.com/xiaoyifang/goldendict-ng/pull/1549, this enhances DSL Description by allowing it to use HTML tags.