### PR TITLE
clean: port away from `QTextCodec` in `slob.cc` and clean up iconv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,6 @@ endif ()
 
 target_compile_definitions(${GOLDENDICT} PUBLIC
         CMAKE_USED_HACK  # temporal hack to avoid breaking qmake build
-        USE_ICONV
         MAKE_QTMULTIMEDIA_PLAYER
         MAKE_CHINESE_CONVERSION_SUPPORT
         )

--- a/src/common/iconv.cc
+++ b/src/common/iconv.cc
@@ -126,3 +126,13 @@ std::string Iconv::toUtf8( char const * fromEncoding, void const * fromData, siz
   const QString outStr = ic.convert( fromData, dataSize );
   return outStr.toStdString();
 }
+
+QString Iconv::toQString( char const * fromEncoding, void const * fromData, size_t dataSize )
+{
+  if ( dataSize == 0 ) {
+    return {};
+  }
+
+  Iconv ic( fromEncoding );
+  return ic.convert( fromData, dataSize );
+}

--- a/src/common/iconv.cc
+++ b/src/common/iconv.cc
@@ -11,33 +11,20 @@ char const * const Iconv::GdWchar = "UTF-32LE";
 char const * const Iconv::Utf16Le = "UTF-16LE";
 char const * const Iconv::Utf8    = "UTF-8";
 
-using gd::wchar;
-
-Iconv::Iconv( char const * from )
-#ifdef USE_ICONV
-  // the to encoding must be UTF8
-  :
+Iconv::Iconv( char const * from ):
   state( iconv_open( Utf8, from ) )
-#endif
 {
-#ifdef USE_ICONV
   if ( state == (iconv_t)-1 )
     throw exCantInit( strerror( errno ) );
-#else
-  codec = QTextCodec::codecForName( from );
-#endif
 }
 
 Iconv::~Iconv()
 {
-#ifdef USE_ICONV
   iconv_close( state );
-#endif
 }
 
 QString Iconv::convert( void const *& inBuf, size_t & inBytesLeft )
 {
-#ifdef USE_ICONV
   size_t dsz = inBytesLeft;
   //avoid most realloc
   std::vector< char > outBuf( dsz + 32 );
@@ -90,12 +77,6 @@ QString Iconv::convert( void const *& inBuf, size_t & inBytesLeft )
   size_t datasize = outBuf.size() - outBufLeft;
   //  QByteArray ba( &outBuf.front(), datasize );
   return QString::fromUtf8( &outBuf.front(), datasize );
-#else
-  if ( codec )
-    return codec->toUnicode( static_cast< const char * >( inBuf ), inBytesLeft );
-  QByteArray ba( static_cast< const char * >( inBuf ), inBytesLeft );
-  return QString( ba );
-#endif
 }
 
 gd::wstring Iconv::toWstring( char const * fromEncoding, void const * fromData, size_t dataSize )
@@ -104,8 +85,9 @@ gd::wstring Iconv::toWstring( char const * fromEncoding, void const * fromData, 
   /// Special-case the dataSize == 0 to avoid any kind of iconv-specific
   /// behaviour in that regard.
 
-  if ( !dataSize )
+  if ( dataSize == 0 ) {
     return {};
+  }
 
   Iconv ic( fromEncoding );
 
@@ -118,8 +100,9 @@ std::string Iconv::toUtf8( char const * fromEncoding, void const * fromData, siz
 {
   // Similar to toWstring
 
-  if ( !dataSize )
+  if ( dataSize == 0 ) {
     return {};
+  }
 
   Iconv ic( fromEncoding );
 

--- a/src/common/iconv.hh
+++ b/src/common/iconv.hh
@@ -4,24 +4,19 @@
 #ifndef __ICONV_HH_INCLUDED__
 #define __ICONV_HH_INCLUDED__
 
-#include <QTextCodec>
+#include <QString>
 
 #include "wstring.hh"
 #include "ex.hh"
 
-#ifdef USE_ICONV
-  #include <iconv.h>
-#endif
+#include <iconv.h>
 
-/// A wrapper for the iconv() character set conversion functions
+
+/// "Internationalization conversion" for char encoding conversion, currently implemented with iconv()
+/// Only supports converting from a known "from" to UTF8
 class Iconv
 {
-#ifdef USE_ICONV
   iconv_t state;
-#else
-  QTextCodec * codec;
-
-#endif
 
 public:
 
@@ -34,7 +29,7 @@ public:
   static char const * const Utf16Le;
   static char const * const Utf8;
 
-  Iconv( char const * from );
+  explicit Iconv( char const * from );
 
   ~Iconv();
 
@@ -49,11 +44,8 @@ public:
 
   static QString toQString( char const * fromEncoding, void const * fromData, size_t dataSize );
 
-private:
-
-  // Copying/assigning not supported
-  Iconv( Iconv const & );
-  Iconv & operator=( Iconv const & );
+  // Copying/assigning isn't supported
+  Q_DISABLE_COPY_MOVE( Iconv );
 };
 
 #endif

--- a/src/common/iconv.hh
+++ b/src/common/iconv.hh
@@ -47,6 +47,8 @@ public:
   // string.
   static std::string toUtf8( char const * fromEncoding, void const * fromData, size_t dataSize );
 
+  static QString toQString( char const * fromEncoding, void const * fromData, size_t dataSize );
+
 private:
 
   // Copying/assigning not supported


### PR DESCRIPTION
Another attempt to remove usage of `Core5Compat`.

Is this change correct?

The Qt5 version of `QTextCodec::codecForName` underneath uses ICU

GNU libiconv has a large table of encoding alias

https://git.savannah.gnu.org/gitweb/?p=libiconv.git;a=blob;f=lib/encodings.def;h=e5063d329886818033e6d3aa14618c75d8b07852;hb=HEAD#l441

ICU also has a big table of encoding alias 

https://github.com/unicode-org/icu/blob/1414e80f6c1376afa65eb388aaaafb53169fc3dc/icu4c/source/data/mappings/convrtrs.txt#L891

Both includes names from various sources like INNA, glibc, java, windows, so I assume `QTextCodec::codecForName` and `iconv_open` are equal.

unrelated
---

`QStringConverter` since Qt6.5 also uses ICU to support equal set of encodings like old QTextCodec btw.

Maybe the correct path forward is just use ICU instead, because multiple dependencies of GD already depends on it one way or another.