### PR TITLE
feature: High-quality dictionary icons in toolbar

### DIFF
--- a/src/dict/dictionary.cc
+++ b/src/dict/dictionary.cc
@@ -271,8 +271,6 @@ bool Class::loadIconFromFile( QString const & _filename, bool isFullName )
     if ( !img.isNull() ) {
       // Load successful
 
-      //some icon is very large ,will crash the application.
-      img = img.scaledToWidth( 64 );
       // Apply the color key
 #if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
       img.setAlphaChannel( img.createMaskFromColor( QColor( 192, 192, 192 ).rgb(), Qt::MaskOutColor ) );

--- a/src/dict/dictionary.cc
+++ b/src/dict/dictionary.cc
@@ -276,7 +276,7 @@ bool Class::loadIconFromFile( QString const & _filename, bool isFullName )
       img.setAlphaChannel( img.createMaskFromColor( QColor( 192, 192, 192 ).rgb(), Qt::MaskOutColor ) );
 #endif
 
-      auto result    = img.scaled( { iconWidth, iconWidth }, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation );
+      auto result    = img.scaled( { iconSize, iconSize }, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation );
       dictionaryIcon = QIcon( QPixmap::fromImage( result ) );
 
       return !dictionaryIcon.isNull();
@@ -292,18 +292,19 @@ bool Class::loadIconFromText( QString iconUrl, QString const & text )
   QImage img( iconUrl );
 
   if ( !img.isNull() ) {
-    QImage result = img.scaled( { iconWidth, iconWidth }, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation );
+    QImage result = img.scaled( { iconSize, iconSize }, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation );
 
     QPainter painter( &result );
+    painter.setRenderHints( QPainter::Antialiasing | QPainter::TextAntialiasing );
     painter.setCompositionMode( QPainter::CompositionMode_SourceAtop );
 
     QFont font = painter.font();
     //the text should be a little smaller than the icon
-    font.setPixelSize( iconWidth * 0.6 );
+    font.setPixelSize( iconSize * 0.6 );
     font.setWeight( QFont::Bold );
     painter.setFont( font );
 
-    const QRect rectangle = QRect( 0, 0, iconWidth, iconWidth );
+    const QRect rectangle = QRect( 0, 0, iconSize, iconSize );
 
     //select a single char.
     auto abbrName = getAbbrName( text );

--- a/src/dict/dictionary.cc
+++ b/src/dict/dictionary.cc
@@ -275,7 +275,6 @@ bool Class::loadIconFromFile( QString const & _filename, bool isFullName )
 #if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
       img.setAlphaChannel( img.createMaskFromColor( QColor( 192, 192, 192 ).rgb(), Qt::MaskOutColor ) );
 #endif
-
     }
   }
   return false;

--- a/src/dict/dictionary.cc
+++ b/src/dict/dictionary.cc
@@ -276,20 +276,6 @@ bool Class::loadIconFromFile( QString const & _filename, bool isFullName )
       img.setAlphaChannel( img.createMaskFromColor( QColor( 192, 192, 192 ).rgb(), Qt::MaskOutColor ) );
 #endif
 
-      // Transform it to be square
-      int max = img.width() > img.height() ? img.width() : img.height();
-
-      QImage result( max, max, QImage::Format_ARGB32 );
-      result.fill( 0 ); // Black transparent
-
-      QPainter painter( &result );
-      painter.setRenderHint( QPainter::RenderHint::Antialiasing );
-      painter.drawImage( QPoint( img.width() == max ? 0 : ( max - img.width() ) / 2,
-                                 img.height() == max ? 0 : ( max - img.height() ) / 2 ),
-                         img );
-
-      painter.end();
-
       dictionaryIcon = QIcon( QPixmap::fromImage( result ) );
 
       return !dictionaryIcon.isNull();

