### PR TITLE
feat: revise getting langfrom, langto from dict name or dict file name

### DIFF
--- a/src/dict/dictdfiles.cc
+++ b/src/dict/dictdfiles.cc
@@ -700,7 +700,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         // if no languages found, try dictionary's name
         if ( langs.first == 0 || langs.second == 0 ) {
-          langs = LangCoder::findLangIdPairFromStr( QString::fromStdString( dictionaryName ) );
+          langs = LangCoder::findLangIdPairFromName( QString::fromStdString( dictionaryName ) );
         }
 
         idxHeader.langFrom = langs.first;

--- a/src/dict/dictdfiles.cc
+++ b/src/dict/dictdfiles.cc
@@ -695,12 +695,12 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
         idxHeader.signature     = Signature;
         idxHeader.formatVersion = CurrentFormatVersion;
 
-        // read languages
-        QPair< quint32, quint32 > langs = LangCoder::findIdsForFilename( QString::fromStdString( dictFiles[ 0 ] ) );
+        // read languages from dictioanry file name
+        auto langs = LangCoder::findLangIdPairFromPath( dictFiles[ 0 ] );
 
         // if no languages found, try dictionary's name
         if ( langs.first == 0 || langs.second == 0 ) {
-          langs = LangCoder::findIdsForFilename( QString::fromStdString( nameFromFileName( dictFiles[ 0 ] ) ) );
+          langs = LangCoder::findLangIdPairFromStr( QString::fromStdString( dictionaryName ) );
         }
 
         idxHeader.langFrom = langs.first;

--- a/src/dict/gls.cc
+++ b/src/dict/gls.cc
@@ -1367,11 +1367,11 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
           idxHeader.langTo   = LangCoder::findIdForLanguage( scanner.getLangTo() );
           if ( idxHeader.langFrom == 0 && idxHeader.langTo == 0 ) {
             // if no languages found, try dictionary's file name
-            QPair< quint32, quint32 > langs = LangCoder::findIdsForFilename( QString::fromStdString( dictFiles[ 0 ] ) );
+            auto langs = LangCoder::findLangIdPairFromPath( dictFiles[ 0 ] );
 
             // if no languages found, try dictionary's name
             if ( langs.first == 0 || langs.second == 0 ) {
-              langs = LangCoder::findIdsForFilename( QString::fromStdString( dictionaryName ) );
+              langs = LangCoder::findLangIdPairFromStr( QString::fromStdString( dictionaryName ) );
             }
             idxHeader.langFrom = langs.first;
             idxHeader.langTo   = langs.second;

--- a/src/dict/gls.cc
+++ b/src/dict/gls.cc
@@ -1371,7 +1371,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
             // if no languages found, try dictionary's name
             if ( langs.first == 0 || langs.second == 0 ) {
-              langs = LangCoder::findLangIdPairFromStr( QString::fromStdString( dictionaryName ) );
+              langs = LangCoder::findLangIdPairFromName( QString::fromStdString( dictionaryName ) );
             }
             idxHeader.langFrom = langs.first;
             idxHeader.langTo   = langs.second;

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -1427,7 +1427,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
       // if no languages found, try dictionary name
       if ( langs.first == 0 || langs.second == 0 ) {
-        langs = LangCoder::findLangIdPairFromStr( parser.title() );
+        langs = LangCoder::findLangIdPairFromName( parser.title() );
       }
 
       idxHeader.langFrom = langs.first;

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -1422,12 +1422,12 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
         }
       }
 
-      // read languages
-      QPair< quint32, quint32 > langs = LangCoder::findIdsForFilename( QString::fromStdString( fileName ) );
+      // read languages from dictioanry's file name
+      auto langs = LangCoder::findLangIdPairFromPath( fileName );
 
-      // if no languages found, try dictionary's name
+      // if no languages found, try dictionary name
       if ( langs.first == 0 || langs.second == 0 ) {
-        langs = LangCoder::findIdsForFilename( parser.title() );
+        langs = LangCoder::findLangIdPairFromStr( parser.title() );
       }
 
       idxHeader.langFrom = langs.first;

--- a/src/dict/slob.cc
+++ b/src/dict/slob.cc
@@ -1318,7 +1318,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
         idxHeader.articleCount = articleCount;
         idxHeader.wordCount    = wordCount;
 
-        QPair< quint32, quint32 > langs = LangCoder::findIdsForFilename( QString::fromStdString( dictFiles[ 0 ] ) );
+        auto langs = LangCoder::findLangIdPairFromPath( dictFiles[ 0 ] );
 
         idxHeader.langFrom = langs.first;
         idxHeader.langTo   = langs.second;

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -1904,10 +1904,10 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
         idxHeader.sameTypeSequenceSize = ifo.sametypesequence.size();
 
         // read languages from dictioanry file name
