### PR TITLE
fix: ensure icu4c are copied to app bundle on macOS

### DIFF
--- a/cmake/Deps_Unix.cmake
+++ b/cmake/Deps_Unix.cmake
@@ -83,6 +83,12 @@ endif ()
 if (WITH_ZIM)
     pkg_check_modules(ZIM REQUIRED IMPORTED_TARGET libzim)
     target_link_libraries(${GOLDENDICT} PRIVATE PkgConfig::ZIM)
+    if (APPLE)
+        # For some reason, icu4c as transitive dependency of libzim may not be copied into app bundle,
+        # so we directly depends on it to help macdeployqt or whatever
+        pkg_check_modules(BREW_ICU_FOR_LIBZIM_FORCE_LINK REQUIRED IMPORTED_TARGET icu-i18n icu-uc)
+        target_link_libraries(${GOLDENDICT} PUBLIC PkgConfig::BREW_ICU_FOR_LIBZIM_FORCE_LINK)
+    endif ()
 endif ()
 
 if (USE_SYSTEM_FMT)


### PR DESCRIPTION
I did notice that the macOS installers are smaller since a few days ago[^1]. I didn't know why, and now we know 😅.

The `libicudata.74.dylib` is missing, but thankfully the other two parts, `libicui18n.74.dylib` and `libicuuc.74.dylib`, does present in the app bundle.

This means that the macdeployqt and other underlying things are working, but just don't consider libicudata as dependency.

So, let's just depends on ICU explicitly to help them.

Tested with https://github.com/shenlebantongying/goldendict-ng/releases/tag/v24.05.13-alpha.dc45837f

related https://github.com/xiaoyifang/goldendict-ng/issues/1761

[^1]: The problem starts from -> https://github.com/xiaoyifang/goldendict-ng/releases/tag/v24.05.13-alpha.22b1c043 (Coincidently, I made https://github.com/xiaoyifang/goldendict-ng/pull/1745, but it is not the reason.