### PR TITLE
opt: Ctrl+F page search remove highlight checkbox

### DIFF
--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -607,7 +607,7 @@ bool ArticleView::handleF3( QObject * /*obj*/, QEvent * ev )
         return true;
       }
     }
-    if ( ke->key() == Qt::Key_F3 && ftsSearchIsOpened ) {
+    if ( ke->key() == Qt::Key_F3 && ftsSearchPanel->isVisible() ) {
       if ( !ke->modifiers() ) {
         if ( ev->type() == QEvent::KeyPress )
           on_ftsSearchNext_clicked();
@@ -1930,7 +1930,7 @@ void ArticleView::openSearch()
   if ( !isVisible() )
     return;
 
-  if ( ftsSearchIsOpened )
+  if ( ftsSearchPanel->isVisible() )
     closeSearch();
 
   if ( !searchPanel->isVisible() ) {
@@ -2070,10 +2070,9 @@ bool ArticleView::closeSearch()
 
     return true;
   }
-  else if ( ftsSearchIsOpened ) {
+  if ( ftsSearchPanel->isVisible() ) {
     firstAvailableText.clear();
     uniqueMatches.clear();
-    ftsSearchIsOpened = false;
 
     ftsSearchPanel->hide();
     webview->setFocus();
@@ -2084,8 +2083,7 @@ bool ArticleView::closeSearch()
 
     return true;
   }
-  else
-    return false;
+  return false;
 }
 
 bool ArticleView::isSearchOpened()
@@ -2156,7 +2154,7 @@ void ArticleView::dictionaryClear( const ActiveDictIds & ad )
 
 void ArticleView::performFtsFindOperation( bool backwards )
 {
-  if ( !ftsSearchIsOpened )
+  if ( !ftsSearchPanel->isVisible() )
     return;
 
   if ( firstAvailableText.isEmpty() ) {

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -141,7 +141,6 @@ ArticleView::ArticleView( QWidget * parent,
   connect( searchPanel->next, &QPushButton::clicked, this, &ArticleView::on_searchNext_clicked );
   connect( searchPanel->close, &QPushButton::clicked, this, &ArticleView::on_searchCloseButton_clicked );
   connect( searchPanel->caseSensitive, &QPushButton::clicked, this, &ArticleView::on_searchCaseSensitive_clicked );
-  connect( searchPanel->highlightAll, &QPushButton::clicked, this, &ArticleView::on_highlightAllButton_clicked );
   connect( searchPanel->lineEdit, &QLineEdit::textEdited, this, &ArticleView::on_searchText_textEdited );
   connect( searchPanel->lineEdit, &QLineEdit::returnPressed, this, &ArticleView::on_searchText_returnPressed );
   connect( ftsSearchPanel->next, &QPushButton::clicked, this, &ArticleView::on_ftsSearchNext_clicked );
@@ -398,8 +397,6 @@ void ArticleView::showDefinition( QString const & word,
   // Any search opened is probably irrelevant now
   closeSearch();
 
-  // Clear highlight all button selection
-  searchPanel->highlightAll->setChecked( false );
   webview->setCursor( Qt::WaitCursor );
 
   load( req );
@@ -1995,11 +1992,6 @@ void ArticleView::on_searchCaseSensitive_clicked()
   performFindOperation( true, false );
 }
 
-void ArticleView::on_highlightAllButton_clicked()
-{
-  performFindOperation( false, false, true );
-}
-
 //the id start with "gdform-"
 void ArticleView::onJsActiveArticleChanged( QString const & id )
 {
@@ -2045,31 +2037,13 @@ void ArticleView::doubleClicked( QPoint pos )
 }
 
 
-void ArticleView::performFindOperation( bool restart, bool backwards, bool checkHighlight )
+void ArticleView::performFindOperation( bool restart, bool backwards )
 {
   QString text = searchPanel->lineEdit->text();
 
-  if ( restart || checkHighlight ) {
-    if ( restart ) {
-      // Anyone knows how we reset the search position?
-      // For now we resort to this hack:
-      if ( webview->selectedText().size() ) {
-        webview->page()->runJavaScript( "window.getSelection().removeAllRanges();_=0;" );
-      }
-    }
-
-    QWebEnginePage::FindFlags f( 0 );
-
-    if ( searchPanel->caseSensitive->isChecked() )
-      f |= QWebEnginePage::FindCaseSensitively;
-
-    webview->findText( "", f );
-
-    if ( searchPanel->highlightAll->isChecked() )
-      webview->findText( text, f );
-
-    if ( checkHighlight )
-      return;
+  if ( restart ) {
+    // Clear any current selection
+    webview->findText( "" );
   }
 
   QWebEnginePage::FindFlags f( 0 );

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -112,7 +112,6 @@ ArticleView::ArticleView( QWidget * parent,
   selectCurrentArticleAction( this ),
   copyAsTextAction( this ),
   inspectAction( this ),
-  searchIsOpened( false ),
   dictionaryBarToggled( dictionaryBarToggled_ ),
   currentGroupId( currentGroupId_ ),
   translateLine( translateLine_ )
@@ -1934,10 +1933,9 @@ void ArticleView::openSearch()
   if ( ftsSearchIsOpened )
     closeSearch();
 
-  if ( !searchIsOpened ) {
+  if ( !searchPanel->isVisible() ) {
     searchPanel->show();
     searchPanel->lineEdit->setText( getTitle() );
-    searchIsOpened = true;
   }
 
   searchPanel->lineEdit->setFocus();
@@ -1953,13 +1951,13 @@ void ArticleView::openSearch()
 
 void ArticleView::on_searchPrevious_clicked()
 {
-  if ( searchIsOpened )
+  if ( searchPanel->isVisible() )
     performFindOperation( true );
 }
 
 void ArticleView::on_searchNext_clicked()
 {
-  if ( searchIsOpened )
+  if ( searchPanel->isVisible() )
     performFindOperation( false );
 }
 
@@ -2066,10 +2064,9 @@ void ArticleView::findText( QString & text,
 
 bool ArticleView::closeSearch()
 {
-  if ( searchIsOpened ) {
+  if ( searchPanel->isVisible() ) {
     searchPanel->hide();
     webview->setFocus();
-    searchIsOpened = false;
 
     return true;
   }
@@ -2093,18 +2090,7 @@ bool ArticleView::closeSearch()
 
 bool ArticleView::isSearchOpened()
 {
-  return searchIsOpened;
-}
-
-void ArticleView::showEvent( QShowEvent * ev )
-{
-  QWidget::showEvent( ev );
-
-  if ( !searchIsOpened )
-    searchPanel->hide();
-
-  if ( !ftsSearchIsOpened )
-    ftsSearchPanel->hide();
+  return searchPanel->isVisible();
 }
 
 void ArticleView::copyAsText()

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -116,12 +116,12 @@ ArticleView::ArticleView( QWidget * parent,
   currentGroupId( currentGroupId_ ),
   translateLine( translateLine_ )
 {
-
   // setup GUI
   webview        = new ArticleWebView( this );
   ftsSearchPanel = new FtsSearchPanel( this );
   searchPanel    = new SearchPanel( this );
-
+  searchPanel->hide();
+  ftsSearchPanel->hide();
   // Layout
   auto * mainLayout = new QVBoxLayout( this );
   mainLayout->addWidget( webview );
@@ -2064,6 +2064,7 @@ void ArticleView::findText( QString & text,
 
 bool ArticleView::closeSearch()
 {
+  webview->findText( "" );
   if ( searchPanel->isVisible() ) {
     searchPanel->hide();
     webview->setFocus();

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -244,14 +244,9 @@ ArticleView::ArticleView( QWidget * parent,
   webview->grabGesture( Gestures::GDPinchGestureType );
   webview->grabGesture( Gestures::GDSwipeGestureType );
 #endif
-  // Variable name for store current selection range
-  rangeVarName = QString( "sr_%1" ).arg( QString::number( (quint64)this, 16 ) );
-
 
   connect( GlobalBroadcaster::instance(), &GlobalBroadcaster::dictionaryChanges, this, &ArticleView::setActiveDictIds );
-
   connect( GlobalBroadcaster::instance(), &GlobalBroadcaster::dictionaryClear, this, &ArticleView::dictionaryClear );
-
 
   channel = new QWebChannel( webview->page() );
   agent   = new ArticleViewAgent( this );
@@ -1950,7 +1945,7 @@ void ArticleView::openSearch()
 
   // Clear any current selection
   if ( webview->selectedText().size() ) {
-    webview->page()->runJavaScript( "window.getSelection().removeAllRanges();_=0;" );
+    webview->findText( "" );
   }
 
   if ( searchPanel->lineEdit->property( "noResults" ).toBool() ) {
@@ -2203,11 +2198,6 @@ void ArticleView::performFtsFindOperation( bool backwards )
 
   if ( ftsSearchMatchCase )
     flags |= QWebEnginePage::FindCaseSensitively;
-
-
-  // Restore saved highlighted selection
-  webview->page()->runJavaScript(
-    QString( "var sel=window.getSelection();sel.removeAllRanges();sel.addRange(%1);_=0;" ).arg( rangeVarName ) );
 
   if ( backwards ) {
 #if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -2166,9 +2166,6 @@ void ArticleView::performFtsFindOperation( bool backwards )
 
   QWebEnginePage::FindFlags flags( 0 );
 
-  if ( ftsSearchMatchCase )
-    flags |= QWebEnginePage::FindCaseSensitively;
-
   if ( backwards ) {
 #if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
     webview->findText( firstAvailableText,

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -1944,7 +1944,7 @@ void ArticleView::openSearch()
   searchPanel->lineEdit->selectAll();
 
   // Clear any current selection
-  if ( webview->selectedText().size() ) {
+  if ( !webview->selectedText().isEmpty() ) {
     webview->findText( "" );
   }
 

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -1958,18 +1958,18 @@ void ArticleView::openSearch()
 void ArticleView::on_searchPrevious_clicked()
 {
   if ( searchIsOpened )
-    performFindOperation( false, true );
+    performFindOperation( true );
 }
 
 void ArticleView::on_searchNext_clicked()
 {
   if ( searchIsOpened )
-    performFindOperation( false, false );
+    performFindOperation( false );
 }
 
 void ArticleView::on_searchText_textEdited()
 {
-  performFindOperation( true, false );
+  performFindOperation( false );
 }
 
 void ArticleView::on_searchText_returnPressed()
@@ -1984,7 +1984,7 @@ void ArticleView::on_searchCloseButton_clicked()
 
 void ArticleView::on_searchCaseSensitive_clicked()
 {
-  performFindOperation( true, false );
+  performFindOperation( false );
 }
 
 //the id start with "gdform-"
@@ -2032,14 +2032,9 @@ void ArticleView::doubleClicked( QPoint pos )
 }
 
 
-void ArticleView::performFindOperation( bool restart, bool backwards )
+void ArticleView::performFindOperation( bool backwards )
 {
   QString text = searchPanel->lineEdit->text();
-
-  if ( restart ) {
-    // Clear any current selection
-    webview->findText( "" );
-  }
 
   QWebEnginePage::FindFlags f( 0 );
 

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -1948,11 +1948,7 @@ void ArticleView::openSearch()
     webview->findText( "" );
   }
 
-  if ( searchPanel->lineEdit->property( "noResults" ).toBool() ) {
-    searchPanel->lineEdit->setProperty( "noResults", false );
-
-    Utils::Widget::setNoResultColor( searchPanel->lineEdit, false );
-  }
+  Utils::Widget::setNoResultColor( searchPanel->lineEdit, false );
 }
 
 void ArticleView::on_searchPrevious_clicked()
@@ -2046,12 +2042,7 @@ void ArticleView::performFindOperation( bool backwards )
 
   findText( text, f, [ text, this ]( bool match ) {
     bool setMark = !text.isEmpty() && !match;
-
-    if ( searchPanel->lineEdit->property( "noResults" ).toBool() != setMark ) {
-      searchPanel->lineEdit->setProperty( "noResults", setMark );
-
-      Utils::Widget::setNoResultColor( searchPanel->lineEdit, setMark );
-    }
+    Utils::Widget::setNoResultColor( searchPanel->lineEdit, setMark );
   } );
 }
 

--- a/src/ui/articleview.hh
+++ b/src/ui/articleview.hh
@@ -84,7 +84,7 @@ class ArticleView: public QWidget
   /// Search in results of full-text search
   QString firstAvailableText;
   QStringList uniqueMatches;
-  bool ftsSearchIsOpened  = false;
+
   bool ftsSearchMatchCase = false;
 
   QString delayedHighlightText;

--- a/src/ui/articleview.hh
+++ b/src/ui/articleview.hh
@@ -85,8 +85,6 @@ class ArticleView: public QWidget
   QString firstAvailableText;
   QStringList uniqueMatches;
 
-  bool ftsSearchMatchCase = false;
-
   QString delayedHighlightText;
 
   void highlightFTSResults();

--- a/src/ui/articleview.hh
+++ b/src/ui/articleview.hh
@@ -410,7 +410,7 @@ private:
 
   bool eventFilter( QObject * obj, QEvent * ev ) override;
 
-  void performFindOperation( bool restart, bool backwards );
+  void performFindOperation( bool backwards );
 
   /// Returns the comma-separated list of dictionary ids which should be muted
   /// for the given group. If there are none, returns empty string.

--- a/src/ui/articleview.hh
+++ b/src/ui/articleview.hh
@@ -363,7 +363,6 @@ private slots:
   void on_searchText_returnPressed();
   void on_searchCloseButton_clicked();
   void on_searchCaseSensitive_clicked();
-  void on_highlightAllButton_clicked();
 
   void on_ftsSearchPrevious_clicked();
   void on_ftsSearchNext_clicked();
@@ -412,7 +411,7 @@ private:
 
   bool eventFilter( QObject * obj, QEvent * ev ) override;
 
-  void performFindOperation( bool restart, bool backwards, bool checkHighlight = false );
+  void performFindOperation( bool restart, bool backwards );
 
   /// Returns the comma-separated list of dictionary ids which should be muted
   /// for the given group. If there are none, returns empty string.

--- a/src/ui/articleview.hh
+++ b/src/ui/articleview.hh
@@ -49,7 +49,7 @@ class ArticleView: public QWidget
 
   QAction pasteAction, articleUpAction, articleDownAction, goBackAction, goForwardAction, selectCurrentArticleAction,
     copyAsTextAction, inspectAction;
-  bool searchIsOpened;
+
   bool expandOptionalParts;
 
   /// An action used to create Anki notes.
@@ -417,10 +417,6 @@ private:
   QString getMutedForGroup( unsigned group );
 
   QStringList getMutedDictionaries( unsigned group );
-
-protected:
-  // We need this to hide the search bar when we're showed
-  void showEvent( QShowEvent * ) override;
 };
 
 class ResourceToSaveHandler: public QObject

--- a/src/ui/articleview.hh
+++ b/src/ui/articleview.hh
@@ -51,7 +51,6 @@ class ArticleView: public QWidget
     copyAsTextAction, inspectAction;
   bool searchIsOpened;
   bool expandOptionalParts;
-  QString rangeVarName;
 
   /// An action used to create Anki notes.
   QAction sendToAnkiAction{ tr( "&Create Anki note" ), this };

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -986,12 +986,7 @@ void MainWindow::refreshTranslateLine()
 
   // Visually mark the input line to mark if there's no results
   bool setMark = wordFinder.getResults().empty() && !wordFinder.wasSearchUncertain();
-
-  if ( translateLine->property( "noResults" ).toBool() != setMark ) {
-    translateLine->setProperty( "noResults", setMark );
-
-    Utils::Widget::setNoResultColor( translateLine, setMark );
-  }
+  Utils::Widget::setNoResultColor( translateLine, setMark );
 }
 
 void MainWindow::clipboardChange( QClipboard::Mode m )
@@ -2352,11 +2347,7 @@ void MainWindow::updateSuggestionList( QString const & newValue )
     ui.wordList->unsetCursor();
 
     // Reset the noResults mark if it's on right now
-    if ( translateLine->property( "noResults" ).toBool() ) {
-      translateLine->setProperty( "noResults", false );
-
-      Utils::Widget::setNoResultColor( translateLine, false );
-    }
+    Utils::Widget::setNoResultColor( translateLine, false );
     return;
   }
 

--- a/src/ui/searchpanel.cc
+++ b/src/ui/searchpanel.cc
@@ -20,11 +20,6 @@ SearchPanel::SearchPanel( QWidget * parent ):
   next->setText( tr( "&Next" ) );
   next->setShortcut( QKeySequence( tr( "Ctrl+G" ) ) );
 
-  highlightAll = new QCheckBox( this );
-  highlightAll->setIcon( QIcon( ":/icons/highlighter.png" ) );
-  highlightAll->setText( tr( "Highlight &all" ) );
-  highlightAll->setChecked( true );
-
   caseSensitive = new QCheckBox( this );
   caseSensitive->setText( tr( "&Case Sensitive" ) );
 
@@ -38,7 +33,6 @@ SearchPanel::SearchPanel( QWidget * parent ):
   auto * buttonsRow = new QHBoxLayout();
   buttonsRow->addWidget( previous );
   buttonsRow->addWidget( next );
-  buttonsRow->addWidget( highlightAll );
   buttonsRow->addWidget( caseSensitive );
   buttonsRow->addStretch();
 

--- a/src/ui/searchpanel.hh
+++ b/src/ui/searchpanel.hh
@@ -16,7 +16,6 @@ public:
   QPushButton * close;
   QPushButton * previous;
   QPushButton * next;
-  QCheckBox * highlightAll;
   QCheckBox * caseSensitive;
 };
 


### PR DESCRIPTION
![image](https://github.com/xiaoyifang/goldendict-ng/assets/105986/da20a7d5-1b4b-44b1-b1d3-1f8def5df26b)


We rely on webengine's findText which will highlight all the matched items on default.
And The highlight feature does not needed and it has not  worked as expected for a little while.