### PR TITLE
doc: clarify that ninja is optional and add other potential useful flags for CMake build (#1768)

### DIFF
--- a/website/docs/howto/build_from_source.md
+++ b/website/docs/howto/build_from_source.md
@@ -41,24 +41,15 @@ Basically, you need those commands:
 ```shell
 cd goldendict-ng && mkdir build_dir
 # config step
-cmake -S . -B build_dir \
-      --install-prefix=/usr/local/ \
-      -DCMAKE_BUILD_TYPE=Release
-# actual build
-cmake --build build_dir --parallel 7
+cmake -S . -B build_dir
+      -G "Ninja"/"Unix Makefiles"/"Xcode"...  (Optional)
+      -install-prefix=/usr/local/             (Optional)
+      -DCMAKE_BUILD_TYPE=Release              (Optional)
 
-cmake --install ./build_dir/
-```
-
-With *Ninja* (optional)
-
-```shell
-cd goldendict-ng && mkdir build_dir
-# config step
-cmake -S . -B build_dir -G Ninja
 # actual build
 cmake --build build_dir
-
+      --parallel 7  (Optional if Ninja was chosen)
+ 
 cmake --install ./build_dir/
 ```
 

--- a/website/docs/howto/build_from_source.md
+++ b/website/docs/howto/build_from_source.md
@@ -41,6 +41,20 @@ Basically, you need those commands:
 ```shell
 cd goldendict-ng && mkdir build_dir
 # config step
+cmake -S . -B build_dir \
+      --install-prefix=/usr/local/ \
+      -DCMAKE_BUILD_TYPE=Release
+# actual build
+cmake --build build_dir --parallel 7
+
+cmake --install ./build_dir/
+```
+
+With *Ninja* (optional)
+
+```shell
+cd goldendict-ng && mkdir build_dir
+# config step
 cmake -S . -B build_dir -G Ninja
 # actual build
 cmake --build build_dir


### PR DESCRIPTION
it's important for the user to have both options of build, and the first one being the simplest and with less dependencies