### PR TITLE
fix: stardict qstring modification

### DIFF
--- a/src/common/htmlescape.cc
+++ b/src/common/htmlescape.cc
@@ -130,7 +130,7 @@ string escapeForJavaScript( string const & str )
   return result;
 }
 
-void stripHtml( QString & tmp )
+QString stripHtml( QString tmp )
 {
   static QRegularExpression htmlRegex(
     "<(?:\\s*/?(?:div|h[1-6r]|q|p(?![alr])|br|li(?![ns])|td|blockquote|[uo]l|pre|d[dl]|nav|address))[^>]{0,}>",
@@ -138,17 +138,17 @@ void stripHtml( QString & tmp )
   tmp.replace( htmlRegex, " " );
   static QRegularExpression htmlElementRegex( "<[^>]*>" );
   tmp.replace( htmlElementRegex, " " );
+  return tmp;
 }
 
-QString unescape( QString const & str, HtmlOption option )
+QString unescape( QString str, HtmlOption option )
 {
   // Does it contain HTML? If it does, we need to strip it
   if ( str.contains( '<' ) || str.contains( '&' ) ) {
-    QString tmp = str;
     if ( option == HtmlOption::Strip ) {
-      stripHtml( tmp );
+      str = stripHtml( str );
     }
-    return QTextDocumentFragment::fromHtml( tmp.trimmed() ).toPlainText();
+    return QTextDocumentFragment::fromHtml( str.trimmed() ).toPlainText();
   }
   return str;
 }

--- a/src/common/htmlescape.cc
+++ b/src/common/htmlescape.cc
@@ -130,15 +130,14 @@ string escapeForJavaScript( string const & str )
   return result;
 }
 
-QString stripHtml( QString & tmp )
+void stripHtml( QString & tmp )
 {
-  tmp.replace(
-    QRegularExpression(
-      "<(?:\\s*/?(?:div|h[1-6r]|q|p(?![alr])|br|li(?![ns])|td|blockquote|[uo]l|pre|d[dl]|nav|address))[^>]{0,}>",
-      QRegularExpression::CaseInsensitiveOption ),
-    " " );
-  tmp.replace( QRegularExpression( "<[^>]*>" ), " " );
-  return tmp;
+  static QRegularExpression htmlRegex(
+    "<(?:\\s*/?(?:div|h[1-6r]|q|p(?![alr])|br|li(?![ns])|td|blockquote|[uo]l|pre|d[dl]|nav|address))[^>]{0,}>",
+    QRegularExpression::CaseInsensitiveOption );
+  tmp.replace( htmlRegex, " " );
+  static QRegularExpression htmlElementRegex( "<[^>]*>" );
+  tmp.replace( htmlElementRegex, " " );
 }
 
 QString unescape( QString const & str, HtmlOption option )

--- a/src/common/htmlescape.hh
+++ b/src/common/htmlescape.hh
@@ -25,9 +25,9 @@ string preformat( string const &, bool baseRightToLeft = false );
 
 // Escapes the given string to be included in JavaScript.
 string escapeForJavaScript( string const & );
-void stripHtml( QString & tmp );
+QString stripHtml( QString tmp );
 // Replace html entities
-QString unescape( QString const & str, HtmlOption option = HtmlOption::Strip );
+QString unescape( QString str, HtmlOption option = HtmlOption::Strip );
 
 QString fromHtmlEscaped( QString const & str );
 string unescapeUtf8( string const & str, HtmlOption option = HtmlOption::Strip );

--- a/src/common/htmlescape.hh
+++ b/src/common/htmlescape.hh
@@ -25,7 +25,7 @@ string preformat( string const &, bool baseRightToLeft = false );
 
 // Escapes the given string to be included in JavaScript.
 string escapeForJavaScript( string const & );
-QString stripHtml( QString & tmp );
+void stripHtml( QString & tmp );
 // Replace html entities
 QString unescape( QString const & str, HtmlOption option = HtmlOption::Strip );
 

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -537,7 +537,7 @@ string StardictDictionary::handleResource( char type, char const * resource, siz
           }
           newTag += "</a></span>";
 