-        auto langs = LangCoder::findLangIdPairFromStr( QString::fromStdString( dictFileName ) );
+        auto langs = LangCoder::findLangIdPairFromName( QString::fromStdString( dictFileName ) );
         // if no languages found, try dictionary's name
         if ( langs.first == 0 || langs.second == 0 ) {
-          langs = LangCoder::findLangIdPairFromStr( QString::fromStdString( ifo.bookname ) );
+          langs = LangCoder::findLangIdPairFromName( QString::fromStdString( ifo.bookname ) );
         }
 
         idxHeader.langFrom = langs.first;

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -1903,12 +1903,11 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
         idxHeader.bookNameSize         = ifo.bookname.size();
         idxHeader.sameTypeSequenceSize = ifo.sametypesequence.size();
 
-        // read languages
-        QPair< quint32, quint32 > langs = LangCoder::findIdsForFilename( QString::fromStdString( dictFileName ) );
-
+        // read languages from dictioanry file name
+        auto langs = LangCoder::findLangIdPairFromStr( QString::fromStdString( dictFileName ) );
         // if no languages found, try dictionary's name
         if ( langs.first == 0 || langs.second == 0 ) {
-          langs = LangCoder::findIdsForFilename( QString::fromStdString( ifo.bookname ) );
+          langs = LangCoder::findLangIdPairFromStr( QString::fromStdString( ifo.bookname ) );
         }
 
         idxHeader.langFrom = langs.first;

