### PR TITLE
fix: slob format's description HTML display

### DIFF
--- a/src/dict/slob.cc
+++ b/src/dict/slob.cc
@@ -726,14 +726,8 @@ QString const & SlobDictionary::getDescription()
   if ( !dictionaryDescription.isEmpty() )
     return dictionaryDescription;
 
-  QMap< QString, QString > const & tags = sf.getTags();
-
-  QMap< QString, QString >::const_iterator it;
-  for ( it = tags.begin(); it != tags.end(); ++it ) {
-    if ( it != tags.begin() )
-      dictionaryDescription += "\n\n";
-
-    dictionaryDescription += it.key() + ": " + it.value();
+  for ( auto [ key, value ] : sf.getTags().asKeyValueRange() ) {
+    dictionaryDescription += "<b>" % key % "</b>" % ": " % value % "<br>";
   }
 
   return dictionaryDescription;


### PR DESCRIPTION
Amend https://github.com/xiaoyifang/goldendict-ng/pull/398

After

<img width="400" src="https://github.com/user-attachments/assets/185d9681-5f77-4b76-959e-dbe715c6ef14">
