### PR TITLE
opt: headwords dialog

### DIFF
--- a/src/btreeidx.cc
+++ b/src/btreeidx.cc
@@ -1157,13 +1157,9 @@ void BtreeIndex::findArticleLinks( QVector< WordArticleLink > * articleLinks,
   }
 }
 
-void BtreeIndex::findHeadWords( QSet< uint32_t > offsets, int & index, QSet< QString > * headwords, uint32_t length )
+void BtreeIndex::findHeadWords( QList< uint32_t > offsets, int & index, QSet< QString > * headwords, uint32_t length )
 {
-  int i = 0;
-  for ( auto begin = offsets.begin(); begin != offsets.end(); begin++, i++ ) {
-    if ( i < index ) {
-      continue;
-    }
+  for ( auto begin = offsets.begin() + index; begin != offsets.end(); begin++ ) {
     findSingleNodeHeadwords( *begin, headwords );
     index++;
 
@@ -1207,8 +1203,8 @@ void BtreeIndex::findSingleNodeHeadwords( uint32_t offsets, QSet< QString > * he
   }
 }
 
-//find the next chain ptr ,which is large than this currentChainPtr
-QSet< uint32_t > BtreeIndex::findNodes()
+//find the next chain ptr ,which is larger than this currentChainPtr
+QList< uint32_t > BtreeIndex::findNodes()
 {
   QMutexLocker _( idxFileMutex );
 
@@ -1219,12 +1215,12 @@ QSet< uint32_t > BtreeIndex::findNodes()
   }
 
   char const * leaf = &rootNode.front();
-  QSet< uint32_t > leafOffset;
+  QList< uint32_t > leafOffset;
 
   uint32_t leafEntries;
   leafEntries = *(uint32_t *)leaf;
   if ( leafEntries != 0xffffFFFF ) {
-    leafOffset.insert( rootOffset );
+    leafOffset.append( rootOffset );
     return leafOffset;
   }
 
@@ -1234,8 +1230,9 @@ QSet< uint32_t > BtreeIndex::findNodes()
   uint32_t * offsets = (uint32_t *)leaf + 1;
   uint32_t i         = 0;
 
-  while ( i++ < ( indexNodeSize + 1 ) )
-    leafOffset.insert( *( offsets++ ) );
+  while ( i++ < ( indexNodeSize + 1 ) ) {
+    leafOffset.append( *( offsets++ ) );
+  }
 
   return leafOffset;
 }

--- a/src/btreeidx.hh
+++ b/src/btreeidx.hh
@@ -100,9 +100,9 @@ public:
                          QSet< QString > * headwords,
                          QAtomicInt * isCancelled = 0 );
 
-  void findHeadWords( QSet< uint32_t > offsets, int & index, QSet< QString > * headwords, uint32_t length );
+  void findHeadWords( QList< uint32_t > offsets, int & index, QSet< QString > * headwords, uint32_t length );
   void findSingleNodeHeadwords( uint32_t offsets, QSet< QString > * headwords );
-  QSet< uint32_t > findNodes();
+  QList< uint32_t > findNodes();
 
   /// Retrieve headwords for presented article addresses
   void

