### PR TITLE
fix: consider devicePixelRatio when scaling icons

### DIFF
--- a/src/dict/dictionary.cc
+++ b/src/dict/dictionary.cc
@@ -6,18 +6,15 @@
 #include <cstdio>
 #include "dictionary.hh"
 
-#include <QCryptographicHash>
-
 // For needToRebuildIndex(), read below
 #include <QFileInfo>
 #include <QDateTime>
 
 #include "config.hh"
 #include <QDir>
-#include <QFileInfo>
 #include <QCryptographicHash>
-#include <QDateTime>
 #include <QImage>
+#include <QPixmap>
 #include <QPainter>
 #include <QRegularExpression>
 #include "utils.hh"
@@ -238,6 +235,11 @@ void Class::loadIcon() noexcept
   dictionaryIconLoaded = true;
 }
 
+int Class::getOptimalIconSize()
+{
+  return 64 * qGuiApp->devicePixelRatio();
+}
+
 bool Class::loadIconFromFile( QString const & _filename, bool isFullName )
 {
   QFileInfo info;
@@ -266,19 +268,14 @@ bool Class::loadIconFromFile( QString const & _filename, bool isFullName )
   }
 
   if ( info.isFile() ) {
-    QImage img( fileName );
+    auto iconSize = getOptimalIconSize();
+    QPixmap img( fileName );
 
     if ( !img.isNull() ) {
       // Load successful
 
-
-      // Apply the color key
-#if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
-      img.setAlphaChannel( img.createMaskFromColor( QColor( 192, 192, 192 ).rgb(), Qt::MaskOutColor ) );
-#endif
-
-      auto result    = img.scaled( { iconSize, iconSize }, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation );
-      dictionaryIcon = QIcon( QPixmap::fromImage( result ) );
+      auto result = img.scaled( { iconSize, iconSize }, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation );
+      dictionaryIcon = QIcon( result );
 
       return !dictionaryIcon.isNull();
     }
@@ -293,7 +290,9 @@ bool Class::loadIconFromText( QString iconUrl, QString const & text )
   QImage img( iconUrl );
 
   if ( !img.isNull() ) {
-    QImage result = img.scaled( { iconSize, iconSize }, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation );
+    auto iconSize = getOptimalIconSize();
+
+    QImage result = img.scaled( { iconSize, iconSize}, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation );
 
     QPainter painter( &result );
     painter.setRenderHints( QPainter::Antialiasing | QPainter::TextAntialiasing );

--- a/src/dict/dictionary.cc
+++ b/src/dict/dictionary.cc
@@ -274,7 +274,7 @@ bool Class::loadIconFromFile( QString const & _filename, bool isFullName )
     if ( !img.isNull() ) {
       // Load successful
 
-      auto result = img.scaled( { iconSize, iconSize }, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation );
+      auto result    = img.scaled( { iconSize, iconSize }, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation );
       dictionaryIcon = QIcon( result );
 
       return !dictionaryIcon.isNull();
@@ -292,7 +292,7 @@ bool Class::loadIconFromText( QString iconUrl, QString const & text )
   if ( !img.isNull() ) {
     auto iconSize = getOptimalIconSize();
 
-    QImage result = img.scaled( { iconSize, iconSize}, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation );
+    QImage result = img.scaled( { iconSize, iconSize }, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation );
 
     QPainter painter( &result );
     painter.setRenderHints( QPainter::Antialiasing | QPainter::TextAntialiasing );

--- a/src/dict/dictionary.hh
+++ b/src/dict/dictionary.hh
@@ -12,6 +12,7 @@
 #include <QObject>
 #include <QString>
 #include <QWaitCondition>
+#include <QGuiApplication>
 
 #include "config.hh"
 #include "ex.hh"
@@ -320,7 +321,7 @@ protected:
   // By default set icon to empty
   virtual void loadIcon() noexcept;
 
-  const int iconSize = 64;
+  static int getOptimalIconSize();
 
   // Load icon from filename directly if isFullName == true
   // else treat filename as name without extension

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -19,12 +19,7 @@ DictionaryBar::DictionaryBar( QWidget * parent,
   editDictionaryCommand( _editDictionaryCommand ),
   maxDictionaryRefsInContextMenu( maxDictionaryRefsInContextMenu_ )
 {
-
-  auto iconWidth  = this->size().width();
-  auto iconHeight = this->size().height();
-
-  normalIconSize = { std::max( iconWidth, iconHeight ), std::max( iconWidth, iconHeight ) };
-
+  normalIconSize = { this->iconSize().height(), this->iconSize().height() };
 
   setObjectName( "dictionaryBar" );
 


### PR DESCRIPTION
@KonstantinDjairo I think this will fix the problem now.

For high density screens, more pixels are needed for the same logical size.

amend https://github.com/xiaoyifang/goldendict-ng/pull/1750