### PR TITLE
clean: replace removed `Qt5/QList` and `QPair`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -5,3 +5,6 @@ b5349478cfb0dc2dd0de8c8e8aeebdd24cf7ac6b
 
 # reformat every .js .css
 534d8c2e96ef00ae03650c2185d7b240ea5a1114
+
+# replace QVector & QPair
+3273f39dd73f4dba07fa95be2be74061f2690b2c

--- a/src/article_maker.cc
+++ b/src/article_maker.cc
@@ -998,9 +998,9 @@ void ArticleRequest::individualWordFinished()
   compoundSearchNextStep( false );
 }
 
-QPair< ArticleRequest::Words, ArticleRequest::Spacings > ArticleRequest::splitIntoWords( QString const & input )
+std::pair< ArticleRequest::Words, ArticleRequest::Spacings > ArticleRequest::splitIntoWords( QString const & input )
 {
-  QPair< Words, Spacings > result;
+  std::pair< Words, Spacings > result;
 
   QChar const * ptr = input.data();
 

--- a/src/btreeidx.cc
+++ b/src/btreeidx.cc
@@ -1028,7 +1028,7 @@ void BtreeIndex::getAllHeadwords( QSet< QString > & headwords )
   findArticleLinks( nullptr, nullptr, &headwords );
 }
 
