### PR TITLE
dev: prepare a new version

### DIFF
--- a/.github/workflows/release-AutoTag.yml
+++ b/.github/workflows/release-AutoTag.yml
@@ -22,8 +22,8 @@ jobs:
     runs-on: ubuntu-latest
       
     env:
-      version: 24.05.13
-      version-suffix: ${{ !contains(github.ref_name,'master') && 'alpha' || 'NextNameHere' }}
+      version: 24.09.0
+      version-suffix: ${{ !contains(github.ref_name,'master') && 'alpha' || 'Release' }}
       prerelease: ${{ !contains(github.ref_name,'master') }}
 
     steps:

--- a/.github/workflows/release-macos-homebrew.yml
+++ b/.github/workflows/release-macos-homebrew.yml
@@ -27,8 +27,8 @@ jobs:
         qt_arch: [clang_64]
     env:
       targetName: GoldenDict
-      version: 24.05.13
-      version-suffix: ${{ !contains(github.ref_name,'master') && 'alpha' || 'NextNameHere' }}
+      version: 24.09.0
+      version-suffix: ${{ !contains(github.ref_name,'master') && 'alpha' || 'Release' }}
       prerelease: ${{ !contains(github.ref_name,'master') }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-windows-vcpkg-cmake.yml
+++ b/.github/workflows/release-windows-vcpkg-cmake.yml
@@ -24,8 +24,8 @@ jobs:
         qt_ver: [ 6.7.2, 6.6.3 ]
         qt_arch: [win64_msvc2019_64]
     env:
-      version: 24.05.13
-      versionSuffix: ${{ !contains(github.ref_name,'master') && 'alpha' || 'NextNameHere' }}
+      version: 24.09.0
+      versionSuffix: ${{ !contains(github.ref_name,'master') && 'alpha' || 'Release' }}
       prerelease: ${{ !contains(github.ref_name,'master') }}
     steps:
       - name: Install Qt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ endif ()
 include(FeatureSummary)
 
 project(goldendict-ng
-        VERSION 24.05.13
+        VERSION 24.09.0
         LANGUAGES CXX C)
 
 set(GOLDENDICT "goldendict") # binary/executable name


### PR DESCRIPTION
As we previously discussed, now we are versioning like Ubuntu. https://github.com/xiaoyifang/goldendict-ng/pull/1543

Also, I think we should stop using obnoxious codename suffix, lets it be a stable suffix “Release”.

In case you want another code name, we can just change the title. I don't think we have to cost time to automate it, since release isn't often, manually edit it is fine.

<img width="400"  src="https://github.com/user-attachments/assets/94af8bcc-7cd6-412b-b34b-91e298474f18">

close https://github.com/xiaoyifang/goldendict-ng/issues/1744