--- a/src/headwordsmodel.cc
+++ b/src/headwordsmodel.cc
@@ -46,7 +46,7 @@ void HeadwordListModel::setFilter( QRegularExpression reg )
   if ( reg.pattern().isEmpty() ) {
     QMutexLocker _( &lock );
     //race condition.
-    if(!filtering){
+    if ( !filtering ) {
       return;
     }
     filtering = false;
@@ -60,14 +60,13 @@ void HeadwordListModel::setFilter( QRegularExpression reg )
 
     return;
   }
-  else{
+  else {
     QMutexLocker _( &lock );
     //the first time to enter filtering mode.
-    if(!filtering){
+    if ( !filtering ) {
       filtering = true;
       original_words << words;
     }
-
   }
   filterWords.clear();
   auto sr = _dict->prefixMatch( gd::removeTrailingZero( reg.pattern() ), maxFilterResults );

--- a/src/headwordsmodel.cc
+++ b/src/headwordsmodel.cc
@@ -142,7 +142,7 @@ void HeadwordListModel::fetchMore( const QModelIndex & parent )
     return;
 
   //arbitrary number
-  if ( totalSize < 500000 ) {
+  if ( totalSize < HEADWORDS_MAX_LIMIT ) {
     finished = true;
 
     beginInsertRows( QModelIndex(), 0, totalSize - 1 );

--- a/src/headwordsmodel.cc
+++ b/src/headwordsmodel.cc
@@ -62,7 +62,7 @@ void HeadwordListModel::setFilter( QRegularExpression reg )
     QMutexLocker _( &lock );
     //the first time to enter filtering mode.
     if ( !filtering ) {
-      filtering = true;
+      filtering      = true;
       original_words = QStringList( words );
     }
   }

--- a/src/headwordsmodel.cc
+++ b/src/headwordsmodel.cc
@@ -53,10 +53,8 @@ void HeadwordListModel::setFilter( QRegularExpression reg )
 
     //reset to previous models
     beginResetModel();
-    words.clear();
-    words << original_words;
+    words = QStringList( original_words );
     endResetModel();
-    original_words.clear();
 
     return;
   }
@@ -65,7 +63,7 @@ void HeadwordListModel::setFilter( QRegularExpression reg )
     //the first time to enter filtering mode.
     if ( !filtering ) {
       filtering = true;
-      original_words << words;
+      original_words = QStringList( words );
     }
   }
   filterWords.clear();

--- a/src/headwordsmodel.cc
+++ b/src/headwordsmodel.cc
@@ -141,7 +141,7 @@ bool HeadwordListModel::canFetchMore( const QModelIndex & parent ) const
 
 void HeadwordListModel::fetchMore( const QModelIndex & parent )
 {
-  if ( parent.isValid() || filtering )
+  if ( parent.isValid() || filtering || finished)
     return;
 
 //arbitrary number

--- a/src/headwordsmodel.cc
+++ b/src/headwordsmodel.cc
@@ -23,7 +23,7 @@ int HeadwordListModel::totalCount() const
 
 bool HeadwordListModel::isFinish() const
 {
-  return finished||(words.size() >= totalSize);
+  return finished || ( words.size() >= totalSize );
 }
 
 // export headword
@@ -38,7 +38,7 @@ QString HeadwordListModel::getRow( int row )
 
 void HeadwordListModel::setFilter( QRegularExpression reg )
 {
-  if(finished){
+  if ( finished ) {
     return;
   }
   if ( reg.pattern().isEmpty() ) {
@@ -127,14 +127,14 @@ bool HeadwordListModel::canFetchMore( const QModelIndex & parent ) const
 
 void HeadwordListModel::fetchMore( const QModelIndex & parent )
 {
-  if ( parent.isValid() || filtering || finished)
+  if ( parent.isValid() || filtering || finished )
     return;
 
-//arbitrary number
-  if(totalSize <500000){
+  //arbitrary number
+  if ( totalSize < 500000 ) {
     finished = true;
 
-    beginInsertRows( QModelIndex(), 0, totalSize-1 );
+    beginInsertRows( QModelIndex(), 0, totalSize - 1 );
     _dict->getHeadwords( words );
 
     endInsertRows();
@@ -188,5 +188,5 @@ void HeadwordListModel::setDict( Dictionary::Class * dict )
 {
   _dict     = dict;
   totalSize = _dict->getWordCount();
-  maxElementSizePerNode = sqrt( totalSize ) +1;
+  maxElementSizePerNode = sqrt( totalSize ) + 1;
 }

--- a/src/headwordsmodel.cc
+++ b/src/headwordsmodel.cc
@@ -5,9 +5,9 @@ HeadwordListModel::HeadwordListModel( QObject * parent ):
   QAbstractListModel( parent ),
   filtering( false ),
   totalSize( 0 ),
+  finished( false ),
   index( 0 ),
-  ptr( nullptr ),
-  finished( false )
+  ptr( nullptr )
 {
 }
 
@@ -55,7 +55,7 @@ void HeadwordListModel::setFilter( QRegularExpression reg )
   }
   filtering = true;
   filterWords.clear();
-  auto sr = _dict->prefixMatch( gd::removeTrailingZero( reg.pattern() ), 500 );
+  auto sr = _dict->prefixMatch( gd::removeTrailingZero( reg.pattern() ), maxFilterResults );
   connect( sr.get(), &Dictionary::Request::finished, this, &HeadwordListModel::requestFinished, Qt::QueuedConnection );
   queuedRequests.push_back( sr );
 }
@@ -168,6 +168,11 @@ int HeadwordListModel::getCurrentIndex() const
 bool HeadwordListModel::containWord( const QString & word )
 {
   return hashedWords.contains( word );
+}
+
+void HeadwordListModel::setMaxFilterResults( int _maxFilterResults )
+{
+  this->maxFilterResults = _maxFilterResults;
 }
 
 QSet< QString > HeadwordListModel::getRemainRows( int & nodeIndex )

--- a/src/headwordsmodel.cc
+++ b/src/headwordsmodel.cc
@@ -193,5 +193,4 @@ void HeadwordListModel::setDict( Dictionary::Class * dict )
 {
   _dict     = dict;
   totalSize = _dict->getWordCount();
-  maxElementSizePerNode = sqrt( totalSize ) + 1;
 }

--- a/src/headwordsmodel.cc
+++ b/src/headwordsmodel.cc
@@ -6,7 +6,8 @@ HeadwordListModel::HeadwordListModel( QObject * parent ):
   filtering( false ),
   totalSize( 0 ),
   index( 0 ),
-  ptr( nullptr )
+  ptr( nullptr ),
+  finished( false )
 {
 }
 
@@ -149,8 +150,8 @@ void HeadwordListModel::fetchMore( const QModelIndex & parent )
     finished = true;
 
     beginInsertRows( QModelIndex(), 0, totalSize-1 );
-    _dict->getHeadwords( &words );
-    
+    _dict->getHeadwords( words );
+
     endInsertRows();
     emit numberPopulated( words.size() );
     return;

--- a/src/headwordsmodel.cc
+++ b/src/headwordsmodel.cc
@@ -36,7 +36,7 @@ QString HeadwordListModel::getRow( int row )
   return fileSortedList.at( row );
 }
 
-void HeadwordListModel::setFilter( QRegularExpression reg )
+void HeadwordListModel::setFilter( const QRegularExpression & reg )
 {
   //if the headword is already finished loaded, do nothing。
   if ( finished ) {

--- a/src/headwordsmodel.cc
+++ b/src/headwordsmodel.cc
@@ -102,9 +102,9 @@ void HeadwordListModel::requestFinished()
       return;
     }
     beginResetModel();
-    words.clear();
-    words << filterWords;
+    words = QStringList( filterWords );
     endResetModel();
+    emit numberPopulated( words.size() );
   }
 }
 

--- a/src/headwordsmodel.hh
+++ b/src/headwordsmodel.hh
@@ -20,7 +20,7 @@ public:
   bool isFinish() const;
   QVariant data( const QModelIndex & index, int role = Qt::DisplayRole ) const override;
   QString getRow( int row );
-  void setFilter( QRegularExpression );
+  void setFilter( const QRegularExpression & );
   void appendWord( const QString & word );
   int getCurrentIndex() const;
   bool containWord( const QString & word );

--- a/src/headwordsmodel.hh
+++ b/src/headwordsmodel.hh
@@ -45,7 +45,6 @@ private:
   QStringList fileSortedList;
   long totalSize;
   int maxFilterResults;
-  long maxElementSizePerNode;
   bool finished;
   Dictionary::Class * _dict;
   int index;

--- a/src/headwordsmodel.hh
+++ b/src/headwordsmodel.hh
@@ -6,6 +6,7 @@
 #include <QAbstractListModel>
 #include <QStringList>
 
+static const int HEADWORDS_MAX_LIMIT = 500000;
 class HeadwordListModel: public QAbstractListModel
 {
   Q_OBJECT

--- a/src/headwordsmodel.hh
+++ b/src/headwordsmodel.hh
@@ -21,7 +21,6 @@ public:
   QString getRow( int row );
   void setFilter( QRegularExpression );
   void appendWord( const QString & word );
-  void addMatches( QStringList matches );
   int getCurrentIndex() const;
   bool containWord( const QString & word );
   QSet< QString > getRemainRows( int & nodeIndex );
@@ -38,6 +37,7 @@ protected:
 
 private:
   QStringList words;
+  QStringList original_words;
   QSet< QString > hashedWords;
   QStringList filterWords;
   bool filtering;

--- a/src/headwordsmodel.hh
+++ b/src/headwordsmodel.hh
@@ -27,7 +27,6 @@ public:
   QSet< QString > getRemainRows( int & nodeIndex );
 signals:
   void numberPopulated( int number );
-  void finished( int number );
 
 public slots:
   void setDict( Dictionary::Class * dict );

--- a/src/headwordsmodel.hh
+++ b/src/headwordsmodel.hh
@@ -44,6 +44,8 @@ private:
   bool filtering;
   QStringList fileSortedList;
   long totalSize;
+  long maxElementSizePerNode;
+  bool finished;
   Dictionary::Class * _dict;
   int index;
   char * ptr;

--- a/src/headwordsmodel.hh
+++ b/src/headwordsmodel.hh
@@ -24,6 +24,7 @@ public:
   int getCurrentIndex() const;
   bool containWord( const QString & word );
   QSet< QString > getRemainRows( int & nodeIndex );
+  void setMaxFilterResults( int _maxFilterResults );
 signals:
   void numberPopulated( int number );
 
@@ -43,6 +44,7 @@ private:
   bool filtering;
   QStringList fileSortedList;
   long totalSize;
+  int maxFilterResults;
   long maxElementSizePerNode;
   bool finished;
   Dictionary::Class * _dict;

--- a/src/ui/dictheadwords.cc
+++ b/src/ui/dictheadwords.cc
@@ -16,14 +16,12 @@
 #include <QMutexLocker>
 #include <memory>
 
-#define AUTO_APPLY_LIMIT 150000
 
 enum SearchType {
   FixedString,
   Wildcard,
   Regex
 };
-
 DictHeadwords::DictHeadwords( QWidget * parent, Config::Class & cfg_, Dictionary::Class * dict_ ):
   QDialog( parent ),
   cfg( cfg_ ),
@@ -139,15 +137,8 @@ void DictHeadwords::setup( Dictionary::Class * dict_ )
   proxy->sort( 0 );
   filterChanged();
 
-  if ( size > AUTO_APPLY_LIMIT ) {
-    cfg.headwordsDialog.autoApply = ui.autoApply->isChecked();
-    ui.autoApply->setChecked( false );
-    ui.autoApply->setEnabled( false );
-  }
-  else {
-    ui.autoApply->setEnabled( true );
-    ui.autoApply->setChecked( cfg.headwordsDialog.autoApply );
-  }
+  ui.autoApply->setEnabled( true );
+  ui.autoApply->setChecked( cfg.headwordsDialog.autoApply );
 
   ui.applyButton->setEnabled( !ui.autoApply->isChecked() );
 
@@ -163,8 +154,7 @@ void DictHeadwords::savePos()
   cfg.headwordsDialog.searchMode = ui.searchModeCombo->currentIndex();
   cfg.headwordsDialog.matchCase  = ui.matchCase->isChecked();
 
-  if ( model->totalCount() <= AUTO_APPLY_LIMIT )
-    cfg.headwordsDialog.autoApply = ui.autoApply->isChecked();
+  cfg.headwordsDialog.autoApply = ui.autoApply->isChecked();
 
   cfg.headwordsDialog.headwordsDialogGeometry = saveGeometry();
 }

--- a/src/ui/dictheadwords.cc
+++ b/src/ui/dictheadwords.cc
@@ -74,6 +74,10 @@ DictHeadwords::DictHeadwords( QWidget * parent, Config::Class & cfg_, Dictionary
 
   ui.autoApply->setChecked( cfg.headwordsDialog.autoApply );
 
+  //arbitrary number.
+  bool exceedLimit = model->totalCount() > HEADWORDS_MAX_LIMIT;
+  ui.filterMaxResult->setEnabled( exceedLimit );
+
   connect( this, &QDialog::finished, this, &DictHeadwords::savePos );
 
   if ( !fromMainWindow ) {
@@ -142,6 +146,10 @@ void DictHeadwords::setup( Dictionary::Class * dict_ )
 
   ui.applyButton->setEnabled( !ui.autoApply->isChecked() );
 
+  //arbitrary number.
+  bool exceedLimit = model->totalCount() > HEADWORDS_MAX_LIMIT;
+  ui.filterMaxResult->setEnabled( exceedLimit );
+
   setWindowIcon( dict->getIcon() );
 
   dictId = QString( dict->getId().c_str() );
@@ -153,9 +161,7 @@ void DictHeadwords::savePos()
 {
   cfg.headwordsDialog.searchMode = ui.searchModeCombo->currentIndex();
   cfg.headwordsDialog.matchCase  = ui.matchCase->isChecked();
-
   cfg.headwordsDialog.autoApply = ui.autoApply->isChecked();
-
   cfg.headwordsDialog.headwordsDialogGeometry = saveGeometry();
 }
 
@@ -283,7 +289,7 @@ void DictHeadwords::showHeadwordsNumber()
   }
 }
 
-void DictHeadwords::loadAllSortedWords( QProgressDialog & progress, QTextStream & out )
+void DictHeadwords::exportAllWords( QProgressDialog & progress, QTextStream & out )
 {
   if ( const QRegularExpression regExp = getFilterRegex(); regExp.isValid() && !regExp.pattern().isEmpty() ) {
     loadRegex( progress, out );
@@ -399,7 +405,7 @@ void DictHeadwords::saveHeadersToFile()
   out.setCodec( "UTF-8" );
 #endif
 
-  loadAllSortedWords( progress, out );
+  exportAllWords( progress, out );
 
   file.close();
 
@@ -410,7 +416,6 @@ void DictHeadwords::saveHeadersToFile()
   }
   else {
     //completed.
-    progress.setValue( headwordsNumber * 2 );
     progress.close();
     QMessageBox::information( this, "GoldenDict", tr( "Export finished" ) );
   }

--- a/src/ui/dictheadwords.cc
+++ b/src/ui/dictheadwords.cc
@@ -161,7 +161,7 @@ void DictHeadwords::savePos()
 {
   cfg.headwordsDialog.searchMode = ui.searchModeCombo->currentIndex();
   cfg.headwordsDialog.matchCase  = ui.matchCase->isChecked();
-  cfg.headwordsDialog.autoApply = ui.autoApply->isChecked();
+  cfg.headwordsDialog.autoApply               = ui.autoApply->isChecked();
   cfg.headwordsDialog.headwordsDialogGeometry = saveGeometry();
 }
 

--- a/src/ui/dictheadwords.cc
+++ b/src/ui/dictheadwords.cc
@@ -55,6 +55,7 @@ DictHeadwords::DictHeadwords( QWidget * parent, Config::Class & cfg_, Dictionary
   ui.matchCase->setChecked( cfg.headwordsDialog.matchCase );
 
   model = std::make_shared< HeadwordListModel >();
+  model->setMaxFilterResults( ui.filterMaxResult->value() );
   proxy = new QSortFilterProxyModel( this );
 
   proxy->setSourceModel( model.get() );
@@ -107,6 +108,9 @@ DictHeadwords::DictHeadwords( QWidget * parent, Config::Class & cfg_, Dictionary
   connect( ui.headersListView, &QAbstractItemView::clicked, this, &DictHeadwords::itemClicked );
 
   connect( proxy, &QAbstractItemModel::dataChanged, this, &DictHeadwords::showHeadwordsNumber );
+  connect( ui.filterMaxResult, &QSpinBox::valueChanged, this, [ this ]( int _value ) {
+    model->setMaxFilterResults( _value );
+  } );
 
   ui.headersListView->installEventFilter( this );
 

--- a/src/ui/dictheadwords.cc
+++ b/src/ui/dictheadwords.cc
@@ -306,13 +306,13 @@ void DictHeadwords::loadAllSortedWords( QProgressDialog & progress, QTextStream 
       continue;
 
     allHeadwords.insert( value.toString() );
-    }
+  }
 
-    for ( const auto & item : allHeadwords ) {
-      progress.setValue( totalCount++ );
+  for ( const auto & item : allHeadwords ) {
+    progress.setValue( totalCount++ );
 
-      writeWordToFile( out, item );
-    }
+    writeWordToFile( out, item );
+  }
 
     // continue to write the remaining headword
     int nodeIndex  = model->getCurrentIndex();

--- a/src/ui/dictheadwords.cc
+++ b/src/ui/dictheadwords.cc
@@ -274,8 +274,16 @@ void DictHeadwords::autoApplyStateChanged( int state )
 
 void DictHeadwords::showHeadwordsNumber()
 {
-  ui.headersNumber->setText( tr( "Unique headwords total: %1, filtered: %2" )
+  if(ui.filterLine->text().isEmpty())
+  {
+    ui.headersNumber->setText( tr( "Unique headwords total: %1." )
+                               .arg( QString::number( model->totalCount() ) ) );
+  }
+  else
+  {
+    ui.headersNumber->setText( tr( "Unique headwords total: %1, filtered(limited): %2" )
                                .arg( QString::number( model->totalCount() ), QString::number( proxy->rowCount() ) ) );
+  }
 }
 
 void DictHeadwords::loadAllSortedWords( QProgressDialog & progress, QTextStream & out )

--- a/src/ui/dictheadwords.cc
+++ b/src/ui/dictheadwords.cc
@@ -294,18 +294,18 @@ void DictHeadwords::loadAllSortedWords( QProgressDialog & progress, QTextStream 
   const int headwordsNumber = model->totalCount();
 
   QMutexLocker const _( &mutex );
-    QSet< QString > allHeadwords;
+  QSet< QString > allHeadwords;
 
-    int totalCount = 0;
-    for ( int i = 0; i < headwordsNumber && i < model->wordCount(); ++i ) {
-      if ( progress.wasCanceled() )
-        break;
+  int totalCount = 0;
+  for ( int i = 0; i < headwordsNumber && i < model->wordCount(); ++i ) {
+    if ( progress.wasCanceled() )
+      break;
 
-      QVariant value = model->getRow( i );
-      if ( !value.canConvert< QString >() )
-        continue;
+    QVariant value = model->getRow( i );
+    if ( !value.canConvert< QString >() )
+      continue;
 
-      allHeadwords.insert( value.toString() );
+    allHeadwords.insert( value.toString() );
     }
 
     for ( const auto & item : allHeadwords ) {

--- a/src/ui/dictheadwords.cc
+++ b/src/ui/dictheadwords.cc
@@ -274,15 +274,12 @@ void DictHeadwords::autoApplyStateChanged( int state )
 
 void DictHeadwords::showHeadwordsNumber()
 {
-  if(ui.filterLine->text().isEmpty())
-  {
-    ui.headersNumber->setText( tr( "Unique headwords total: %1." )
-                               .arg( QString::number( model->totalCount() ) ) );
+  if ( ui.filterLine->text().isEmpty() ) {
+    ui.headersNumber->setText( tr( "Unique headwords total: %1." ).arg( QString::number( model->totalCount() ) ) );
   }
-  else
-  {
+  else {
     ui.headersNumber->setText( tr( "Unique headwords total: %1, filtered(limited): %2" )
-                               .arg( QString::number( model->totalCount() ), QString::number( proxy->rowCount() ) ) );
+                                 .arg( QString::number( model->totalCount() ), QString::number( proxy->rowCount() ) ) );
   }
 }
 

--- a/src/ui/dictheadwords.cc
+++ b/src/ui/dictheadwords.cc
@@ -109,10 +109,6 @@ DictHeadwords::DictHeadwords( QWidget * parent, Config::Class & cfg_, Dictionary
 
   connect( ui.headersListView, &QAbstractItemView::clicked, this, &DictHeadwords::itemClicked );
 
-  connect( proxy, &QAbstractItemModel::dataChanged, this, &DictHeadwords::showHeadwordsNumber );
-  connect( ui.filterMaxResult, &QSpinBox::valueChanged, this, [ this ]( int _value ) {
-    model->setMaxFilterResults( _value );
-  } );
 
   ui.headersListView->installEventFilter( this );
 
@@ -136,6 +132,7 @@ void DictHeadwords::setup( Dictionary::Class * dict_ )
   const auto size                            = dict->getWordCount();
   std::shared_ptr< HeadwordListModel > other = std::make_shared< HeadwordListModel >();
   model.swap( other );
+  model->setMaxFilterResults( ui.filterMaxResult->value() );
   model->setDict( dict );
   proxy->setSourceModel( model.get() );
   proxy->sort( 0 );
@@ -155,6 +152,13 @@ void DictHeadwords::setup( Dictionary::Class * dict_ )
   dictId = QString( dict->getId().c_str() );
 
   QApplication::restoreOverrideCursor();
+  connect( model.get(), &HeadwordListModel::numberPopulated, this, [ this ]( int _ ) {
+    showHeadwordsNumber();
+  } );
+  connect( proxy, &QAbstractItemModel::dataChanged, this, &DictHeadwords::showHeadwordsNumber );
+  connect( ui.filterMaxResult, &QSpinBox::valueChanged, this, [ this ]( int _value ) {
+    model->setMaxFilterResults( _value );
+  } );
 }
 
 void DictHeadwords::savePos()

--- a/src/ui/dictheadwords.hh
+++ b/src/ui/dictheadwords.hh
@@ -44,7 +44,7 @@ private:
   Ui::DictHeadwords ui;
   //  QStringList sortedWords;
   QMutex mutex;
-  void writeWordToFile( QTextStream & out, const QString & word );
+  static void writeWordToFile( QTextStream & out, const QString & word );
 
 private slots:
   void savePos();
@@ -56,7 +56,7 @@ private slots:
   void itemClicked( const QModelIndex & index );
   void autoApplyStateChanged( int state );
   void showHeadwordsNumber();
-  void loadAllSortedWords( QProgressDialog & progress, QTextStream & stream );
+  void exportAllWords( QProgressDialog & progress, QTextStream & out );
   void loadRegex( QProgressDialog & progress, QTextStream & out );
   virtual void reject();
 

--- a/src/ui/dictheadwords.hh
+++ b/src/ui/dictheadwords.hh
@@ -42,8 +42,10 @@ protected:
 
 private:
   Ui::DictHeadwords ui;
-  QStringList sortedWords;
+  //  QStringList sortedWords;
   QMutex mutex;
+  void writeWordToFile( QTextStream & out, const QString & word );
+
 private slots:
   void savePos();
   void filterChangedInternal();
@@ -54,7 +56,8 @@ private slots:
   void itemClicked( const QModelIndex & index );
   void autoApplyStateChanged( int state );
   void showHeadwordsNumber();
-  void loadAllSortedWords( QProgressDialog & progress );
+  void loadAllSortedWords( QProgressDialog & progress, QTextStream & stream );
+  void loadRegex( QProgressDialog & progress, QTextStream & out );
   virtual void reject();
 
 signals:

--- a/src/ui/dictheadwords.ui
+++ b/src/ui/dictheadwords.ui
@@ -116,13 +116,13 @@
                       <string/>
                   </property>
                   <property name="minimum">
-                      <number>500</number>
+                      <number>10</number>
                   </property>
                   <property name="maximum">
                       <number>3000</number>
                   </property>
                   <property name="singleStep">
-                      <number>50</number>
+                      <number>10</number>
                   </property>
               </widget>
           </item>

--- a/src/ui/dictheadwords.ui
+++ b/src/ui/dictheadwords.ui
@@ -101,6 +101,32 @@
         </widget>
        </item>
        <item>
+           <widget class="QLabel" name="label_2">
+               <property name="toolTip">
+                   <string>Specify the maximum filtered headwords returned.</string>
+               </property>
+               <property name="text">
+                   <string>Filter max results:</string>
+               </property>
+           </widget>
+       </item>
+          <item>
+              <widget class="QSpinBox" name="filterMaxResult">
+                  <property name="toolTip">
+                      <string/>
+                  </property>
+                  <property name="minimum">
+                      <number>500</number>
+                  </property>
+                  <property name="maximum">
+                      <number>3000</number>
+                  </property>
+                  <property name="singleStep">
+                      <number>50</number>
+                  </property>
+              </widget>
+          </item>
+          <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>


### PR DESCRIPTION
![image](https://github.com/xiaoyifang/goldendict-ng/assets/105986/a8735f10-fba2-45a5-bbe4-520356a901f8)

This modification based on the assumption that users will not have intention to go through all the headwords  when there are too much of the headwords.
For example, there are 1000 headwords,users may be glad to go through it one by one.
10000 headwords, users may still  have patience to go through it.
1000000 headwords,  users will  retreat from the task.

The modification load the headwords in batch mode.
If users want to check certain words,  users can use filter functionality to meet the goal.
For performance consideration ,  the max returned number of filtered headwords can be set through the UI.


Changes:
when the headwords count < 500000, load all at once.
otherwise load the headwords in batch .


The max returned filtered headwords configuration only available when in batch mode.


