### PR TITLE
opt: rewrite keymodifier

### DIFF
--- a/src/keyboardstate.cc
+++ b/src/keyboardstate.cc
@@ -2,16 +2,12 @@
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
 #include "keyboardstate.hh"
-#include <QObject> // To get Qt Q_OS defines
 
 #include <QApplication>
 
 bool KeyboardState::checkModifiersPressed( int mask )
 {
-
-  auto modifiers = QApplication::keyboardModifiers();
-
-  qDebug() << modifiers;
+  auto modifiers = QApplication::queryKeyboardModifiers();
 
   return !( ( mask & Alt && !( modifiers.testFlag( Qt::AltModifier ) ) )
             || ( mask & Ctrl && !( modifiers.testFlag( Qt::ControlModifier ) ) )

--- a/src/keyboardstate.cc
+++ b/src/keyboardstate.cc
@@ -12,10 +12,5 @@ bool KeyboardState::checkModifiersPressed( int mask )
   return !( ( mask & Alt && !( modifiers.testFlag( Qt::AltModifier ) ) )
             || ( mask & Ctrl && !( modifiers.testFlag( Qt::ControlModifier ) ) )
             || ( mask & Shift && !( modifiers.testFlag( Qt::ShiftModifier ) ) )
-            || ( mask & LeftAlt && !( modifiers.testFlag( Qt::AltModifier ) ) )
-            || ( mask & RightAlt && !( modifiers.testFlag( Qt::AltModifier ) ) )
-            || ( mask & LeftCtrl && !( modifiers.testFlag( Qt::ControlModifier ) ) )
-            || ( mask & RightCtrl && !( modifiers.testFlag( Qt::ControlModifier ) ) )
-            || ( mask & LeftShift && !( modifiers.testFlag( Qt::ShiftModifier ) ) )
-            || ( mask & RightShift && !( modifiers.testFlag( Qt::ShiftModifier ) ) ) );
+             );
 }

--- a/src/keyboardstate.cc
+++ b/src/keyboardstate.cc
@@ -11,6 +11,5 @@ bool KeyboardState::checkModifiersPressed( int mask )
 
   return !( ( mask & Alt && !( modifiers.testFlag( Qt::AltModifier ) ) )
             || ( mask & Ctrl && !( modifiers.testFlag( Qt::ControlModifier ) ) )
-            || ( mask & Shift && !( modifiers.testFlag( Qt::ShiftModifier ) ) )
-             );
+            || ( mask & Shift && !( modifiers.testFlag( Qt::ShiftModifier ) ) ) );
 }

--- a/src/keyboardstate.cc
+++ b/src/keyboardstate.cc
@@ -4,55 +4,22 @@
 #include "keyboardstate.hh"
 #include <QObject> // To get Qt Q_OS defines
 
