### PR TITLE
opt: macos add qt6.6.3 release

### DIFF
--- a/.github/workflows/release-macos-homebrew.yml
+++ b/.github/workflows/release-macos-homebrew.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-12,macos-14]
-        qt_ver: [ 6.7.2 ]
+        qt_ver: [ 6.7.2,6.6.3 ]
         qt_arch: [clang_64]
     env:
       targetName: GoldenDict


### PR DESCRIPTION
from feedback of community and issue report ,
gd-ng does not run stable on Macos + qt6.7 

add qt 6.6.3 macos release
https://github.com/xiaoyifang/goldendict-ng/issues/1591