--- a/src/dict/dictionary.cc
+++ b/src/dict/dictionary.cc
@@ -292,8 +292,6 @@ bool Class::loadIconFromText( QString iconUrl, QString const & text )
   QImage img( iconUrl );
 
   if ( !img.isNull() ) {
-    //some icon is very large ,will crash the application.
-    img = img.scaledToWidth( iconWidth );
     QImage result = img.scaled( { iconWidth, iconWidth }, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation );
 
     QPainter painter( &result );

--- a/src/dict/dictionary.cc
+++ b/src/dict/dictionary.cc
@@ -276,7 +276,7 @@ bool Class::loadIconFromFile( QString const & _filename, bool isFullName )
       img.setAlphaChannel( img.createMaskFromColor( QColor( 192, 192, 192 ).rgb(), Qt::MaskOutColor ) );
 #endif
 
-      auto result = img.scaled( {iconSize,iconSize},Qt::KeepAspectRatioByExpanding,Qt::SmoothTransformation );
+      auto result    = img.scaled( { iconSize, iconSize }, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation );
       dictionaryIcon = QIcon( QPixmap::fromImage( result ) );
 
       return !dictionaryIcon.isNull();
@@ -294,7 +294,7 @@ bool Class::loadIconFromText( QString iconUrl, QString const & text )
   if ( !img.isNull() ) {
     //some icon is very large ,will crash the application.
     img = img.scaledToWidth( iconSize );
-    QImage result = img.scaled( {iconSize,iconSize},Qt::KeepAspectRatioByExpanding,Qt::SmoothTransformation);
+    QImage result = img.scaled( { iconSize, iconSize }, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation );
 
     QPainter painter( &result );
     painter.setCompositionMode( QPainter::CompositionMode_SourceAtop );

--- a/src/dict/dictionary.cc
+++ b/src/dict/dictionary.cc
@@ -276,9 +276,6 @@ bool Class::loadIconFromFile( QString const & _filename, bool isFullName )
       img.setAlphaChannel( img.createMaskFromColor( QColor( 192, 192, 192 ).rgb(), Qt::MaskOutColor ) );
 #endif
 
-      dictionaryIcon = QIcon( QPixmap::fromImage( result ) );
-
-      return !dictionaryIcon.isNull();
     }
   }
   return false;

--- a/src/dict/dictionary.cc
+++ b/src/dict/dictionary.cc
@@ -275,6 +275,11 @@ bool Class::loadIconFromFile( QString const & _filename, bool isFullName )
 #if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
       img.setAlphaChannel( img.createMaskFromColor( QColor( 192, 192, 192 ).rgb(), Qt::MaskOutColor ) );
 #endif
+
+      auto result = img.scaled( {iconSize,iconSize},Qt::KeepAspectRatioByExpanding,Qt::SmoothTransformation );
+      dictionaryIcon = QIcon( QPixmap::fromImage( result ) );
+
+      return !dictionaryIcon.isNull();
     }
   }
   return false;