-#ifdef Q_OS_WIN32
-  #include <windows.h>
-#elif defined( HAVE_X11 )
-  #if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
-    #include <QGuiApplication>
-  #else
-    #include <QX11Info>
-  #endif
-  #include <X11/X.h>
-  #include <X11/XKBlib.h>
-#elif defined Q_OS_MAC
-  #define __SECURITYHI__
-  #include <Carbon/Carbon.h>
-#endif
+#include <QApplication>
 
 bool KeyboardState::checkModifiersPressed( int mask )
 {
-#if defined( Q_OS_WIN32 )
 
-  return !( ( mask & Alt && !( GetAsyncKeyState( VK_MENU ) & 0x8000 ) )
-            || ( mask & Ctrl && !( GetAsyncKeyState( VK_CONTROL ) & 0x8000 ) )
-            || ( mask & Shift && !( GetAsyncKeyState( VK_SHIFT ) & 0x8000 ) )
-            || ( mask & LeftAlt && !( GetAsyncKeyState( VK_LMENU ) & 0x8000 ) )
-            || ( mask & RightAlt && !( GetAsyncKeyState( VK_RMENU ) & 0x8000 ) )
-            || ( mask & LeftCtrl && !( GetAsyncKeyState( VK_LCONTROL ) & 0x8000 ) )
-            || ( mask & RightCtrl && !( GetAsyncKeyState( VK_RCONTROL ) & 0x8000 ) )
-            || ( mask & LeftShift && !( GetAsyncKeyState( VK_LSHIFT ) & 0x8000 ) )
-            || ( mask & RightShift && !( GetAsyncKeyState( VK_RSHIFT ) & 0x8000 ) ) );
+  auto modifiers = QApplication::keyboardModifiers();
 
-#elif defined Q_OS_MAC
-  UInt32 keys = GetCurrentKeyModifiers();
-  return !( ( mask & Alt && !( keys & ( 1 << optionKeyBit ) ) ) || ( mask & Ctrl && !( keys & ( 1 << cmdKeyBit ) ) )
-            || ( mask & Shift && !( keys & ( 1 << shiftKeyBit ) ) )
-            || ( mask & Win && !( keys & ( 1 << controlKeyBit ) ) ) );
-#else
+  qDebug() << modifiers;
 
-  #if QT_VERSION < 0x060000
-  Display * displayID = QX11Info::display();
-  #else
-  QNativeInterface::QX11Application * x11AppInfo = qApp->nativeInterface< QNativeInterface::QX11Application >();
-  Display * displayID                            = x11AppInfo->display();
-  #endif
-
-  XkbStateRec state;
-
-  XkbGetState( displayID, XkbUseCoreKbd, &state );
-
-  return !( ( mask & Alt && !( state.base_mods & Mod1Mask ) ) || ( mask & Ctrl && !( state.base_mods & ControlMask ) )
-            || ( mask & Shift && !( state.base_mods & ShiftMask ) )
-            || ( mask & Win && !( state.base_mods & Mod4Mask ) ) );
-#endif
+  return !( ( mask & Alt && !( modifiers.testFlag( Qt::AltModifier ) ) )
+            || ( mask & Ctrl && !( modifiers.testFlag( Qt::ControlModifier ) ) )
+            || ( mask & Shift && !( modifiers.testFlag( Qt::ShiftModifier ) ) )
+            || ( mask & LeftAlt && !( modifiers.testFlag( Qt::AltModifier ) ) )
+            || ( mask & RightAlt && !( modifiers.testFlag( Qt::AltModifier ) ) )
+            || ( mask & LeftCtrl && !( modifiers.testFlag( Qt::ControlModifier ) ) )
+            || ( mask & RightCtrl && !( modifiers.testFlag( Qt::ControlModifier ) ) )
+            || ( mask & LeftShift && !( modifiers.testFlag( Qt::ShiftModifier ) ) )
+            || ( mask & RightShift && !( modifiers.testFlag( Qt::ShiftModifier ) ) ) );
 }

--- a/src/keyboardstate.hh
+++ b/src/keyboardstate.hh
@@ -15,7 +15,7 @@ public:
     Alt        = 1,
     Ctrl       = 2,
     Shift      = 4,
-    Win        = 8,  // Ironically, Linux only, since it's no use under Windows
+    Win        = 8, // Ironically, Linux only, since it's no use under Windows
   };
 
   /// Returns true if all Modifiers present within the given mask are pressed

--- a/src/keyboardstate.hh
+++ b/src/keyboardstate.hh
@@ -16,12 +16,6 @@ public:
     Ctrl       = 2,
     Shift      = 4,
     Win        = 8,  // Ironically, Linux only, since it's no use under Windows
-    LeftAlt    = 16, // Those Left-Right are Windows-only, at least for now
-    RightAlt   = 32,
-    LeftCtrl   = 64,
-    RightCtrl  = 128,
-    LeftShift  = 256,
-    RightShift = 512
   };
 
   /// Returns true if all Modifiers present within the given mask are pressed

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -27,18 +27,6 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
 
   connect( ui.showScanFlag, &QAbstractButton::toggled, this, &Preferences::showScanFlagToggled );
 
-  connect( ui.altKey, &QAbstractButton::clicked, this, &Preferences::wholeAltClicked );
-  connect( ui.ctrlKey, &QAbstractButton::clicked, this, &Preferences::wholeCtrlClicked );
-  connect( ui.shiftKey, &QAbstractButton::clicked, this, &Preferences::wholeShiftClicked );
-
-  connect( ui.leftAlt, &QAbstractButton::clicked, this, &Preferences::sideAltClicked );
-  connect( ui.rightAlt, &QAbstractButton::clicked, this, &Preferences::sideAltClicked );
-  connect( ui.leftCtrl, &QAbstractButton::clicked, this, &Preferences::sideCtrlClicked );
-  connect( ui.rightCtrl, &QAbstractButton::clicked, this, &Preferences::sideCtrlClicked );
-  connect( ui.leftShift, &QAbstractButton::clicked, this, &Preferences::sideShiftClicked );
-  connect( ui.rightShift, &QAbstractButton::clicked, this, &Preferences::sideShiftClicked );
-
-
   helpAction.setShortcut( QKeySequence( "F1" ) );
   helpAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
 
