### PR TITLE
fix: stardict crash

### DIFF
--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -545,7 +545,7 @@ string StardictDictionary::handleResource( char type, char const * resource, siz
         articleNewText.clear();
       }
 
-      return ( articleText.toUtf8().data() );
+      return articleText.toStdString();
     }
     case 'm': // Pure meaning, usually means preformatted text
       return "<div class=\"sdct_m\">" + Html::preformat( string( resource, size ), isToLanguageRTL() ) + "</div>";


### PR DESCRIPTION
`articleText.toUtf8().data()` has crashed with 
> Crash reason:  EXCEPTION_ACCESS_VIOLATION_READ

`articleText.toStdString()`  has not.


Do not know the actual reason .