@@ -287,18 +292,11 @@ bool Class::loadIconFromText( QString iconUrl, QString const & text )
   QImage img( iconUrl );
 
   if ( !img.isNull() ) {
-    int iconSize = 64;
     //some icon is very large ,will crash the application.
     img = img.scaledToWidth( iconSize );
-    QImage result( iconSize, iconSize, QImage::Format_ARGB32 );
-    result.fill( 0 ); // Black transparent
-    int max = img.width() > img.height() ? img.width() : img.height();
+    QImage result = img.scaled( {iconSize,iconSize},Qt::KeepAspectRatioByExpanding,Qt::SmoothTransformation);
 
     QPainter painter( &result );
-    painter.setRenderHint( QPainter::RenderHint::Antialiasing );
-    painter.drawImage( QPoint( img.width() == max ? 0 : ( max - img.width() ) / 2,
-                               img.height() == max ? 0 : ( max - img.height() ) / 2 ),
-                       img );
     painter.setCompositionMode( QPainter::CompositionMode_SourceAtop );
 
     QFont font = painter.font();

--- a/src/dict/dictionary.cc
+++ b/src/dict/dictionary.cc
@@ -276,7 +276,7 @@ bool Class::loadIconFromFile( QString const & _filename, bool isFullName )
       img.setAlphaChannel( img.createMaskFromColor( QColor( 192, 192, 192 ).rgb(), Qt::MaskOutColor ) );
 #endif
 
-      auto result    = img.scaled( { iconSize, iconSize }, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation );
+      auto result    = img.scaled( { iconWidth, iconWidth }, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation );
       dictionaryIcon = QIcon( QPixmap::fromImage( result ) );
 
       return !dictionaryIcon.isNull();
@@ -293,19 +293,19 @@ bool Class::loadIconFromText( QString iconUrl, QString const & text )
 
   if ( !img.isNull() ) {
     //some icon is very large ,will crash the application.
-    img = img.scaledToWidth( iconSize );
-    QImage result = img.scaled( { iconSize, iconSize }, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation );
+    img = img.scaledToWidth( iconWidth );
+    QImage result = img.scaled( { iconWidth, iconWidth }, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation );
 
     QPainter painter( &result );
     painter.setCompositionMode( QPainter::CompositionMode_SourceAtop );
 
     QFont font = painter.font();
     //the text should be a little smaller than the icon
-    font.setPixelSize( iconSize * 0.6 );
+    font.setPixelSize( iconWidth * 0.6 );
     font.setWeight( QFont::Bold );
     painter.setFont( font );
 
-    const QRect rectangle = QRect( 0, 0, iconSize, iconSize );
+    const QRect rectangle = QRect( 0, 0, iconWidth, iconWidth );
 
     //select a single char.
     auto abbrName = getAbbrName( text );

--- a/src/dict/dictionary.hh
+++ b/src/dict/dictionary.hh
@@ -316,10 +316,11 @@ protected:
   bool synonymSearchEnabled;
   string dictionaryName;
   std::optional< bool > metadata_enable_fts = std::nullopt;
-
   // Load user icon if it exist
   // By default set icon to empty
   virtual void loadIcon() noexcept;
+
+  const int iconSize = 64;
 
   // Load icon from filename directly if isFullName == true
   // else treat filename as name without extension

--- a/src/dict/dictionary.hh
+++ b/src/dict/dictionary.hh
@@ -320,7 +320,7 @@ protected:
   // By default set icon to empty
   virtual void loadIcon() noexcept;
 
-  const int iconSize = 64;
+  const int iconWidth = 64;
 
   // Load icon from filename directly if isFullName == true
   // else treat filename as name without extension

--- a/src/dict/dictionary.hh
+++ b/src/dict/dictionary.hh
@@ -320,7 +320,7 @@ protected:
   // By default set icon to empty
   virtual void loadIcon() noexcept;
 
-  const int iconWidth = 64;
+  const int iconSize = 64;
 
   // Load icon from filename directly if isFullName == true
   // else treat filename as name without extension

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -20,7 +20,7 @@ DictionaryBar::DictionaryBar( QWidget * parent,
   maxDictionaryRefsInContextMenu( maxDictionaryRefsInContextMenu_ )
 {
 
-  normalIconSize = this->size();
+  normalIconSize = this->size(); // At the time of initialization, this equals `QStyle::PM_ToolBarIconSize`
 
   setObjectName( "dictionaryBar" );
 
@@ -79,7 +79,7 @@ void DictionaryBar::setDictionaries( vector< sptr< Dictionary::Class > > const &
   setUpdatesEnabled( true );
 }
 
-void DictionaryBar::updateDictionaryIconSize( IconSize size )
+void DictionaryBar::setDictionaryIconSize( IconSize size )
 {
   switch ( size ) {
     case IconSize::Small: {

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -20,10 +20,10 @@ DictionaryBar::DictionaryBar( QWidget * parent,
   maxDictionaryRefsInContextMenu( maxDictionaryRefsInContextMenu_ )
 {
 
-auto iconWidth = this->size().width();
-auto iconHeight = this->size().height();
+  auto iconWidth  = this->size().width();
+  auto iconHeight = this->size().height();
 
-normalIconSize = { std::max(iconWidth, iconHeight), std::max(iconWidth, iconHeight) };
+  normalIconSize = { std::max( iconWidth, iconHeight ), std::max( iconWidth, iconHeight ) };
 
 
   setObjectName( "dictionaryBar" );

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -76,7 +76,6 @@ void DictionaryBar::setDictionaries( vector< sptr< Dictionary::Class > > const &
 }
 
 
-
 void DictionaryBar::contextMenuEvent( QContextMenuEvent * event )
 {
   showContextMenu( event );

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -72,15 +72,10 @@ void DictionaryBar::setDictionaries( vector< sptr< Dictionary::Class > > const &
     dictActions.append( action );
   }
 
-  setDictionaryIconSize( 200 );
-
   setUpdatesEnabled( true );
 }
 
-void DictionaryBar::setDictionaryIconSize( int extent )
-{
-  setIconSize( QSize( extent, extent ) );
-}
+
 
 void DictionaryBar::contextMenuEvent( QContextMenuEvent * event )
 {

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -75,11 +75,16 @@ void DictionaryBar::setDictionaries( vector< sptr< Dictionary::Class > > const &
   setUpdatesEnabled( true );
 }
 
+void DictionaryBar::setDictionaryIconSize( int extent )
+{
+  setIconSize( QSize( extent, extent ) );
+}
 
 void DictionaryBar::contextMenuEvent( QContextMenuEvent * event )
 {
   showContextMenu( event );
 }
+
 
 void DictionaryBar::showContextMenu( QContextMenuEvent * event, bool extended )
 {

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -20,8 +20,11 @@ DictionaryBar::DictionaryBar( QWidget * parent,
   maxDictionaryRefsInContextMenu( maxDictionaryRefsInContextMenu_ )
 {
 
-  auto iconHeight = this->size().height(); // At the time of initialization, this equals `QStyle::PM_ToolBarIconSize`
-  normalIconSize  = { iconHeight, iconHeight };
+auto iconWidth = this->size().width();
+auto iconHeight = this->size().height();
+
+normalIconSize = { std::max(iconWidth, iconHeight), std::max(iconWidth, iconHeight) };
+
 
   setObjectName( "dictionaryBar" );
 

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -4,6 +4,7 @@
 #include <QMenu>
 #include <QContextMenuEvent>
 #include <QProcess>
+#include <QStyle>
 
 
 using std::vector;
@@ -18,6 +19,9 @@ DictionaryBar::DictionaryBar( QWidget * parent,
   editDictionaryCommand( _editDictionaryCommand ),
   maxDictionaryRefsInContextMenu( maxDictionaryRefsInContextMenu_ )
 {
+
+  normalIconSize = this->size();
+
   setObjectName( "dictionaryBar" );
 
   maxDictionaryRefsAction =
@@ -75,9 +79,20 @@ void DictionaryBar::setDictionaries( vector< sptr< Dictionary::Class > > const &
   setUpdatesEnabled( true );
 }
 
-void DictionaryBar::setDictionaryIconSize( int extent )
+void DictionaryBar::updateDictionaryIconSize( iconSize size )
 {
-  setIconSize( QSize( extent, extent ) );
+  switch ( size ) {
+    case iconSize::small: {
+      auto smallSize = QApplication::style()->pixelMetric( QStyle::PM_SmallIconSize );
+      setIconSize( { smallSize, smallSize } );
+      break;
+    }
+
+    case iconSize::normal: {
+      setIconSize( normalIconSize );
+      break;
+    }
+  }
 }
 
 void DictionaryBar::contextMenuEvent( QContextMenuEvent * event )

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -79,16 +79,16 @@ void DictionaryBar::setDictionaries( vector< sptr< Dictionary::Class > > const &
   setUpdatesEnabled( true );
 }
 
-void DictionaryBar::updateDictionaryIconSize( iconSize size )
+void DictionaryBar::updateDictionaryIconSize( IconSize size )
 {
   switch ( size ) {
-    case iconSize::small: {
+    case IconSize::Small: {
       auto smallSize = QApplication::style()->pixelMetric( QStyle::PM_SmallIconSize );
       setIconSize( { smallSize, smallSize } );
       break;
     }
 
-    case iconSize::normal: {
+    case IconSize::Normal: {
       setIconSize( normalIconSize );
       break;
     }

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -20,7 +20,8 @@ DictionaryBar::DictionaryBar( QWidget * parent,
   maxDictionaryRefsInContextMenu( maxDictionaryRefsInContextMenu_ )
 {
 
-  normalIconSize = this->size(); // At the time of initialization, this equals `QStyle::PM_ToolBarIconSize`
+  auto iconHeight = this->size().height(); // At the time of initialization, this equals `QStyle::PM_ToolBarIconSize`
+  normalIconSize  = { iconHeight, iconHeight };
 
   setObjectName( "dictionaryBar" );
 

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -72,7 +72,7 @@ void DictionaryBar::setDictionaries( vector< sptr< Dictionary::Class > > const &
     dictActions.append( action );
   }
 
-  setDictionaryIconSize( 21 );
+  setDictionaryIconSize( 200 );
 
   setUpdatesEnabled( true );
 }

--- a/src/ui/dictionarybar.hh
+++ b/src/ui/dictionarybar.hh
@@ -41,7 +41,7 @@ public:
     // TODO: implement something to have an Large option
   };
 
-  void updateDictionaryIconSize( IconSize size );
+  void setDictionaryIconSize( IconSize size );
 
 signals:
 

--- a/src/ui/dictionarybar.hh
+++ b/src/ui/dictionarybar.hh
@@ -34,7 +34,15 @@ public:
   {
     return mutedDictionaries;
   }
-  void setDictionaryIconSize( int extent );
+
+  enum class iconSize
+  {
+    small,
+    normal,
+    // large TODO: implement this.
+  };
+
+  void updateDictionaryIconSize( iconSize size );
 
 signals:
 
@@ -68,6 +76,8 @@ private:
   /// All the actions we have added to the toolbar
   QList< QAction * > dictActions;
   QAction * maxDictionaryRefsAction;
+
+  QSize normalIconSize; // cache icon size set by stylesheet provided by user
 
 protected:
 

--- a/src/ui/dictionarybar.hh
+++ b/src/ui/dictionarybar.hh
@@ -35,14 +35,13 @@ public:
     return mutedDictionaries;
   }
 
-  enum class iconSize
-  {
-    small,
-    normal,
-    // large TODO: implement this.
+  enum class IconSize {
+    Small,
+    Normal,
+    // TODO: implement something to have an Large option
   };
 
-  void updateDictionaryIconSize( iconSize size );
+  void updateDictionaryIconSize( IconSize size );
 
 signals:
 

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1656,7 +1656,7 @@ void MainWindow::updateDictionaryBar()
     dictionaryBar.setDictionaries( grp->dictionaries );
 
     dictionaryBar.updateDictionaryIconSize(
-      useSmallIconsInToolbarsAction.isChecked() ? DictionaryBar::iconSize::small : DictionaryBar::iconSize::normal );
+      useSmallIconsInToolbarsAction.isChecked() ? DictionaryBar::IconSize::Small : DictionaryBar::IconSize::Normal );
   }
 }
 

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1655,8 +1655,8 @@ void MainWindow::updateDictionaryBar()
 
     dictionaryBar.setDictionaries( grp->dictionaries );
 
-    dictionaryBar.updateDictionaryIconSize(
-      useSmallIconsInToolbarsAction.isChecked() ? DictionaryBar::IconSize::Small : DictionaryBar::IconSize::Normal );
+    dictionaryBar.setDictionaryIconSize( useSmallIconsInToolbarsAction.isChecked() ? DictionaryBar::IconSize::Small :
+                                                                                     DictionaryBar::IconSize::Normal );
   }
 }
 

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1655,11 +1655,8 @@ void MainWindow::updateDictionaryBar()
 
     dictionaryBar.setDictionaries( grp->dictionaries );
 
-    int extent = useSmallIconsInToolbarsAction.isChecked() ?
-      QApplication::style()->pixelMetric( QStyle::PM_SmallIconSize ) :
-      QApplication::style()->pixelMetric( QStyle::PM_ToolBarIconSize );
-
-    dictionaryBar.setDictionaryIconSize( extent );
+    dictionaryBar.updateDictionaryIconSize(
+      useSmallIconsInToolbarsAction.isChecked() ? DictionaryBar::iconSize::small : DictionaryBar::iconSize::normal );
   }
 }
 

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -1110,8 +1110,8 @@ void ScanPopup::on_goForwardButton_clicked() const
 
 void ScanPopup::setDictionaryIconSize()
 {
-  dictionaryBar.updateDictionaryIconSize( cfg.usingSmallIconsInToolbars ? DictionaryBar::IconSize::Small :
-                                                                          DictionaryBar::IconSize::Normal );
+  dictionaryBar.setDictionaryIconSize( cfg.usingSmallIconsInToolbars ? DictionaryBar::IconSize::Small :
+                                                                       DictionaryBar::IconSize::Normal );
 }
 
 void ScanPopup::setGroupByName( QString const & name ) const

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -1110,9 +1110,8 @@ void ScanPopup::on_goForwardButton_clicked() const
 
 void ScanPopup::setDictionaryIconSize()
 {
-  int extent = cfg.usingSmallIconsInToolbars ? QApplication::style()->pixelMetric( QStyle::PM_SmallIconSize ) :
-                                               QApplication::style()->pixelMetric( QStyle::PM_ToolBarIconSize );
-  dictionaryBar.setDictionaryIconSize( extent );
+  dictionaryBar.updateDictionaryIconSize( cfg.usingSmallIconsInToolbars ? DictionaryBar::iconSize::small :
+                                                                          DictionaryBar::iconSize::normal );
 }
 
 void ScanPopup::setGroupByName( QString const & name ) const

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -1110,8 +1110,8 @@ void ScanPopup::on_goForwardButton_clicked() const
 
 void ScanPopup::setDictionaryIconSize()
 {
-  dictionaryBar.updateDictionaryIconSize( cfg.usingSmallIconsInToolbars ? DictionaryBar::iconSize::small :
-                                                                          DictionaryBar::iconSize::normal );
+  dictionaryBar.updateDictionaryIconSize( cfg.usingSmallIconsInToolbars ? DictionaryBar::IconSize::Small :
+                                                                          DictionaryBar::IconSize::Normal );
 }
 
 void ScanPopup::setGroupByName( QString const & name ) const


### PR DESCRIPTION
some of the code added to prevent crashes had a bad side effect, causing the icons to get a bad quality.
two line of codes in two different files were causing that downscaling, the first line was removed, the second had its value changed to a higher value, both conditions were tested and the result is pretty good:

![2024-09-08_23-06](https://github.com/user-attachments/assets/1e167b33-7a77-4817-9bb0-2076c1745ba1)