--- a/src/langcoder.cc
+++ b/src/langcoder.cc
@@ -208,19 +208,19 @@ QMap< QString, GDLangCode > LangCoder::LANG_CODE_MAP = {
 
 QString LangCoder::decode( quint32 _code )
 {
-  if ( auto code = intToCode2( _code ); exists( code ) )
+  if ( auto code = intToCode2( _code ); code2Exists( code ) )
     return QString::fromStdString( LANG_CODE_MAP[ code ].lang );
 
   return {};
 }
-bool LangCoder::exists( const QString & _code )
+bool LangCoder::code2Exists( const QString & _code )
 {
   return LANG_CODE_MAP.contains( _code );
 }
 
 QIcon LangCoder::icon( quint32 _code )
 {
-  if ( auto code = intToCode2( _code ); exists( code ) ) {
+  if ( auto code = intToCode2( _code ); code2Exists( code ) ) {
     const GDLangCode & lc = LANG_CODE_MAP[ code ];
     return QIcon( ":/flags/" + QString( lc.code ) + ".png" );
   }
@@ -285,7 +285,7 @@ quint32 LangCoder::guessId( const QString & lang )
   return code2toInt( lstr.left( 2 ).toLatin1().data() );
 }
 
-QPair< quint32, quint32 > LangCoder::findIdsForName( QString const & name )
+std::pair< quint32, quint32 > LangCoder::findLangIdPairFromStr( QString const & name )
 {
   QString nameFolded = "|" + name.toCaseFolded() + "|";
   QRegExp reg( "[^a-z]([a-z]{2,3})-([a-z]{2,3})[^a-z]" );
@@ -304,14 +304,14 @@ QPair< quint32, quint32 > LangCoder::findIdsForName( QString const & name )
   return QPair< quint32, quint32 >( 0, 0 );
 }
 
-QPair< quint32, quint32 > LangCoder::findIdsForFilename( QString const & name )
+static std::pair< quint32, quint32 > findLangIdPairFromPath( std::string const & p )
 {
-  return findIdsForName( QFileInfo( name ).fileName() );
+  return LangCoder::findLangIdPairFromStr( QFileInfo( QString::fromStdString( p ) ).fileName() );
 }
 
 bool LangCoder::isLanguageRTL( quint32 _code )
 {
-  if ( auto code = intToCode2( _code ); exists( code ) ) {
+  if ( auto code = intToCode2( _code ); code2Exists( code ) ) {
     GDLangCode lc = LANG_CODE_MAP[ code ];
     if ( lc.isRTL < 0 ) {
       lc.isRTL = static_cast< int >( QLocale( lc.code ).textDirection() == Qt::RightToLeft );

--- a/src/langcoder.cc
+++ b/src/langcoder.cc
@@ -219,7 +219,7 @@ QIcon LangCoder::icon( quint32 _code )
 {
   if ( auto code = intToCode2( _code ); code2Exists( code ) ) {
     const GDLangCode & lc = LANG_CODE_MAP[ code ];
-    return QIcon( ":/flags/" + QString( lc.code ) + ".png" );
+    return QIcon( ":/flags/" + QString( lc.code2 ) + ".png" );
   }
 
   return {};
@@ -243,7 +243,7 @@ quint32 LangCoder::findIdForLanguage( gd::wstring const & lang )
 
   for ( auto const & lc : LANG_CODE_MAP ) {
     if ( strcasecmp( langFolded.c_str(), lc.lang.c_str() ) == 0 ) {
-      return code2toInt( lc.code.toStdString().c_str() );
+      return code2toInt( lc.code2.toStdString().c_str() );
     }
   }
 
@@ -254,7 +254,7 @@ quint32 LangCoder::findIdForLanguageCode3( std::string const & code )
 {
   for ( auto const & lc : LANG_CODE_MAP ) {
     if ( code == lc.code3 ) {
-      return code2toInt( lc.code );
+      return code2toInt( lc.code2 );
     }
   }
 
@@ -273,7 +273,7 @@ quint32 LangCoder::guessId( const QString & lang )
   if ( lstr.size() >= 3 ) {
     for ( auto const & lc : LANG_CODE_MAP ) {
       if ( lstr == ( lstr.size() == 3 ? QString::fromStdString( lc.code3 ) : QString::fromStdString( lc.lang ) ) ) {
-        return code2toInt( lc.code );
+        return code2toInt( lc.code2 );
       }
     }
   }
@@ -311,7 +311,7 @@ bool LangCoder::isLanguageRTL( quint32 _code )
   if ( auto code = intToCode2( _code ); code2Exists( code ) ) {
     GDLangCode lc = LANG_CODE_MAP[ code ];
     if ( lc.isRTL < 0 ) {
-      lc.isRTL = static_cast< int >( QLocale( lc.code ).textDirection() == Qt::RightToLeft );
+      lc.isRTL = static_cast< int >( QLocale( lc.code2 ).textDirection() == Qt::RightToLeft );
     }
     return lc.isRTL != 0;
   }

--- a/src/langcoder.hh
+++ b/src/langcoder.hh
@@ -40,8 +40,8 @@ public:
   static quint32 findIdForLanguageCode3( std::string const & );
 
   /// find id pairs like en-zh in dictioanry name
-  static std::pair< quint32, quint32 > findLangIdPairFromStr( QString const & );
-  static std::pair< quint32, quint32 > findLangIdPairFromPath( std::string const & );
+  static QPair< quint32, quint32 > findLangIdPairFromName( QString const & );
+  static QPair< quint32, quint32 > findLangIdPairFromPath( std::string const & );
 
   static quint32 guessId( const QString & lang );
 

--- a/src/langcoder.hh
+++ b/src/langcoder.hh
@@ -39,8 +39,9 @@ public:
 
   static quint32 findIdForLanguageCode3( std::string const & );
 
-  static QPair< quint32, quint32 > findIdsForName( QString const & );
-  static QPair< quint32, quint32 > findIdsForFilename( QString const & );
+  /// find id pairs like en-zh in dictioanry name
+  static std::pair< quint32, quint32 > findLangIdPairFromStr( QString const & );
+  static std::pair< quint32, quint32 > findLangIdPairFromPath( std::string const & );
 
   static quint32 guessId( const QString & lang );
 
@@ -54,7 +55,7 @@ public:
 
 private:
   static QMap< QString, GDLangCode > LANG_CODE_MAP;
-  static bool exists( const QString & _code );
+  static bool code2Exists( const QString & _code );
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/langcoder.hh
+++ b/src/langcoder.hh
@@ -7,7 +7,7 @@
 
 struct GDLangCode
 {
-  QString code;      // ISO 639-1
+  QString code2;     // ISO 639-1 -> always 2 letters thus code2
   std::string code3; // ISO 639-2B ( http://www.loc.gov/standards/iso639-2/ )
   int isRTL;         // Right-to-left writing; 0 - no, 1 - yes, -1 - let Qt define
   std::string lang;  // Language name in English

--- a/src/ui/groups_widgets.cc
+++ b/src/ui/groups_widgets.cc
@@ -661,7 +661,7 @@ void DictGroupsWidget::addAutoGroups()
       // Attempt to find language pair in dictionary name
 
       const QPair< quint32, quint32 > ids =
-        LangCoder::findLangIdPairFromStr( QString::fromUtf8( dict->getName().c_str() ) );
+        LangCoder::findLangIdPairFromName( QString::fromUtf8( dict->getName().c_str() ) );
       idFrom                              = ids.first;
       idTo                                = ids.second;
     }

--- a/src/ui/groups_widgets.cc
+++ b/src/ui/groups_widgets.cc
@@ -660,7 +660,8 @@ void DictGroupsWidget::addAutoGroups()
     if ( idFrom == 0 ) {
       // Attempt to find language pair in dictionary name
 
-      const QPair< quint32, quint32 > ids = LangCoder::findIdsForName( QString::fromUtf8( dict->getName().c_str() ) );
+      const QPair< quint32, quint32 > ids =
+        LangCoder::findLangIdPairFromStr( QString::fromUtf8( dict->getName().c_str() ) );
       idFrom                              = ids.first;
       idTo                                = ids.second;
     }

--- a/src/ui/orderandprops.cc
+++ b/src/ui/orderandprops.cc
@@ -33,7 +33,7 @@ bool dictLessThan( sptr< Dictionary::Class > const & dict1, sptr< Dictionary::Cl
   int idFrom1 = dict1->getLangFrom();
   int idTo1   = dict1->getLangTo();
   if ( idFrom1 == 0 ) {
-    QPair< quint32, quint32 > ids = LangCoder::findLangIdPairFromStr( QString::fromUtf8( dict1->getName().c_str() ) );
+    QPair< quint32, quint32 > ids = LangCoder::findLangIdPairFromName( QString::fromUtf8( dict1->getName().c_str() ) );
     idFrom1                       = ids.first;
     idTo1                         = ids.second;
   }
@@ -41,7 +41,7 @@ bool dictLessThan( sptr< Dictionary::Class > const & dict1, sptr< Dictionary::Cl
   int idFrom2 = dict2->getLangFrom();
   int idTo2   = dict2->getLangTo();
   if ( idFrom2 == 0 ) {
-    QPair< quint32, quint32 > ids = LangCoder::findLangIdPairFromStr( QString::fromUtf8( dict2->getName().c_str() ) );
+    QPair< quint32, quint32 > ids = LangCoder::findLangIdPairFromName( QString::fromUtf8( dict2->getName().c_str() ) );
     idFrom2                       = ids.first;
     idTo2                         = ids.second;
   }

--- a/src/ui/orderandprops.cc
+++ b/src/ui/orderandprops.cc
@@ -33,7 +33,7 @@ bool dictLessThan( sptr< Dictionary::Class > const & dict1, sptr< Dictionary::Cl
   int idFrom1 = dict1->getLangFrom();
   int idTo1   = dict1->getLangTo();
   if ( idFrom1 == 0 ) {
-    QPair< quint32, quint32 > ids = LangCoder::findIdsForName( QString::fromUtf8( dict1->getName().c_str() ) );
+    QPair< quint32, quint32 > ids = LangCoder::findLangIdPairFromStr( QString::fromUtf8( dict1->getName().c_str() ) );
     idFrom1                       = ids.first;
     idTo1                         = ids.second;
   }
@@ -41,7 +41,7 @@ bool dictLessThan( sptr< Dictionary::Class > const & dict1, sptr< Dictionary::Cl
   int idFrom2 = dict2->getLangFrom();
   int idTo2   = dict2->getLangTo();
   if ( idFrom2 == 0 ) {
-    QPair< quint32, quint32 > ids = LangCoder::findIdsForName( QString::fromUtf8( dict2->getName().c_str() ) );
+    QPair< quint32, quint32 > ids = LangCoder::findLangIdPairFromStr( QString::fromUtf8( dict2->getName().c_str() ) );
     idFrom2                       = ids.first;
     idTo2                         = ids.second;
   }

--- a/website/docs/manage_groups.md
+++ b/website/docs/manage_groups.md
@@ -10,13 +10,11 @@ Additionally, multiple strategies of automatic grouping are provided:
 
 ## Auto groups by dictionary language
 
-When group by dictionary language, the language is taken from dictionary's built-in metadata which has been embed when creating dictionary.
+For formats like DSL, which has embedded language from / to metadata, GoldenDict will use the dictionary's built-in metadata.
 
-If the language is not present in the dictionary, it will try to detect the language from the dictionary file name.
+For other formats, GoldenDict will try to extract languages from the dictionary's name or its file name by finding `{id}-{id}` pair. The `{id}` is 2 or 3 letters ISO 639 codes. For example, if a dictionary named `some name en-zh`, it will be automatically grouped into `en-zh`.
 
-Then use the founded language to create dictionary groups.
-
-Groups created in this method also include a context menu when rich click the group name, in which you can do additional dictionaries grouping by source or target language and combine dictionaries in more large groups.
+Groups created in this method also include a context menu when right-click the group name, in which you can do additional dictionaries grouping by source or target language and combine dictionaries in more large groups.
 
 ## Auto groups by folders
 


### PR DESCRIPTION
I was just trying to port away from `qt5compat` by porting one single `QRegExp`, and it turns out this feature is implemented wrong in a few places and only partially documented (not only file name, but also dict's canonical name for some formats).

`findIdsForFilename` is just `findIdsForName` plus `QFileInfo::filename`, but every dicts is implemented very differently. Read those code needs to read what is wrapped in `findIdsForFilename` anyway, so I deleted it.

Qt5 CI will fail, how about delete it now 😅