### PR TITLE
opt: do not read splitted headword

### DIFF
--- a/src/btreeidx.cc
+++ b/src/btreeidx.cc
@@ -1123,7 +1123,12 @@ void BtreeIndex::findArticleLinks( QVector< WordArticleLink > * articleLinks,
         return;
 
       if ( headwords )
-        headwords->insert( QString::fromUtf8( ( i.prefix + i.word ).c_str() ) );
+      {
+        if(i.prefix.empty())
+        {
+          headwords->insert( QString::fromUtf8( ( i.prefix + i.word ).c_str() ) );
+        }
+      }
 
       if ( offsets && offsets->contains( i.articleOffset ) )
         continue;

--- a/src/btreeidx.cc
+++ b/src/btreeidx.cc
@@ -1122,10 +1122,8 @@ void BtreeIndex::findArticleLinks( QVector< WordArticleLink > * articleLinks,
       if ( isCancelled && Utils::AtomicInt::loadAcquire( *isCancelled ) )
         return;
 
-      if ( headwords )
-      {
-        if(i.prefix.empty())
-        {
+      if ( headwords ) {
+        if ( i.prefix.empty() ) {
           headwords->insert( QString::fromUtf8( ( i.prefix + i.word ).c_str() ) );
         }
       }


### PR DESCRIPTION
Due to the parsing of headword.   
`a lot of` 
may be counted as three different entries in the index.
`a lot of`
prefix=`a` ,`lot of`
prefix=`a lot`,  `of`