### PR TITLE
feat: switch Windows release build to CMake + vcpkg

### DIFF
--- a/.github/workflows/release-macos-homebrew.yml
+++ b/.github/workflows/release-macos-homebrew.yml
@@ -160,28 +160,14 @@ jobs:
           release_name: GoldenDict-ng-v${{env.version}}-${{env.version-suffix}}.${{ steps.vars.outputs.release_hm }}.${{ steps.vars.outputs.sha_short }}
           prerelease: ${{env.prerelease}}
           body: |
-            #### Install instructions for Windows, macOS and Linux 
-
-            <https://xiaoyifang.github.io/goldendict-ng/install/>.
-
-            #### Filename pattern (文件名模式): **[Qt version]-GoldenDict-ng-[OS]-[release-date].[ext]**  
-
-            Windows users can use either `****-installer.exe` (for installer) or `****.zip` (unzip and run).
-            The `goldendict.exe` can be dropped into previous installation's folder (if dependencies aren't changed).
-
-            Linux users can use Flatpak or build from source.
-            https://flathub.org/apps/io.github.xiaoyifang.goldendict_ng
-
-            macOS users can use `.dmg` installer.
-
-            `6.5.1-GoldenDict.exe_windows-2019_20230701.zip` means built with Qt6.5.1, windows/msvc-2019 at 20230701 as a zip archive.
-
-            #### Build Details
-
-            macOS: macOS-12 (x86_64) and macOS-14 (Arm)
-            Windows: Visual studio 2019
-            based on: ${{github.ref_name}}
-
+            [Install instructions for Windows, macOS and Linux](https://xiaoyifang.github.io/goldendict-ng/install/).
+            
+            Filaname pattern: GoldenDict-[version]-[Qt version]-[system name]-...
+            
+            For Linux, released vesion is on Flathub -> [io.github.xiaoyifang.goldendict_ng](https://flathub.org/apps/io.github.xiaoyifang.goldendict_ng).
+  
+            Based on branch: ${{github.ref_name}}
+  
             #### Changes
             
             ${{steps.build_changelog.outputs.changelog}}

--- a/.github/workflows/release-windows-vcpkg-cmake.yml
+++ b/.github/workflows/release-windows-vcpkg-cmake.yml
@@ -1,0 +1,182 @@
+name: Release Windows Vcpkg CMake
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+on: 
+  workflow_dispatch:
+  push:
+    branches:
+      - dev
+      - master
+      - experimental
+    paths-ignore:
+      - 'docs/**'
+      - "*.md"
+      - ".*"      
+
+jobs:
+  build:
+    name: Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-2022]
+        qt_ver: [ 6.7.2 ]
+        qt_arch: [win64_msvc2019_64]
+    env:
+      version: 24.05.13
+      versionSuffix: ${{ !contains(github.ref_name,'master') && 'alpha' || 'NextNameHere' }}
+      prerelease: ${{ !contains(github.ref_name,'master') }}
+    steps:
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v3
+        with:
+          version: ${{ matrix.qt_ver }}
+          # target: ${{ matrix.qt_target }}
+          arch: ${{ matrix.qt_arch }}
+          modules: qtwebengine qtwebchannel qtpositioning qt5compat qtmultimedia qtimageformats qtspeech
+          setup-python: 'false'
+          
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Setup changelog
+        id: changelog
+        shell: bash
+        env:
+          prerelease: ${{env.prerelease}}
+        run: |   
+          if [[ "$prerelease" == 'true' ]]
+          then
+            echo "This is a pre-release"
+            previousTag=$(git tag --sort=-creatordate | grep "^v" | sed -n 2p)
+            currentTag=$(git tag --sort=-creatordate | grep "^v" | sed -n 1p)
+          else 
+            echo "This is not a pre-release"
+            previousTag=$(git tag --sort=-creatordate | grep "^v" | grep -v "alpha"  | sed -n 2p)
+            currentTag=$(git tag --sort=-creatordate | grep "^v"  | grep -v "alpha" | sed -n 1p)
+          fi
+          echo "prev_tag=$previousTag" >> $GITHUB_OUTPUT
+          echo "curr_tag=$currentTag" >> $GITHUB_OUTPUT
+          echo "previousTag : $previousTag"
+          echo "currentTag : $currentTag"
+
+      - name: "Build Changelog"
+        id: build_changelog
+        uses: mikepenz/release-changelog-builder-action@v3    
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}     
+        with:
+          commitMode: false
+          fromTag: "${{ steps.changelog.outputs.prev_tag }}"
+          toTag:  "${{ steps.changelog.outputs.curr_tag }}"
+          configurationJson: |
+            {
+              "template": "#{{CHANGELOG}}\n\n<details>\n<summary>🔴 Uncategorized</summary>\n\n#{{UNCATEGORIZED}}\n</details>",
+              "categories": [
+                {
+                    "title": "## 🚀 Features",
+                    "labels": ["feature","feat","opt"]
+                },
+                {
+                    "title": "## 🐛 Fixes",
+                    "labels": ["fix","bug"]
+                }
+                ,
+                {
+                    "title": "##  🤖  Github action",
+                    "labels": ["action"]
+                }
+                ,
+                {
+                    "title": "##  🧼  Clean Code",
+                    "labels": ["clean"]
+                }
+
+
+              ],
+              "label_extractor": [
+              {
+                "pattern": "([^:]*):.*",
+                "target": "$1",
+                "on_property": "title",
+                "flags": "gu"
+              }
+            ]
+            }
+      - name: setup vcpkg github caches variables
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      - name: Build binaries
+        id: build
+        env:
+          VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+        run: |
+          # Launch-VsDevShell also provides Ninja
+          & 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1' `
+            -SkipAutomaticLocation -Arch amd64 -HostArch amd64
+          New-Item -Path './build_dir' -ItemType Directory
+          
+          # RelWithDebInfo + msvc's = .pdb file beside program file.
+          cmake -S . -B "./build_dir" `
+            -G Ninja `
+            -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" `
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo `
+            -DWITH_FFMPEG_PLAYER=OFF `
+            -DUSE_VCPKG=ON `
+            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" `
+            -DWITH_VCPKG_BREAKPAD=ON
+          cmake --build "./build_dir"
+      - name: CPack create package
+        run: |
+          cd './build_dir'
+          cpack --verbose --trace
+          cd ..
+          pwd
+      - name: Upload packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $tagName = "v$env:version-$env:versionSuffix.$(git rev-parse --short=8 HEAD)"
+          
+          $changeNotes = "
+          [Install instructions for Windows, macOS and Linux](https://xiaoyifang.github.io/goldendict-ng/install/).
+          
+          Filaname pattern: GoldenDict-[version]-[Qt version]-[system name]-...
+          
+          For Linux, released vesion is on Flathub -> [io.github.xiaoyifang.goldendict_ng](https://flathub.org/apps/io.github.xiaoyifang.goldendict_ng).
+
+          Based on branch: ${{github.ref_name}}
+
+          #### Changes
+          
+          ${{steps.build_changelog.outputs.changelog}}
+          "          
+
+          $tagExist = gh api --silent "repos/:owner/:repo/git/refs/tags/${{github.ref_name}}"
+          if (-not $?) {
+            if ($env:prerelease -eq "true") {
+              gh release create ${tagName} --target ${{github.ref_name}} --notes "${changeNotes}" --latest=false --prerelease
+            } else {
+              gh release create ${tagName} --target ${{github.ref_name}} --notes "${changeNotes}" --latest=true 
+            }
+          }
+
+          # file name after # is display label
+          
+          $namePrefix="GoldenDict-${{env.version}}-Qt${{matrix.qt_ver}}"
+          
+          cd './build_dir'
+          gh release upload "${tagName}"  "${namePrefix}.7z#${namePrefix}-Windows.7z"  --clobber
+          gh release upload "${tagName}"  "${namePrefix}.exe#${namePrefix}-Windows-installer.exe"  --clobber
+          
+          cd './goldendict'
+          gh release upload "${tagName}"  "goldendict.exe#${namePrefix}-Windows-main-exe-file-only.exe"  --clobber
+          gh release upload "${tagName}"  "goldendict.pdb#${namePrefix}-Windows-debug-file.pdb"  --clobber
+          cd ..
+

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -7,18 +7,18 @@ on:
   #   workflows: [AutoTag]
   #   types: [completed]
   workflow_dispatch:
-  push:
-    branches:
-      - dev
-      - master
-      - experimental
-      # - staged
-    paths-ignore:
-      - 'docs/**'
-      # - ".github/**"
-      - "howto/**"
-      - "*.md"
-      - ".clang-format"      
+#  push:
+#    branches:
+#      - dev
+#      - master
+#      - experimental
+#      # - staged
+#    paths-ignore:
+#      - 'docs/**'
+#      # - ".github/**"
+#      - "howto/**"
+#      - "*.md"
+#      - ".clang-format"
 
 jobs:
   build:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,7 +270,7 @@ if (APPLE)
             --volicon ${CMAKE_SOURCE_DIR}/icons/macicon.icns \
             --icon \"${App_Name}\" 100 100
             --app-drop-link 300 100 \
-            \"GoldenDict-${CMAKE_PROJECT_VERSION}-Qt${Qt6_VERSION}-${CMAKE_SYSTEM_PROCESSOR}.dmg\" \
+            \"GoldenDict-${CMAKE_PROJECT_VERSION}-Qt${Qt6_VERSION}-macOS-${CMAKE_SYSTEM_PROCESSOR}.dmg\" \
             \"${Assembling_Dir}\")"
         )
     else ()
@@ -353,12 +353,23 @@ if (WIN32)
             PATTERN "*.ilk" EXCLUDE)
 
 
