### PR TITLE
use vcpkg cache on windows release built too

### DIFF
--- a/.github/workflows/release-windows-vcpkg-cmake.yml
+++ b/.github/workflows/release-windows-vcpkg-cmake.yml
@@ -106,16 +106,8 @@ jobs:
               }
             ]
             }
-      - name: setup vcpkg github caches variables
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
       - name: Build binaries
         id: build
-        env:
-          VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
         run: |
           # Launch-VsDevShell also provides Ninja
           & 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1' `
@@ -128,7 +120,6 @@ jobs:
             -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" `
             -DCMAKE_BUILD_TYPE=RelWithDebInfo `
             -DWITH_FFMPEG_PLAYER=OFF `
-            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" `
             -DWITH_VCPKG_BREAKPAD=ON
           cmake --build "./build_dir"
       - name: CPack create package


### PR DESCRIPTION
close https://github.com/xiaoyifang/goldendict-ng/issues/1681