### PR TITLE
dev: ensure line ending is always LF

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,6 @@ object_script.goldendict.Release
 
 version.txt
 
-.gitattributes
-
 *.dmg
 
 .DS_Store


### PR DESCRIPTION
Pretty annoying, tools on Windows randomly change line endings to 💩.

`.editorconfig` is mostly for VS2017+ and various other https://editorconfig.org/#pre-installed

`.gitattributes` is for git (the git for windows convert CLRF by default? No idea and don't care, this will override it.)