### PR TITLE
opt: vcpkg manifest error

### DIFF
--- a/.github/workflows/windows-6.x.yml
+++ b/.github/workflows/windows-6.x.yml
@@ -152,6 +152,7 @@ jobs:
       - name: copy vcpkg packages into winlibs
         shell: bash
         run: |   
+          vcpkg install --x-feature=breakpad
           cp -R vcpkg/packages/breakpad_x64-windows-release/*  thirdparty/breakpad
           ls -al thirdparty/breakpad
 

--- a/.github/workflows/windows-6.x.yml
+++ b/.github/workflows/windows-6.x.yml
@@ -140,19 +140,23 @@ jobs:
           echo "$VAR_VERSION-$VAR_SUFFIX.$release_date.$current_tag">version.txt  
           cat version.txt
           echo "$version"  
-
+      # rename the vcpkg.json. with this file existed,the vcpkg action will fall to manifest mode
+      - name: remove vcpkg.json
+        shell: bash
+        run: |   
+          mv vcpkg.json vcpkg.json.bak
       - name: vcpkg build
         uses: johnwason/vcpkg-action@v6
         id: vcpkg
         with:
-          manifest-dir: ${{ github.workspace }}
+          #manifest-dir: ${{ github.workspace }}
+          pkgs: breakpad
           triplet: x64-windows-release
           token: ${{ github.token }}
           github-binarycache: true
       - name: copy vcpkg packages into winlibs
         shell: bash
         run: |   
-          vcpkg install --x-feature=breakpad
           cp -R vcpkg/packages/breakpad_x64-windows-release/*  thirdparty/breakpad
           ls -al thirdparty/breakpad
 

--- a/.github/workflows/windows-6.x.yml
+++ b/.github/workflows/windows-6.x.yml
@@ -145,8 +145,7 @@ jobs:
         uses: johnwason/vcpkg-action@v6
         id: vcpkg
         with:
-          # pkgs: ffmpeg[core,avcodec,avformat,mp3lame,opus,speex,swresample,vorbis,fdk-aac,gpl]  breakpad
-          pkgs: breakpad
+          manifest-dir: ${{ github.workspace }}
           triplet: x64-windows-release
           token: ${{ github.token }}
           github-binarycache: true

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -12,6 +12,7 @@
     "opencc",
     "xapian",
     "zlib",
-    "openssl"
+    "openssl",
+    "breakpad"
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -12,7 +12,12 @@
     "opencc",
     "xapian",
     "zlib",
-    "openssl",
-    "breakpad"
-  ]
+    "openssl"
+  ],
+  "features": {
+    "breakpad": {
+      "description": "enable breakpad crash reporting",
+      "dependencies": [ "breakpad" ]
+    }
+  }
 }


### PR DESCRIPTION
with `vcpkg.json` in workspace ,  the vcpkg command will fall to manifest mode.   and git action will throw error.