@@ -206,12 +194,6 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   ui.ctrlKey->setChecked( p.scanPopupModifiers & KeyboardState::Ctrl );
   ui.shiftKey->setChecked( p.scanPopupModifiers & KeyboardState::Shift );
   ui.winKey->setChecked( p.scanPopupModifiers & KeyboardState::Win );
-  ui.leftAlt->setChecked( p.scanPopupModifiers & KeyboardState::LeftAlt );
-  ui.rightAlt->setChecked( p.scanPopupModifiers & KeyboardState::RightAlt );
-  ui.leftCtrl->setChecked( p.scanPopupModifiers & KeyboardState::LeftCtrl );
-  ui.rightCtrl->setChecked( p.scanPopupModifiers & KeyboardState::RightCtrl );
-  ui.leftShift->setChecked( p.scanPopupModifiers & KeyboardState::LeftShift );
-  ui.rightShift->setChecked( p.scanPopupModifiers & KeyboardState::RightShift );
 
   ui.ignoreOwnClipboardChanges->setChecked( p.ignoreOwnClipboardChanges );
   ui.scanToMainWindow->setChecked( p.scanToMainWindow );
@@ -250,12 +232,6 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
 #ifdef Q_OS_WIN32
   ui.winKey->hide();
 #else
-  ui.leftAlt->hide();
-  ui.rightAlt->hide();
-  ui.leftCtrl->hide();
-  ui.rightCtrl->hide();
-  ui.leftShift->hide();
-  ui.rightShift->hide();
   #ifdef Q_OS_MAC
   ui.altKey->setText( "Opt" );
   ui.winKey->setText( "Ctrl" );
@@ -446,12 +422,6 @@ Config::Preferences Preferences::getPreferences()
   p.scanPopupModifiers += ui.ctrlKey->isChecked() ? KeyboardState::Ctrl : 0;
   p.scanPopupModifiers += ui.shiftKey->isChecked() ? KeyboardState::Shift : 0;
   p.scanPopupModifiers += ui.winKey->isChecked() ? KeyboardState::Win : 0;
-  p.scanPopupModifiers += ui.leftAlt->isChecked() ? KeyboardState::LeftAlt : 0;
-  p.scanPopupModifiers += ui.rightAlt->isChecked() ? KeyboardState::RightAlt : 0;
-  p.scanPopupModifiers += ui.leftCtrl->isChecked() ? KeyboardState::LeftCtrl : 0;
-  p.scanPopupModifiers += ui.rightCtrl->isChecked() ? KeyboardState::RightCtrl : 0;
-  p.scanPopupModifiers += ui.leftShift->isChecked() ? KeyboardState::LeftShift : 0;
-  p.scanPopupModifiers += ui.rightShift->isChecked() ? KeyboardState::RightShift : 0;
 
   p.ignoreOwnClipboardChanges = ui.ignoreOwnClipboardChanges->isChecked();
   p.scanToMainWindow          = ui.scanToMainWindow->isChecked();
@@ -556,48 +526,6 @@ void Preferences::showScanFlagToggled( bool b )
     ui.enableScanPopupModifiers->setChecked( false );
 }
 
