### PR TITLE
opt: remove explict RTL elide mode settings of text layout

### DIFF
--- a/src/delegate.cc
+++ b/src/delegate.cc
@@ -12,19 +12,13 @@ void WordListItemDelegate::paint( QPainter * painter,
                                   const QStyleOptionViewItem & option,
                                   const QModelIndex & index ) const
 {
-  QStyleOptionViewItem opt4 = option;
-
   QStyleOptionViewItem opt = option;
-  initStyleOption( &opt4, index );
-  if ( opt4.text.isRightToLeft() ) {
+  initStyleOption( &opt, index );
+  if ( opt.text.isRightToLeft() ) {
     opt.direction = Qt::RightToLeft;
-    if ( opt4.textElideMode != Qt::ElideNone )
-      opt.textElideMode = Qt::ElideLeft;
   }
   else {
     opt.direction = Qt::LeftToRight;
-    if ( opt4.textElideMode != Qt::ElideNone )
-      opt.textElideMode = Qt::ElideRight;
   }
   mainDelegate->paint( painter, opt, index );
 }


### PR DESCRIPTION
current right to left layout with elidemode and align
![image](https://github.com/xiaoyifang/goldendict-ng/assets/105986/0458e9f9-bec1-4202-b515-9d37cfb75aa2)

![image](https://github.com/xiaoyifang/goldendict-ng/assets/105986/183da002-b555-40de-a270-50ca0584e4f9)

Changes based on:

![image](https://github.com/xiaoyifang/goldendict-ng/assets/105986/1c288a33-c90d-40a1-990f-dfe986b93bb9)

qt must has changed its implementation .

ElideRight in Right to Left Layout will behave exactly like ElideLeft.

After the PR:
![image](https://github.com/xiaoyifang/goldendict-ng/assets/105986/52f33d1b-d9e3-4b52-941a-2366c3918354)
