### PR TITLE
opt: remove mimetex.cgi logic

### DIFF
--- a/src/dict/slob.cc
+++ b/src/dict/slob.cc
@@ -702,9 +702,7 @@ SlobDictionary::SlobDictionary( string const & id, string const & indexFile, vec
   ftsIdxName = indexFile + Dictionary::getFtsSuffix();
 }
 
-SlobDictionary::~SlobDictionary()
-{
-}
+SlobDictionary::~SlobDictionary() {}
 
 void SlobDictionary::loadIcon() noexcept
 {
@@ -825,13 +823,13 @@ string SlobDictionary::convert( const string & in, RefEntry const & entry )
   }
   newText.clear();
 
-  #ifdef Q_OS_WIN32
-    // Increase equations scale
-    text = QString::fromLatin1( "<script type=\"text/x-mathjax-config\">MathJax.Hub.Config({" )
-      + " SVG: { scale: 170, linebreaks: { automatic:true } }"
-      + ", \"HTML-CSS\": { scale: 210, linebreaks: { automatic:true } }"
-      + ", CommonHTML: { scale: 210, linebreaks: { automatic:true } }" + " });</script>" + text;
-  #endif
+#ifdef Q_OS_WIN32
+  // Increase equations scale
+  text = QString::fromLatin1( "<script type=\"text/x-mathjax-config\">MathJax.Hub.Config({" )
+    + " SVG: { scale: 170, linebreaks: { automatic:true } }"
+    + ", \"HTML-CSS\": { scale: 210, linebreaks: { automatic:true } }"
+    + ", CommonHTML: { scale: 210, linebreaks: { automatic:true } }" + " });</script>" + text;
+#endif
 
   // Fix outstanding elements
   text += "<br style=\"clear:both;\" />";

--- a/website/docs/dictformats.md
+++ b/website/docs/dictformats.md
@@ -70,7 +70,7 @@ Main file of DictD dictionary (.dict) or Xdxf dictionary (.xdxf) can be compress
 
 ### Slob
 
-GoldenDict can render formulas in TeX format with the built-in web engine.
+GoldenDict can render TeX formulas when a slob dictionary bundles MathJax.
 
 ### GLS
 

--- a/website/docs/dictformats.md
+++ b/website/docs/dictformats.md
@@ -70,7 +70,7 @@ Main file of DictD dictionary (.dict) or Xdxf dictionary (.xdxf) can be compress
 
 ### Slob
 
-GoldenDict can render formulas in TeX format via Mimetex program. Just place "mimetex.cgi" file beside GoldenDict executable file.
+GoldenDict can render formulas in TeX format with the built-in web engine.
 
 ### GLS
 


### PR DESCRIPTION
fix #1556 

All slob dicts with raw TeX comes from mw2slob, which already bundles mathjax since a decade ago.
https://github.com/itkach/mw2slob/tree/56da4744af4a6b9099e6bde9bad6cd30ae802226/mwscrape2slob/_MathJax