-
-void Preferences::wholeAltClicked( bool b )
-{
-  if ( b ) {
-    ui.leftAlt->setChecked( false );
-    ui.rightAlt->setChecked( false );
-  }
-}
-
-void Preferences::wholeCtrlClicked( bool b )
-{
-  if ( b ) {
-    ui.leftCtrl->setChecked( false );
-    ui.rightCtrl->setChecked( false );
-  }
-}
-
-void Preferences::wholeShiftClicked( bool b )
-{
-  if ( b ) {
-    ui.leftShift->setChecked( false );
-    ui.rightShift->setChecked( false );
-  }
-}
-
-void Preferences::sideAltClicked( bool )
-{
-  if ( ui.leftAlt->isChecked() || ui.rightAlt->isChecked() )
-    ui.altKey->setChecked( false );
-}
-
-void Preferences::sideCtrlClicked( bool )
-{
-  if ( ui.leftCtrl->isChecked() || ui.rightCtrl->isChecked() )
-    ui.ctrlKey->setChecked( false );
-}
-
-void Preferences::sideShiftClicked( bool )
-{
-  if ( ui.leftShift->isChecked() || ui.rightShift->isChecked() )
-    ui.shiftKey->setChecked( false );
-}
 void Preferences::on_enableMainWindowHotkey_toggled( bool checked )
 {
   ui.mainWindowHotkey->setEnabled( checked );

--- a/src/ui/preferences.hh
+++ b/src/ui/preferences.hh
@@ -41,14 +41,6 @@ private slots:
   void enableScanPopupModifiersToggled( bool );
   void showScanFlagToggled( bool b );
 
-  void wholeAltClicked( bool );
-  void wholeCtrlClicked( bool );
-  void wholeShiftClicked( bool );
-
-  void sideAltClicked( bool );
-  void sideCtrlClicked( bool );
-  void sideShiftClicked( bool );
-
   void on_enableMainWindowHotkey_toggled( bool checked );
   void on_enableClipboardHotkey_toggled( bool checked );
 

--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -621,26 +621,6 @@ in the pressed state when the word selection changes.</string>
                </item>
                <item>
                 <layout class="QGridLayout" name="gridLayout">
-                 <item row="1" column="1">
-                  <widget class="QCheckBox" name="leftCtrl">
-                   <property name="toolTip">
-                    <string>Left Ctrl only</string>
-                   </property>
-                   <property name="text">
-                    <string>Left Ctrl</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="2">
-                  <widget class="QCheckBox" name="rightShift">
-                   <property name="toolTip">
-                    <string>Right Shift only</string>
-                   </property>
-                   <property name="text">
-                    <string>Right Shift</string>
-                   </property>
-                  </widget>
-                 </item>
                  <item row="0" column="0">
                   <widget class="QCheckBox" name="altKey">
                    <property name="toolTip">
@@ -661,16 +641,6 @@ in the pressed state when the word selection changes.</string>
                    </property>
                   </widget>
                  </item>
-                 <item row="1" column="0">
-                  <widget class="QCheckBox" name="leftAlt">
-                   <property name="toolTip">
-                    <string>Left Alt only</string>
-                   </property>
-                   <property name="text">
-                    <string>Left Alt</string>
-                   </property>
-                  </widget>
-                 </item>
                  <item row="0" column="2">
                   <widget class="QCheckBox" name="shiftKey">
                    <property name="toolTip">
@@ -678,36 +648,6 @@ in the pressed state when the word selection changes.</string>
                    </property>
                    <property name="text">
                     <string>Shift</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="0">
-                  <widget class="QCheckBox" name="rightAlt">
-                   <property name="toolTip">
-                    <string>Right Alt only</string>
-                   </property>
-                   <property name="text">
-                    <string>Right Alt</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="1">
-                  <widget class="QCheckBox" name="rightCtrl">
-                   <property name="toolTip">
-                    <string>Right Ctrl only</string>
-                   </property>
-                   <property name="text">
-                    <string>Right Ctrl</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="2">
-                  <widget class="QCheckBox" name="leftShift">
-                   <property name="toolTip">
-                    <string>Left Shift only</string>
-                   </property>
-                   <property name="text">
-                    <string>Left Shift</string>
                    </property>
                   </widget>
                  </item>
@@ -2035,15 +1975,9 @@ from Stardict, Babylon and GLS dictionaries</string>
   <tabstop>startToTray</tabstop>
   <tabstop>closeToTray</tabstop>
   <tabstop>cbAutostart</tabstop>
-  <tabstop>leftCtrl</tabstop>
-  <tabstop>rightShift</tabstop>
   <tabstop>altKey</tabstop>
   <tabstop>ctrlKey</tabstop>
-  <tabstop>leftAlt</tabstop>
   <tabstop>shiftKey</tabstop>
-  <tabstop>rightAlt</tabstop>
-  <tabstop>rightCtrl</tabstop>
-  <tabstop>leftShift</tabstop>
   <tabstop>winKey</tabstop>
   <tabstop>useProxyServer</tabstop>
   <tabstop>proxyType</tabstop>


### PR DESCRIPTION
I think LeftAlt ,rightAlt ,etc keymodifiers can also be deleted.
![image](https://github.com/xiaoyifang/goldendict-ng/assets/105986/e1a1de47-4c23-4220-a3d2-3f7a0606ab22)
These keys added for Windows, but on Windows ,the keys are hidden already.
