### PR TITLE
breakpad support for cmake/vcpkg build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ option(USE_SYSTEM_TOML "use system toml++ instead of bundled one" OFF)
 
 # vcpkg build - only tested on Windows, does not support FFMPEG
 option(USE_VCPKG "uses VCPKG for providing dependencies" OFF)
+option(WITH_VCPKG_BREAKPAD "build with Breakpad support for VCPKG build only" OFF)
 
 ## Change binary & resources folder to parallel install with original GD.
 ## This flag should be avoided because it leads to small regressions:
@@ -20,6 +21,10 @@ option(USE_VCPKG "uses VCPKG for providing dependencies" OFF)
 option(USE_ALTERNATIVE_NAME "Force the name goldendict-ng " OFF)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}") # to put staff in the ./cmake folder
+
+if(WITH_VCPKG_BREAKPAD)
+  list(APPEND VCPKG_MANIFEST_FEATURES "breakpad")
+endif()
 
 include(FeatureSummary)
 
@@ -190,6 +195,10 @@ endif ()
 
 if (WITH_ZIM)
     target_compile_definitions(${GOLDENDICT} PUBLIC MAKE_ZIM_SUPPORT)
+endif ()
+
+if (WITH_VCPKG_BREAKPAD)
+    target_compile_definitions(${GOLDENDICT} PUBLIC USE_BREAKPAD)
 endif ()
 
 #### libraries linking && includes for Win or Unix

--- a/cmake/Deps_Vcpkg.cmake
+++ b/cmake/Deps_Vcpkg.cmake
@@ -24,6 +24,11 @@ target_link_libraries(${GOLDENDICT}
         ZLIB::ZLIB
 )
 
+if (WITH_VCPKG_BREAKPAD)
+    find_package(unofficial-breakpad REQUIRED)
+    target_link_libraries(${GOLDENDICT} PRIVATE unofficial::breakpad::libbreakpad_client)
+endif ()
+
 if (WITH_EPWING_SUPPORT)
     add_subdirectory(thirdparty/eb EXCLUDE_FROM_ALL)
     target_include_directories(${GOLDENDICT} PRIVATE

--- a/website/docs/howto/build_from_source.md
+++ b/website/docs/howto/build_from_source.md
@@ -91,6 +91,7 @@ Add this to cmake command:
 Most `.dll` built by vcpkg will be automatically copied, but the Qt ones won't.
 
 You can
+
 * run `cmake --install .` (recommended)
 * manually run windeployqt
 * add `${Qt's install path}\Qt\6.5.2\msvc2019_64\bin` to your PATH environment variable


### PR DESCRIPTION
Tested manually by inserting a `throw std::runtime_error("whatever")` and GD will create a dmp file successfully.


Unrelated known issues:

+ For some reason, vcpkg can no longer build the Windows version of dump_syms.exe/minidump_stackwalk.exe now. The needed tool has to be obtained from somewhere else.
+ The `-llibbreakpad` here is unneeded: https://github.com/xiaoyifang/goldendict-ng/blob/ddb9203e3425a9762fb1d56666c201adf13cc325/goldendict.pro#L81