### PR TITLE
Update xdxf.cc to support "dict.bmp" icons

### DIFF
--- a/src/dict/xdxf.cc
+++ b/src/dict/xdxf.cc
@@ -323,10 +323,9 @@ void XdxfDictionary::loadIcon() noexcept
     info     = QFileInfo( fileName );
   }
 
-   if( !info.isFile() )
-  {
-      fileName = baseInfo.absoluteDir().absoluteFilePath( "dict.bmp" );
-      info = QFileInfo( fileName );
+  if ( !info.isFile() ) {
+    fileName = baseInfo.absoluteDir().absoluteFilePath( "dict.bmp" );
+    info     = QFileInfo( fileName );
   }
 
   if ( info.isFile() )

--- a/src/dict/xdxf.cc
+++ b/src/dict/xdxf.cc
@@ -323,6 +323,12 @@ void XdxfDictionary::loadIcon() noexcept
     info     = QFileInfo( fileName );
   }
 
+   if( !info.isFile() )
+  {
+      fileName = baseInfo.absoluteDir().absoluteFilePath( "dict.bmp" );
+      info = QFileInfo( fileName );
+  }
+
   if ( info.isFile() )
     loadIconFromFile( fileName, true );
 

--- a/website/docs/dictformats.md
+++ b/website/docs/dictformats.md
@@ -5,7 +5,7 @@ Popular dictionary formats are all supported.
 * [MDict](https://www.mdict.cn/) dictionaries (.mdx/.mdd)
 * [StarDict](http://www.huzheng.org/stardict/) dictionaries (.ifo/.dict./.idx/.syn)
 * [DSL](https://lingvoboard.ru/store/html/DSLReference_HTML/index.html) dictionaries (ABBYY Lingvo source files .dsl(.dz))
-* [Xdxf](https://github.com/soshial/xdxf_makedict) dictionaries (.xdxf(.dz))
+* [XDXF](https://github.com/soshial/xdxf_makedict) dictionaries (.xdxf(.dz))
 * [Zim](https://wiki.openzim.org/wiki/OpenZIM) dictionaries (.zim)
 * [Slob (Aard 2)](https://aarddict.org/) dictionaries (.slob)
 * [DictD](https://en.wikipedia.org/wiki/DICT#Dict_file_format) dictionaries (.index/.dict(.dz))
@@ -44,7 +44,7 @@ Every local dictionary can have individual icon. BMP, PNG, JPG or ICO files can 
 
 For Babylon, StarDict, DictD, ABBYY Lingvo, AardDictionary, SDictionary, Zim, MDict, Lsa, Zips, Slob, Gls dictionaries such graphics file must be named by main dictionary file name and places beside one. That is if main file of your dictionary, for example, named "My_best_dictionary.dsl" therefore icon file must be named "My_best_dictionary.bmp" (.png, .jpg etc.).
 
-For Xdxf dictionaries icon file must be named "icon16.png" (for 16х16 images) or "icon32.png" (for 32х32 images) and placed into dictionary folder.
+For XDXF dictionaries, the icon file must be named "icon16.png" (for 16х16 images) or "icon32.png" (for 32х32 images) or "dict.bmp" and placed into the dictionary folder.
 
 For Epwing dictionaries icon file must be named by name of folder with dictionary data beside "catalogs" file (a few folders can be presented, every folder is separate dictionary) and placed beside "catalogs" file.
 
@@ -64,9 +64,9 @@ Additional dictionary resources (images, sound files, etc.) also can be compress
 
 GoldenDict supports the "#SOUND_DICTIONARY" directive. Sounds missing in the resources of the dictionary will be searched first in the dictionary specified in this directive.
 
-### DictD, Xdxf
+### DictD and XDXF compression
 
-Main file of DictD dictionary (.dict) or Xdxf dictionary (.xdxf) can be compressed by Dictzip program to reduce its size.
+Main file of DictD dictionary (.dict) or XDXF dictionary (.xdxf) can be compressed into `*.dict.dz` or `*.xdxf.dz` by Dictzip program to reduce its size.
 
 ### Slob
 


### PR DESCRIPTION
There is a huge number of XDXF dictionaries with "dict.bmp" icon filename (for example: https://booktracker.org/viewtopic.php?p=211743#211743)