### PR TITLE
opt: GlobalNetworkAccessManager

### DIFF
--- a/src/ankiconnector.cc
+++ b/src/ankiconnector.cc
@@ -3,6 +3,7 @@
 #include <QJsonObject>
 #include <QJsonValue>
 #include "utils.hh"
+#include "global_network_access_manager.hh"
 
 QString markTargetWord( QString const & sentence, QString const & word )
 {
@@ -12,10 +13,10 @@ QString markTargetWord( QString const & sentence, QString const & word )
 }
 
 AnkiConnector::AnkiConnector( QObject * parent, Config::Class const & _cfg ):
-  QObject{ parent },
+  QObject{parent},
   cfg( _cfg )
 {
-  mgr = new QNetworkAccessManager( this );
+  mgr = GlobalNetworkAccessManager;
   connect( mgr, &QNetworkAccessManager::finished, this, &AnkiConnector::finishedSlot );
 }
 

--- a/src/ankiconnector.cc
+++ b/src/ankiconnector.cc
@@ -13,7 +13,7 @@ QString markTargetWord( QString const & sentence, QString const & word )
 }
 
 AnkiConnector::AnkiConnector( QObject * parent, Config::Class const & _cfg ):
-  QObject{parent},
+  QObject{ parent },
   cfg( _cfg )
 {
   mgr = GlobalNetworkAccessManager;

--- a/src/global_network_access_manager.hh
+++ b/src/global_network_access_manager.hh
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <QNetworkAccessManager>
+
+/*
+ * Notes:
+ *
+ * This MUST be used only in the main/UI thread
+ *
+ * Retaining a pointer in objects to this globalNetworkAccessManager is OK.
+ * Having a pointer to it reduce minor overhead of global object accessing.
+ *
+ */
+
+#if ( QT_VERSION < QT_VERSION_CHECK( 6, 4, 0 ) )
+Q_GLOBAL_STATIC( QNetworkAccessManager, GlobalNetworkAccessManager );
+#else
+#include <qapplicationstatic.h>
+Q_APPLICATION_STATIC( QNetworkAccessManager, GlobalNetworkAccessManager );
+
+#endif

--- a/src/global_network_access_manager.hh
+++ b/src/global_network_access_manager.hh
@@ -15,7 +15,7 @@
 #if ( QT_VERSION < QT_VERSION_CHECK( 6, 4, 0 ) )
 Q_GLOBAL_STATIC( QNetworkAccessManager, GlobalNetworkAccessManager );
 #else
-#include <qapplicationstatic.h>
+  #include <qapplicationstatic.h>
 Q_APPLICATION_STATIC( QNetworkAccessManager, GlobalNetworkAccessManager );
 
 #endif

--- a/src/iframeschemehandler.cc
+++ b/src/iframeschemehandler.cc
@@ -1,6 +1,9 @@
 #include "iframeschemehandler.hh"
 
+#include <iostream>
 #include <QTextCodec>
+
+#include "global_network_access_manager.hh"
 
 IframeSchemeHandler::IframeSchemeHandler( QObject * parent ):
   QWebEngineUrlSchemeHandler( parent )
@@ -17,7 +20,8 @@ void IframeSchemeHandler::requestStarted( QWebEngineUrlRequestJob * requestJob )
   request.setAttribute( QNetworkRequest::RedirectPolicyAttribute,
                         QNetworkRequest::RedirectPolicy::NoLessSafeRedirectPolicy );
 
-  QNetworkReply * reply = mgr.get( request );
+  QNetworkReply * reply = GlobalNetworkAccessManager->get( request );
+  std::cout<< "thread ID" << std::this_thread::get_id() << std::endl;
 
   auto finishAction = [ = ]() {
     QByteArray contentType = "text/html";

--- a/src/iframeschemehandler.cc
+++ b/src/iframeschemehandler.cc
@@ -21,7 +21,7 @@ void IframeSchemeHandler::requestStarted( QWebEngineUrlRequestJob * requestJob )
                         QNetworkRequest::RedirectPolicy::NoLessSafeRedirectPolicy );
 
   QNetworkReply * reply = GlobalNetworkAccessManager->get( request );
-  std::cout << "thread ID" << std::this_thread::get_id() << std::endl;
+  std::cout << std::this_thread::get_id() << "thread id" << std::endl;
 
   auto finishAction = [ = ]() {
     QByteArray contentType = "text/html";

--- a/src/iframeschemehandler.cc
+++ b/src/iframeschemehandler.cc
@@ -21,7 +21,7 @@ void IframeSchemeHandler::requestStarted( QWebEngineUrlRequestJob * requestJob )
                         QNetworkRequest::RedirectPolicy::NoLessSafeRedirectPolicy );
 
   QNetworkReply * reply = GlobalNetworkAccessManager->get( request );
-  std::cout<< "thread ID" << std::this_thread::get_id() << std::endl;
+  std::cout << "thread ID" << std::this_thread::get_id() << std::endl;
 
   auto finishAction = [ = ]() {
     QByteArray contentType = "text/html";

--- a/src/iframeschemehandler.hh
+++ b/src/iframeschemehandler.hh
@@ -10,11 +10,6 @@ class IframeSchemeHandler: public QWebEngineUrlSchemeHandler
 public:
   IframeSchemeHandler( QObject * parent = nullptr );
   void requestStarted( QWebEngineUrlRequestJob * requestJob );
-
-protected:
-
-private:
-  QNetworkAccessManager mgr;
 };
 
 #endif // IFRAMESCHEMEHANDLER_H

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -172,10 +172,10 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   // Ensure globalNetworkAccessManager initalized on the UI theread by doing something with side effect.
   qDebug() << "Initalized: " << GlobalNetworkAccessManager->metaObject()->className();
-  std::cout<< "Main thread ID" << std::this_thread::get_id() << std::endl;
+  std::cout << "Main thread ID" << std::this_thread::get_id() << std::endl;
 
   localSchemeHandler     = new LocalSchemeHandler( articleNetMgr, this );
-  QStringList htmlScheme = {"gdlookup", "bword", "entry"};
+  QStringList htmlScheme = { "gdlookup", "bword", "entry" };
   for ( const auto & localScheme : htmlScheme ) {
     QWebEngineProfile::defaultProfile()->installUrlSchemeHandler( localScheme.toLatin1(), localSchemeHandler );
   }
@@ -711,7 +711,10 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   //set  webengineview font
   changeWebEngineViewFont();
 
-  connect( GlobalNetworkAccessManager, &QNetworkAccessManager::proxyAuthenticationRequired, this, &MainWindow::proxyAuthentication );
+  connect( GlobalNetworkAccessManager,
+           &QNetworkAccessManager::proxyAuthenticationRequired,
+           this,
+           &MainWindow::proxyAuthentication );
 
   connect( &articleNetMgr,
            &QNetworkAccessManager::proxyAuthenticationRequired,
@@ -2844,7 +2847,8 @@ void MainWindow::checkNewRelease()
   // github_release_api.setRawHeader( QByteArray( "Authorization" ), QByteArray( "" ) );
   github_release_api.setRawHeader( QByteArray( "X-GitHub-Api-Version" ), QByteArray( "2022-11-28" ) );
 
-  auto * github_reply = GlobalNetworkAccessManager->get( github_release_api ); // will be marked as deleteLater when reply finished.
+  auto * github_reply =
+    GlobalNetworkAccessManager->get( github_release_api ); // will be marked as deleteLater when reply finished.
 
   QObject::connect( github_reply, &QNetworkReply::finished, [ github_reply, this ]() {
     if ( github_reply->error() != QNetworkReply::NoError ) {

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -172,7 +172,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   // Ensure globalNetworkAccessManager initalized on the UI theread by doing something with side effect.
   qDebug() << "Initalized: " << GlobalNetworkAccessManager->metaObject()->className();
-  std::cout << "Main thread ID" << std::this_thread::get_id() << std::endl;
+  std::cout << std::this_thread::get_id() << "main thread id" << std::endl;
 
   localSchemeHandler     = new LocalSchemeHandler( articleNetMgr, this );
   QStringList htmlScheme = { "gdlookup", "bword", "entry" };

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -137,9 +137,7 @@ private:
   Instances::Groups groupInstances;
   ArticleMaker articleMaker;
   ArticleNetworkAccessManager articleNetMgr;
-  QNetworkAccessManager dictNetMgr; // We give dictionaries a separate manager,
-                                    // since their requests can be destroyed
-                                    // in a separate thread
+
   AudioPlayerFactory audioPlayerFactory;
 
   //current active translateLine;


### PR DESCRIPTION
Things happens in the main event loop can share the same QNetworkAccessManager

https://github.com/xiaoyifang/goldendict-ng/issues/974

Other than `AnkiConnector` and `iframehandler`, all `QNetworkAccessManager` are created by `MainWindow`, then passed down to various places. This means, if the old code is correct, then obtaining the pointer from global (pretty much the same as the `MainWindow`) is also correct.

We can further remove the `netMgr` parameter from `loadDictioanries/editDictionaries`. And instead, let dictionaries obtain a pointer to the `globalNetworkAccessManager` during initialization.

---

Random related things:

`QThread::isMainThread` in Qt6.8 https://github.com/qt/qtbase/commit/a3d50112e44bc42b310d9d3a8e6c7805ef31ef53#diff-4bb5aaa078a4700cf1c8a805176a3d445f6b0408e526612cb0a13fb19f5bd1dbR429-R444