-          articleNewText += newTag;
+          articleNewText += QString::fromStdString( newTag );
         }
       }
       if ( pos ) {

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -547,8 +547,7 @@ string StardictDictionary::handleResource( char type, char const * resource, siz
         articleNewText.clear();
       }
 
-      auto _article = articleText.toStdString();
-      return std::move( _article );
+      return articleText.toLocal8Bit().constData();
     }
     case 'm': // Pure meaning, usually means preformatted text
       return "<div class=\"sdct_m\">" + Html::preformat( string( resource, size ), isToLanguageRTL() ) + "</div>";

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -531,7 +531,7 @@ string StardictDictionary::handleResource( char type, char const * resource, siz
         else {
           std::string href   = "\"gdau://" + getId() + "/" + src.toUtf8().data() + "\"";
           std::string newTag = addAudioLink( href, getId() ) + "<span class=\"sdict_h_wav\"><a href=" + href + ">";
-          newTag += match.captured( 4 ).c_str();
+          newTag += match.captured( 4 ).toUtf8().constData();
           if ( match.captured( 4 ).indexOf( "<img " ) < 0 ) {
             newTag += R"( <img src="qrc:///icons/playsound.png" border="0" alt="Play">)";
           }

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -529,13 +529,12 @@ string StardictDictionary::handleResource( char type, char const * resource, siz
           articleNewText += match.captured();
 
         else {
-          std::string href = "\"gdau://" + getId() + "/" + src.toUtf8().data() + "\"";
-          QString newTag   = QString::fromStdString(
-             addAudioLink( href, getId() ) + "<span class=\"sdict_h_wav\"><a href=" + href + ">"  );
-          newTag += match.captured( 4 );
-          if ( match.captured( 4 ).indexOf( "<img " ) < 0 )
-
+          std::string href   = "\"gdau://" + getId() + "/" + src.toUtf8().data() + "\"";
+          std::string newTag = addAudioLink( href, getId() ) + "<span class=\"sdict_h_wav\"><a href=" + href + ">";
+          newTag += match.captured( 4 ).c_str();
+          if ( match.captured( 4 ).indexOf( "<img " ) < 0 ) {
             newTag += R"( <img src="qrc:///icons/playsound.png" border="0" alt="Play">)";
+          }
           newTag += "</a></span>";
 
           articleNewText += newTag;
@@ -546,8 +545,8 @@ string StardictDictionary::handleResource( char type, char const * resource, siz
         articleText = articleNewText;
         articleNewText.clear();
       }
-
-      return articleText.toUtf8().constData();
+      auto text = articleText.toUtf8();
+      return text.data();
     }
     case 'm': // Pure meaning, usually means preformatted text
       return "<div class=\"sdct_m\">" + Html::preformat( string( resource, size ), isToLanguageRTL() ) + "</div>";

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -547,7 +547,8 @@ string StardictDictionary::handleResource( char type, char const * resource, siz
         articleNewText.clear();
       }
 
-      return articleText.toStdString();
+      auto _article = articleText.toStdString();
+      return std::move( _article );
     }
     case 'm': // Pure meaning, usually means preformatted text
       return "<div class=\"sdct_m\">" + Html::preformat( string( resource, size ), isToLanguageRTL() ) + "</div>";

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -525,9 +525,9 @@ string StardictDictionary::handleResource( char type, char const * resource, siz
 
         QString src = match.captured( 2 );
 
-        if ( src.indexOf( "://" ) >= 0 )
+        if ( src.indexOf( "://" ) >= 0 ) {
           articleNewText += match.captured();
-
+        }
         else {
           std::string href   = "\"gdau://" + getId() + "/" + src.toUtf8().data() + "\"";
           std::string newTag = addAudioLink( href, getId() ) + "<span class=\"sdict_h_wav\"><a href=" + href + ">";

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -530,8 +530,8 @@ string StardictDictionary::handleResource( char type, char const * resource, siz
 
         else {
           std::string href = "\"gdau://" + getId() + "/" + src.toUtf8().data() + "\"";
-          QString newTag   = QString::fromUtf8(
-            ( addAudioLink( href, getId() ) + "<span class=\"sdict_h_wav\"><a href=" + href + ">" ).c_str() );
+          QString newTag   = QString::fromStdString(
+             addAudioLink( href, getId() ) + "<span class=\"sdict_h_wav\"><a href=" + href + ">"  );
           newTag += match.captured( 4 );
           if ( match.captured( 4 ).indexOf( "<img " ) < 0 )
 
@@ -547,7 +547,7 @@ string StardictDictionary::handleResource( char type, char const * resource, siz
         articleNewText.clear();
       }
 
-      return articleText.toLocal8Bit().constData();
+      return articleText.toUtf8().constData();
     }
     case 'm': // Pure meaning, usually means preformatted text
       return "<div class=\"sdct_m\">" + Html::preformat( string( resource, size ), isToLanguageRTL() ) + "</div>";


### PR DESCRIPTION
the stardict qstring part has caused crash sometimes.
Fix #1702

basic rule: avoid unnecessary conversions between QString and string 

Changes:
1.
```
QString newTag   = QString::fromUtf8(
            ( addAudioLink( href, getId() ) + "<span class=\"sdict_h_wav\"><a href=" + href + ">" ).c_str() );
```
to 
string only.

2. `return (articleText.toUtf8.data());`
to
```
     auto text = articleText.toUtf8();
      return text.data();
```

3. 
`QString stripHtml( const QString & tmp )`
to
`QString stripHtml( QString tmp )`