### PR TITLE
opt: remove deprecated method setActiveWindow()

### DIFF
--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -2756,7 +2756,6 @@ void MainWindow::toggleMainWindow( bool onlyShow )
   if ( !isVisible() ) {
     show();
 
-    qApp->setActiveWindow( this );
     activateWindow();
     raise();
     shown = true;
@@ -2771,10 +2770,9 @@ void MainWindow::toggleMainWindow( bool onlyShow )
     shown = true;
   }
   else if ( !isActiveWindow() ) {
-    qApp->setActiveWindow( this );
+    activateWindow();
     if ( cfg.preferences.raiseWindowOnSearch ) {
       raise();
-      activateWindow();
     }
     shown = true;
   }


### PR DESCRIPTION
the method was deprecated when qt>6.5

![image](https://github.com/xiaoyifang/goldendict-ng/assets/105986/d9208be3-b63b-4058-8333-cb085ed7e1f0)

From the document , the activateWindows() method seems more suitable.