-void BtreeIndex::findAllArticleLinks( QVector< WordArticleLink > & articleLinks )
+void BtreeIndex::findAllArticleLinks( QList< WordArticleLink > & articleLinks )
 {
   if ( !idxFile )
     throw exIndexWasNotOpened();
@@ -1038,7 +1038,7 @@ void BtreeIndex::findAllArticleLinks( QVector< WordArticleLink > & articleLinks 
   findArticleLinks( &articleLinks, &offsets, nullptr );
 }
 
-void BtreeIndex::findArticleLinks( QVector< WordArticleLink > * articleLinks,
+void BtreeIndex::findArticleLinks( QList< WordArticleLink > * articleLinks,
                                    QSet< uint32_t > * offsets,
                                    QSet< QString > * headwords,
                                    QAtomicInt * isCancelled )
@@ -1217,7 +1217,7 @@ QList< uint32_t > BtreeIndex::findNodes()
 }
 
 void BtreeIndex::getHeadwordsFromOffsets( QList< uint32_t > & offsets,
-                                          QVector< QString > & headwords,
+                                          QList< QString > & headwords,
                                           QAtomicInt * isCancelled )
 {
   uint32_t currentNodeOffset = rootOffset;

--- a/src/btreeidx.hh
+++ b/src/btreeidx.hh
@@ -89,7 +89,7 @@ public:
   vector< WordArticleLink > findArticles( wstring const &, bool ignoreDiacritics = false, uint32_t maxMatchCount = -1 );
 
   /// Find all unique article links in the index
-  void findAllArticleLinks( QVector< WordArticleLink > & articleLinks );
+  void findAllArticleLinks( QList< WordArticleLink > & articleLinks );
 
   /// Retrieve all unique headwords from index
   void getAllHeadwords( QSet< QString > & headwords );

--- a/src/common/wstring_qt.cc
+++ b/src/common/wstring_qt.cc
@@ -1,5 +1,5 @@
 #include "wstring_qt.hh"
-#include <QVector>
+#include <QList>
 
 namespace gd {
 wstring toWString( QString const & in )
@@ -19,7 +19,7 @@ wstring removeTrailingZero( wstring const & v )
 
 wstring removeTrailingZero( QString const & in )
 {
-  QVector< unsigned int > v = in.toUcs4();
+  QList< unsigned int > v = in.toUcs4();
 
   int n = v.size();
   while ( n > 0 && v[ n - 1 ] == 0 )

--- a/src/dict/dsl.cc
+++ b/src/dict/dsl.cc
@@ -119,8 +119,8 @@ struct InsidedCard
 {
   uint32_t offset;
   uint32_t size;
-  QVector< wstring > headwords;
-  InsidedCard( uint32_t _offset, uint32_t _size, QVector< wstring > const & words ):
+  QList< wstring > headwords;
+  InsidedCard( uint32_t _offset, uint32_t _size, QList< wstring > const & words ):
     offset( _offset ),
     size( _size ),
     headwords( words )
@@ -950,8 +950,8 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
       QString attr = QString::fromStdU32String( node.tagAttrs ).remove( '\"' );
       int n        = attr.indexOf( '=' );
       if ( n > 0 ) {
-        QList< QPair< QString, QString > > query;
-        query.append( QPair< QString, QString >( attr.left( n ), attr.mid( n + 1 ) ) );
+        QList< std::pair< QString, QString > > query;
+        query.append( std::pair< QString, QString >( attr.left( n ), attr.mid( n + 1 ) ) );
         Utils::Url::setQueryItems( url, query );
       }
     }
@@ -1920,9 +1920,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
             int insideInsided = 0;
             wstring headword;
-            QVector< InsidedCard > insidedCards;
+            QList< InsidedCard > insidedCards;
             uint32_t offset = curOffset;
-            QVector< wstring > insidedHeadwords;
+            QList< wstring > insidedHeadwords;
             unsigned linesInsideCard = 0;
             int dogLine              = 0;
             bool wasEmptyLine        = false;

--- a/src/dict/epwing.cc
+++ b/src/dict/epwing.cc
@@ -137,7 +137,7 @@ public:
 
   QString const & getDescription() override;
 
-  void getHeadwordPos( wstring const & word_, QVector< int > & pg, QVector< int > & off );
+  void getHeadwordPos( wstring const & word_, QList< int > & pg, QList< int > & off );
 
   sptr< Dictionary::DataRequest >
   getArticle( wstring const &, vector< wstring > const & alts, wstring const &, bool ignoreDiacritics ) override;
@@ -543,8 +543,8 @@ void EpwingHeadwordsRequest::run()
   }
 
 
-  QVector< int > pg;
-  QVector< int > off;
+  QList< int > pg;
+  QList< int > off;
   dict.getHeadwordPos( parts[ 0 ].toStdU32String(), pg, off );
 
   for ( unsigned i = 0; i < pg.size(); ++i ) {
@@ -600,8 +600,8 @@ public:
   void run();
 
   void getBuiltInArticle( wstring const & word_,
-                          QVector< int > & pages,
-                          QVector< int > & offsets,
+                          QList< int > & pages,
+                          QList< int > & offsets,
                           multimap< wstring, pair< string, string > > & mainArticles );
 
   void cancel() override
@@ -642,7 +642,7 @@ void EpwingArticleRequest::run()
   if ( ignoreDiacritics )
     wordCaseFolded = Folding::applyDiacriticsOnly( wordCaseFolded );
 
-  QVector< int > pages, offsets;
+  QList< int > pages, offsets;
 
   for ( auto & x : chain ) {
     if ( Utils::AtomicInt::loadAcquire( isCancelled ) ) {
@@ -751,14 +751,14 @@ void EpwingArticleRequest::run()
 }
 
 void EpwingArticleRequest::getBuiltInArticle( wstring const & word_,
-                                              QVector< int > & pages,
-                                              QVector< int > & offsets,
+                                              QList< int > & pages,
+                                              QList< int > & offsets,
                                               multimap< wstring, pair< string, string > > & mainArticles )
 {
   try {
     string headword, articleText;
 
-    QVector< int > pg, off;
+    QList< int > pg, off;
     {
       QMutexLocker _( &dict.eBook.getLibMutex() );
       dict.eBook.getArticlePos( QString::fromStdU32String( word_ ), pg, off );
@@ -787,7 +787,7 @@ void EpwingArticleRequest::getBuiltInArticle( wstring const & word_,
   }
 }
 
-void EpwingDictionary::getHeadwordPos( wstring const & word_, QVector< int > & pg, QVector< int > & off )
+void EpwingDictionary::getHeadwordPos( wstring const & word_, QList< int > & pg, QList< int > & off )
 {
   try {
     QMutexLocker _( &eBook.getLibMutex() );
@@ -986,7 +986,7 @@ void EpwingWordSearchRequest::findMatches()
   }
 
   while ( matches.size() < maxResults ) {
-    QVector< QString > headwords;
+    QList< QString > headwords;
     {
       QMutexLocker _( &edict.eBook.getLibMutex() );
       if ( Utils::AtomicInt::loadAcquire( isCancelled ) )

--- a/src/dict/epwing_book.cc
+++ b/src/dict/epwing_book.cc
@@ -1857,7 +1857,7 @@ QString EpwingBook::currentCandidate()
   return QString{};
 }
 
-bool EpwingBook::getMatches( QString word, QVector< QString > & matches )
+bool EpwingBook::getMatches( QString word, QList< QString > & matches )
 {
   QByteArray bword, bword2;
   EB_Hit hits[ HitsBufferSize ];
@@ -1904,7 +1904,7 @@ bool EpwingBook::getMatches( QString word, QVector< QString > & matches )
     }
   }
 
-  QVector< int > pages, offsets;
+  QList< int > pages, offsets;
 
   for ( int i = 0; i < hitCount; i++ ) {
     bool same_article = false;
@@ -1928,7 +1928,7 @@ bool EpwingBook::getMatches( QString word, QVector< QString > & matches )
   return true;
 }
 
-bool EpwingBook::getArticlePos( QString word, QVector< int > & pages, QVector< int > & offsets )
+bool EpwingBook::getArticlePos( QString word, QList< int > & pages, QList< int > & offsets )
 {
   QByteArray bword, bword2;
   EB_Hit hits[ HitsBufferSize ];

--- a/src/dict/hunspell.cc
+++ b/src/dict/hunspell.cc
@@ -126,7 +126,7 @@ string encodeToHunspell( Hunspell &, wstring const & );
 wstring decodeFromHunspell( Hunspell &, char const * );
 
 /// Generates suggestions via hunspell
-QVector< wstring > suggest( wstring & word, QMutex & hunspellMutex, Hunspell & hunspell );
+QList< wstring > suggest( wstring & word, QMutex & hunspellMutex, Hunspell & hunspell );
 
 /// Generates suggestions for compound expression
 void getSuggestionsForExpression( wstring const & expression,
@@ -362,7 +362,7 @@ void HunspellHeadwordsRequest::run()
       matches.push_back( result );
   }
   else {
-    QVector< wstring > suggestions = suggest( trimmedWord, hunspellMutex, hunspell );
+    QList< wstring > suggestions = suggest( trimmedWord, hunspellMutex, hunspell );
 
     if ( !suggestions.empty() ) {
       QMutexLocker _( &dataMutex );
@@ -375,9 +375,9 @@ void HunspellHeadwordsRequest::run()
   finish();
 }
 
-QVector< wstring > suggest( wstring & word, QMutex & hunspellMutex, Hunspell & hunspell )
+QList< wstring > suggest( wstring & word, QMutex & hunspellMutex, Hunspell & hunspell )
 {
-  QVector< wstring > result;
+  QList< wstring > result;
 
   vector< string > suggestions;
 
@@ -522,7 +522,7 @@ void getSuggestionsForExpression( wstring const & expression,
 
   wstring trimmedWord = Folding::trimWhitespaceOrPunct( expression );
   wstring word, punct;
-  QVector< wstring > words;
+  QList< wstring > words;
 
   suggestions.clear();
 
@@ -556,7 +556,7 @@ void getSuggestionsForExpression( wstring const & expression,
 
   // Combine result strings from suggestions
 
-  QVector< wstring > results;
+  QList< wstring > results;
 
   for ( const auto & i : words ) {
     word = i;
@@ -565,7 +565,7 @@ void getSuggestionsForExpression( wstring const & expression,
         result.append( word );
     }
     else {
-      QVector< wstring > sugg = suggest( word, hunspellMutex, hunspell );
+      QList< wstring > sugg   = suggest( word, hunspellMutex, hunspell );
       int suggNum             = sugg.size() + 1;
       if ( suggNum > 3 )
         suggNum = 3;

--- a/src/dict/slob.cc
+++ b/src/dict/slob.cc
@@ -28,14 +28,14 @@
 #include <QFileInfo>
 #include <QDir>
 #include <QMap>
-#include <QPair>
 #include <QProcess>
-#include <QVector>
+#include <QList>
 
 #include <QRegularExpression>
 
 #include <string>
 #include <vector>
+#include <utility>
 #include <map>
 #include <set>
 #include <algorithm>
@@ -113,8 +113,8 @@ bool indexIsOldOrBad( string const & indexFile )
 class SlobFile
 {
 public:
-  typedef QPair< quint64, quint32 > RefEntryOffsetItem;
-  typedef QVector< RefEntryOffsetItem > RefOffsetsVector;
+  typedef std::pair< quint64, quint32 > RefEntryOffsetItem;
+  typedef QList< RefEntryOffsetItem > RefOffsetsVector;
 
 private:
   enum Compressions {
@@ -131,7 +131,7 @@ private:
   std::string encoding;
   unsigned char uuid[ 16 ];
   QMap< QString, QString > tags;
-  QVector< QString > contentTypes;
+  QList< QString > contentTypes;
   quint32 blobCount;
   quint64 storeOffset, fileSize, refsOffset;
   quint32 refsCount, itemsCount;
@@ -499,7 +499,7 @@ quint8 SlobFile::getItem( RefEntry const & entry, string * data )
     if ( entry.binIndex >= bins )
       return 0xFF;
 
-    QVector< quint8 > ids;
+    QList< quint8 > ids;
     ids.resize( bins );
     if ( file.read( (char *)ids.data(), bins ) != bins )
       break;

--- a/src/dict/voiceengines.cc
+++ b/src/dict/voiceengines.cc
@@ -92,8 +92,8 @@ VoiceEnginesDictionary::getArticle( wstring const & word, vector< wstring > cons
   url.setScheme( "gdtts" );
   url.setHost( "localhost" );
   url.setPath( Utils::Url::ensureLeadingSlash( QString::fromUtf8( wordUtf8.c_str() ) ) );
-  QList< QPair< QString, QString > > query;
-  query.push_back( QPair< QString, QString >( "engine", QString::fromStdString( getId() ) ) );
+  QList< std::pair< QString, QString > > query;
+  query.push_back( std::pair< QString, QString >( "engine", QString::fromStdString( getId() ) ) );
   Utils::Url::setQueryItems( url, query );
 
   string encodedUrl = url.toEncoded().data();

--- a/src/ftshelpers.cc
+++ b/src/ftshelpers.cc
@@ -76,7 +76,7 @@ void makeFTSIndex( BtreeIndexing::BtreeDictionary * dict, QAtomicInt & isCancell
     if ( Utils::AtomicInt::loadAcquire( isCancelled ) )
       throw exUserAbort();
 
-    QVector< uint32_t > offsets;
+    QList< uint32_t > offsets;
     offsets.resize( setOfOffsets.size() );
     uint32_t * ptr = offsets.data();
 
@@ -220,7 +220,7 @@ void FTSResultsRequest::run()
       }
 
       if ( !offsetsForHeadwords.isEmpty() ) {
-        QVector< QString > headwords;
+        QList< QString > headwords;
         QMutexLocker _( &dataMutex );
         QString id = QString::fromUtf8( dict.getId().c_str() );
         dict.getHeadwordsFromOffsets( offsetsForHeadwords, headwords, &isCancelled );

--- a/src/instances.cc
+++ b/src/instances.cc
@@ -24,7 +24,7 @@ Group::Group( Config::Group const & cfgGroup,
     iconData = iconFromData( cfgGroup.iconData );
 
   QMap< string, sptr< Dictionary::Class > > groupDicts;
-  QVector< string > dictOrderList;
+  QList< string > dictOrderList;
   auto dictMap = Dictionary::dictToMap( allDictionaries );
 
   for ( auto const & dict : cfgGroup.dictionaries ) {

--- a/src/langcoder.cc
+++ b/src/langcoder.cc
@@ -283,7 +283,7 @@ quint32 LangCoder::guessId( const QString & lang )
 }
 
 
-QPair< quint32, quint32 > LangCoder::findLangIdPairFromName( QString const & name )
+std::pair< quint32, quint32 > LangCoder::findLangIdPairFromName( QString const & name )
 {
   static QRegularExpression reg( "(?=([a-z]{2,3})-([a-z]{2,3}))", QRegularExpression::CaseInsensitiveOption );
 
@@ -301,7 +301,7 @@ QPair< quint32, quint32 > LangCoder::findLangIdPairFromName( QString const & nam
   return { 0, 0 };
 }
 
-QPair< quint32, quint32 > LangCoder::findLangIdPairFromPath( std::string const & p )
+std::pair< quint32, quint32 > LangCoder::findLangIdPairFromPath( std::string const & p )
 {
   return findLangIdPairFromName( QFileInfo( QString::fromStdString( p ) ).fileName() );
 }

--- a/src/speechclient.cc
+++ b/src/speechclient.cc
@@ -30,7 +30,7 @@ SpeechClient::Engines SpeechClient::availableEngines()
 
     qDebug() << engine_name << sp->state();
 
-    //    const QVector< QLocale > locales = sp->availableLocales();
+    //    const QList< QLocale > locales = sp->availableLocales();
     //    for ( const QLocale & locale : locales )
     {
       QLocale locale;

--- a/src/splitfile.cc
+++ b/src/splitfile.cc
@@ -27,7 +27,7 @@ void SplitFile::appendFile( const QString & name )
 
 void SplitFile::close()
 {
-  for ( QVector< QFile * >::const_iterator i = files.begin(); i != files.end(); ++i ) {
+  for ( QList< QFile * >::const_iterator i = files.begin(); i != files.end(); ++i ) {
     ( *i )->close();
     delete ( *i );
   }
@@ -40,7 +40,7 @@ void SplitFile::close()
 
 void SplitFile::getFilenames( vector< string > & names ) const
 {
-  for ( QVector< QFile * >::const_iterator i = files.begin(); i != files.end(); ++i )
+  for ( QList< QFile * >::const_iterator i = files.begin(); i != files.end(); ++i )
     names.push_back( ( *i )->fileName().toStdString() );
 }
 
@@ -51,7 +51,7 @@ int SplitFile::getCurrentFile() const
 
 bool SplitFile::open( QFile::OpenMode mode )
 {
-  for ( QVector< QFile * >::iterator i = files.begin(); i != files.end(); ++i )
+  for ( QList< QFile * >::iterator i = files.begin(); i != files.end(); ++i )
     if ( !( *i )->open( mode ) ) {
       close();
       return false;

--- a/src/ui/groups_widgets.cc
+++ b/src/ui/groups_widgets.cc
@@ -19,7 +19,7 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QTimer>
-#include <QVector>
+#include <QList>
 
 using std::vector;
 
@@ -374,8 +374,8 @@ void DictListModel::addSelectedUniqueFromModel( QItemSelectionModel * source )
   if ( !baseModel )
     return;
 
-  QVector< std::string > list;
-  QVector< std::string > dicts;
+  QList< std::string > list;
+  QList< std::string > dicts;
   for ( const auto & dictionarie : dictionaries )
     dicts.append( dictionarie->getId() );
 
@@ -649,8 +649,8 @@ void DictGroupsWidget::addAutoGroups()
        != QMessageBox::Yes )
     return;
 
-  QMap< QString, QVector< sptr< Dictionary::Class > > > dictMap;
-  QMap< QString, QVector< sptr< Dictionary::Class > > > morphoMap;
+  QMap< QString, QList< sptr< Dictionary::Class > > > dictMap;
+  QMap< QString, QList< sptr< Dictionary::Class > > > morphoMap;
 
   // Put active dictionaries into lists
 
@@ -660,7 +660,7 @@ void DictGroupsWidget::addAutoGroups()
     if ( idFrom == 0 ) {
       // Attempt to find language pair in dictionary name
 
-      const QPair< quint32, quint32 > ids =
+      const std::pair< quint32, quint32 > ids =
         LangCoder::findLangIdPairFromName( QString::fromUtf8( dict->getName().c_str() ) );
       idFrom                              = ids.first;
       idTo                                = ids.second;
@@ -693,7 +693,7 @@ void DictGroupsWidget::addAutoGroups()
   // Insert morphology dictionaries into corresponding lists
   for ( const auto & gr : groupList ) {
     if ( auto morpho_key = gr.left( 2 ).toLower(); morphoMap.contains( morpho_key ) ) {
-      QVector< sptr< Dictionary::Class > > vdg = dictMap[ gr ];
+      QList< sptr< Dictionary::Class > > vdg = dictMap[ gr ];
       vdg += morphoMap[ morpho_key ];
       dictMap[ gr ] = vdg;
     }
@@ -704,7 +704,7 @@ void DictGroupsWidget::addAutoGroups()
     const auto idx = addUniqueGroup( gr );
 
     // add dictionaries into the current group
-    QVector< sptr< Dictionary::Class > > const vd = dictMap[ gr ];
+    QList< sptr< Dictionary::Class > > const vd = dictMap[ gr ];
     DictListModel * model                   = getModelAt( idx );
     if ( !model )
       continue;

--- a/src/ui/orderandprops.cc
+++ b/src/ui/orderandprops.cc
@@ -7,9 +7,9 @@
 #include "language.hh"
 
 #include <algorithm>
+#include <utility>
 
 #include <QMenu>
-#include <QPair>
 
 using std::vector;
 using std::sort;
@@ -33,7 +33,8 @@ bool dictLessThan( sptr< Dictionary::Class > const & dict1, sptr< Dictionary::Cl
   int idFrom1 = dict1->getLangFrom();
   int idTo1   = dict1->getLangTo();
   if ( idFrom1 == 0 ) {
-    QPair< quint32, quint32 > ids = LangCoder::findLangIdPairFromName( QString::fromUtf8( dict1->getName().c_str() ) );
+    std::pair< quint32, quint32 > ids =
+      LangCoder::findLangIdPairFromName( QString::fromUtf8( dict1->getName().c_str() ) );
     idFrom1                       = ids.first;
     idTo1                         = ids.second;
   }
@@ -41,7 +42,8 @@ bool dictLessThan( sptr< Dictionary::Class > const & dict1, sptr< Dictionary::Cl
   int idFrom2 = dict2->getLangFrom();
   int idTo2   = dict2->getLangTo();
   if ( idFrom2 == 0 ) {
-    QPair< quint32, quint32 > ids = LangCoder::findLangIdPairFromName( QString::fromUtf8( dict2->getName().c_str() ) );
+    std::pair< quint32, quint32 > ids =
+      LangCoder::findLangIdPairFromName( QString::fromUtf8( dict2->getName().c_str() ) );
     idFrom2                       = ids.first;
     idTo2                         = ids.second;
   }

--- a/src/zipfile.cc
+++ b/src/zipfile.cc
@@ -230,7 +230,7 @@ void SplitZipFile::setFileName( const QString & name )
 QDateTime SplitZipFile::lastModified() const
 {
   unsigned long ts = 0;
-  for ( QVector< QFile * >::const_iterator i = files.begin(); i != files.end(); ++i ) {
+  for ( QList< QFile * >::const_iterator i = files.begin(); i != files.end(); ++i ) {
     unsigned long t = QFileInfo( ( *i )->fileName() ).lastModified().toSecsSinceEpoch();
     if ( t > ts )
       ts = t;


### PR DESCRIPTION
These 2 types are just alias in Qt6.

* `Qt5/QList` is removed, and `Qt6/QList` is actually `Qt5/QVector`. (Mostly because the use case of `Qt5/QList` doesn't exist, and it is slow.)
   * Pretty sure this is the dude who pushed the removal `Qt5/Qlist` (it only takes a decade 😅)
   * https://marcmutz.wordpress.com/2010/07/29/sneak-preview-qlist-considered-harmful/
* `QPair` is deleted.
  * Unrelated to this PR, but various style guides simply ban/discourage "Pair" https://google.github.io/styleguide/cppguide.html#Structs_vs._Tuples 