### PR TITLE
dev: update .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,15 +1,18 @@
 # https://clang.llvm.org/extra/clang-tidy/
 ---
 Checks: >
-  -*
+  -*,
   bugprone-*,
   cert-*,
   clang-analyzer-*,
   clang-diagnostic-*,
+  concurrency-*,
   cppcoreguidelines-*,
   google-*,
+  hicpp-*,
   misc-*,
   modernize-*,
+  objc-*,
   performance-*,
   portability-*,
   readability-*,
@@ -17,18 +20,22 @@ Checks: >
   -bugprone-reserved-identifier,
   -cppcoreguidelines-owning-memory,
   -cppcoreguidelines-prefer-member-initializer,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-type-cstyle-cast,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
   -google-default-arguments,
-  -misc-non-private-member-variables-in-classes,
+  -google-readability-casting,
+  -hicpp-deprecated-headers,
   -misc-const-correctness,
+  -misc-non-private-member-variables-in-classes,
   -modernize-avoid-c-arrays,
-#  -modernize-use-auto,
+  -modernize-deprecated-headers,
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
-  -readability-magic-numbers,
-  -google-readability-braces-around-statements,
   -readability-braces-around-statements,
-  -readability-identifier-length,
   -readability-function-cognitive-complexity,
+  -readability-identifier-length,
+  -readability-magic-numbers,
 CheckOptions:
   - key: modernize-loop-convert.MinConfidence
     value: reasonable


### PR DESCRIPTION
Fix

* The missing comma at the head doesn't exclude many warnings
* The comment in middle doesn't exclude warnings in the following lines

Thankfully, both leads to more warnings instead of reducing 😅 

* Remove `deprecated-headers` warnings -> Couldn't matter less.

* Remove C-style cast & reinterpret_cast warnings
  * We only use them in a few places to interact with external APIs
    * The warnings are conflicting, convert C-style cast will warn reinterpret_cast is wrong or const_cast is wrong.
    * There is noway to satisfy clang-tidy.
* Remove `cppcoreguidelines-pro-bounds-array-to-pointer-decay`
  * A pain of C style array, but it is not obvious what to fix when interacting with C libraries
    * just avoid them altogether is better -> `cppcoreguidelines-avoid-c-arrays`
* Add a few more
* Sort