-    set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}-${PROJECT_VERSION}-Qt${Qt6Widgets_VERSION}-${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
-    set(CPACK_GENERATOR "7Z;NSIS")
-    set(CPACK_NSIS_MANIFEST_DPI_AWARE ON)
-    set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.txt")
-    include(CPack)
+    set(CPACK_PACKAGE_FILE_NAME "GoldenDict-${PROJECT_VERSION}-Qt${Qt6Widgets_VERSION}")
+    set(CPACK_GENERATOR "7Z;NSIS64")
 
+    # override the default install path, which is $PROGRAMFILES64\${project-name} ${project-version} in NSIS
+    set(CPACK_PACKAGE_INSTALL_DIRECTORY "GoldenDict-ng")
+
+    # NSIS specificS
+    set(CPACK_NSIS_MANIFEST_DPI_AWARE ON)
+    set(CPACK_NSIS_MUI_ICON "${CMAKE_SOURCE_DIR}/icons/programicon.ico")
+    set(CPACK_NSIS_PACKAGE_NAME "${CMAKE_PROJECT_NAME}-${CMAKE_PROJECT_VERSION}")
+    set(CPACK_NSIS_DISPLAY_NAME "${CMAKE_PROJECT_NAME}-${CMAKE_PROJECT_VERSION}")
+    set(CPACK_NSIS_URL_INFO_ABOUT [=[https://xiaoyifang.github.io/goldendict-ng/]=])
+    set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.txt")
+    set(CPACK_NSIS_CREATE_ICONS_EXTRA "CreateShortCut '$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\GoldenDict-ng.lnk' '$INSTDIR\\\\${GOLDENDICT}.exe'")
+    set(CPACK_NSIS_DELETE_ICONS_EXTRA "Delete '$SMPROGRAMS\\\\$START_MENU\\\\GoldenDict-ng.lnk'")
+
+    include(CPack)
 endif ()
 
 feature_summary(WHAT ALL DESCRIPTION "Build configuration:")

--- a/website/docs/howto/build_from_source.md
+++ b/website/docs/howto/build_from_source.md
@@ -96,6 +96,8 @@ You can
 * manually run windeployqt
 * add `${Qt's install path}\Qt\6.5.2\msvc2019_64\bin` to your PATH environment variable
 
+Note that `-G Ninja` in CMake is assumed to be used. MSBuild has minor bugs for being "Multi-Config".
+
 ### macOS
 
 If you build in an IDE, then the created `GoldenDict.app`  will be runnable from the IDE which set up necessary magics for you.


### PR DESCRIPTION
Sample release: https://github.com/shenlebantongying/goldendict-ng/releases

### Compared to the previous qmake-windows-release:

* `windows-2022` runner
* use PowerShell and avoid bash/cmd
* simply uses `gh release` for packages uploading
* `.7z` & NSIS installer via CPack

### Various details

* vcpkg utilizes GitHub caches, initial build cost around 35 mins, subsequent builds cost ignorable time
* build time reduced from `qmake+nmake` -> 7.5mins to `cmake+ninja` -> 5mins.

### Known issues:

* For some reason, CPack cost super long time to compress the files