### PR TITLE
dev: ship macOS version with debuginfo

### DIFF
--- a/.github/workflows/release-macos-homebrew.yml
+++ b/.github/workflows/release-macos-homebrew.yml
@@ -73,7 +73,7 @@ jobs:
       - name: compile
         run: |
           mkdir build_dir
-          cmake -S . -B build_dir -G Ninja -DWITH_FFMPEG_PLAYER=OFF -DWITH_TTS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET="12.0"
+          cmake -S . -B build_dir -G Ninja -DWITH_FFMPEG_PLAYER=OFF -DWITH_TTS=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_OSX_DEPLOYMENT_TARGET="12.0"
           cmake --build build_dir
           
       - name: package


### PR DESCRIPTION
For 2 reasons
* Nobody else has macOS hardware → hard to figure out macOS only issues.
* macOS has a top-notch crash handler built into the system that supports C++ very well. Let's just use it.

Both Qt & Homebrew strips debug symbols, so only symbols from goldendict's main executable are included.

The size of "goldendict" executable increases merely from 5.8Mb to 6.2Mb on my machine.