### PR TITLE
clean: mark all `Idxheader` packed explicitly

### DIFF
--- a/src/dict/aard.cc
+++ b/src/dict/aard.cc
@@ -75,11 +75,15 @@ struct IndexElement
   quint32 wordOffset;
   quint32 articleOffset;
 };
+static_assert( alignof( IndexElement ) == 1 );
+
 struct IndexElement64
 {
   quint32 wordOffset;
   quint64 articleOffset;
 };
+static_assert( alignof( IndexElement64 ) == 1 );
+
 
 enum {
   Signature            = 0x58524141, // AARX on little-endian, XRAA on big-endian
@@ -99,7 +103,6 @@ struct IdxHeader
   quint32 langTo;   // Target language
 };
 static_assert( alignof( IdxHeader ) == 1 );
-
 #pragma pack( pop )
 
 bool indexIsOldOrBad( string const & indexFile )

--- a/src/dict/aard.cc
+++ b/src/dict/aard.cc
@@ -67,31 +67,19 @@ struct AAR_header
   char indexItemFormat[ 4 ];
   char keyLengthFormat[ 2 ];
   char articleLengthFormat[ 2 ];
-}
-#ifndef _MSC_VER
-__attribute__( ( packed ) )
-#endif
-;
+};
+static_assert( alignof( AAR_header ) == 1 );
 
 struct IndexElement
 {
   quint32 wordOffset;
   quint32 articleOffset;
-}
-#ifndef _MSC_VER
-__attribute__( ( packed ) )
-#endif
-;
-
+};
 struct IndexElement64
 {
   quint32 wordOffset;
   quint64 articleOffset;
-}
-#ifndef _MSC_VER
-__attribute__( ( packed ) )
-#endif
-;
+};
 
 enum {
   Signature            = 0x58524141, // AARX on little-endian, XRAA on big-endian
@@ -109,11 +97,8 @@ struct IdxHeader
   quint32 articleCount;
   quint32 langFrom; // Source language
   quint32 langTo;   // Target language
-}
-#ifndef _MSC_VER
-__attribute__( ( packed ) )
-#endif
-;
+};
+static_assert( alignof( IdxHeader ) == 1 );
 
 #pragma pack( pop )
 

--- a/src/dict/bgl.cc
+++ b/src/dict/bgl.cc
@@ -53,6 +53,8 @@ enum {
   CurrentFormatVersion = 19 + BtreeIndexing::FormatVersion
 };
 
+#pragma pack( push, 1 )
+
 struct IdxHeader
 {
   uint32_t signature;      // First comes the signature, BGLX
@@ -77,11 +79,9 @@ struct IdxHeader
   uint32_t iconSize;           // Size of the icon in the chunks' storage, 0 = no icon
   uint32_t descriptionAddress; // Address of the dictionary description in the chunks' storage
   uint32_t descriptionSize;    // Size of the description in the chunks' storage, 0 = no description
-}
-#ifndef _MSC_VER
-__attribute__( ( packed ) )
-#endif
-;
+};
+static_assert( alignof( IdxHeader ) == 1 );
+#pragma pack( pop )
 
 bool indexIsOldOrBad( string const & indexFile )
 {

--- a/src/dict/dictdfiles.cc
+++ b/src/dict/dictdfiles.cc
@@ -55,6 +55,8 @@ enum {
   CurrentFormatVersion = 5 + BtreeIndexing::FormatVersion + Folding::Version
 };
 
+#pragma pack( push, 1 )
+
 struct IdxHeader
 {
   uint32_t signature;             // First comes the signature, DCDX
@@ -65,11 +67,10 @@ struct IdxHeader
   uint32_t indexRootOffset;
   uint32_t langFrom; // Source language
   uint32_t langTo;   // Target language
-}
-#ifndef _MSC_VER
-__attribute__( ( packed ) )
-#endif
-;
+};
+static_assert( alignof( IdxHeader ) == 1 );
+#pragma pack( pop )
+
 
 bool indexIsOldOrBad( string const & indexFile )
 {

--- a/src/dict/dsl.cc
+++ b/src/dict/dsl.cc
@@ -86,6 +86,8 @@ enum {
   CurrentFtsIndexVersion   = 7
 };
 
+#pragma pack( push, 1 )
+
 struct IdxHeader
 {
   uint32_t signature;             // First comes the signature, DSLX
@@ -93,7 +95,7 @@ struct IdxHeader
   uint32_t zipSupportVersion;     // Zip support version -- narrows down reindexing
                                   // when it changes only for dictionaries with the
                                   // zip files
-  int dslEncoding;                // Which encoding is used for the file indexed
+  uint32_t dslEncoding;                // Which encoding is used for the file indexed
   uint32_t chunksOffset;          // The offset to chunks' storage
   uint32_t hasAbrv;               // Non-zero means file has abrvs at abrvAddress
   uint32_t abrvAddress;           // Address of abrv map in the chunked storage
@@ -109,11 +111,10 @@ struct IdxHeader
   uint32_t zipIndexBtreeMaxElements; // Two fields from IndexInfo of the zip
                                      // resource index.
   uint32_t zipIndexRootOffset;
-}
-#ifndef _MSC_VER
-__attribute__( ( packed ) )
-#endif
-;
+};
+static_assert( alignof( IdxHeader ) == 1 );
+#pragma pop( pop )
+
 
 struct InsidedCard
 {

--- a/src/dict/dsl.cc
+++ b/src/dict/dsl.cc
@@ -95,7 +95,7 @@ struct IdxHeader
   uint32_t zipSupportVersion;     // Zip support version -- narrows down reindexing
                                   // when it changes only for dictionaries with the
                                   // zip files
-  uint32_t dslEncoding;                // Which encoding is used for the file indexed
+  uint32_t dslEncoding;           // Which encoding is used for the file indexed
   uint32_t chunksOffset;          // The offset to chunks' storage
   uint32_t hasAbrv;               // Non-zero means file has abrvs at abrvAddress
   uint32_t abrvAddress;           // Address of abrv map in the chunked storage
@@ -113,7 +113,7 @@ struct IdxHeader
   uint32_t zipIndexRootOffset;
 };
 static_assert( alignof( IdxHeader ) == 1 );
-#pragma pop( pop )
+#pragma pack( pop )
 
 
 struct InsidedCard

--- a/src/dict/epwing.cc
+++ b/src/dict/epwing.cc
@@ -62,7 +62,7 @@ struct IdxHeader
   quint32 langTo;   // Target language
 };
 static_assert( alignof( IdxHeader ) == 1 );
-#pragma pack( pop )
+  #pragma pack( pop )
 
 bool indexIsOldOrBad( string const & indexFile )
 {

--- a/src/dict/epwing.cc
+++ b/src/dict/epwing.cc
@@ -60,7 +60,7 @@ struct IdxHeader
   quint32 nameSize;
   quint32 langFrom; // Source language
   quint32 langTo;   // Target language
-}
+};
 static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
 

--- a/src/dict/epwing.cc
+++ b/src/dict/epwing.cc
@@ -61,11 +61,7 @@ struct IdxHeader
   quint32 langFrom; // Source language
   quint32 langTo;   // Target language
 }
-#ifndef _MSC_VER
-__attribute__( ( packed ) )
-#endif
-;
-
+static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
 
 bool indexIsOldOrBad( string const & indexFile )

--- a/src/dict/gls.cc
+++ b/src/dict/gls.cc
@@ -304,6 +304,8 @@ enum {
   CurrentFtsIndexVersion   = 1
 };
 
+#pragma pack( push, 1 )
+
 struct IdxHeader
 {
   uint32_t signature;             // First comes the signature, GLSX
@@ -311,7 +313,7 @@ struct IdxHeader
   uint32_t zipSupportVersion;     // Zip support version -- narrows down reindexing
                                   // when it changes only for dictionaries with the
                                   // zip files
-  int glsEncoding;                // Which encoding is used for the file indexed
+  uint32_t glsEncoding;                // Which encoding is used for the file indexed
   uint32_t chunksOffset;          // The offset to chunks' storage
   uint32_t indexBtreeMaxElements; // Two fields from IndexInfo
   uint32_t indexRootOffset;
@@ -324,11 +326,9 @@ struct IdxHeader
   uint32_t zipIndexBtreeMaxElements; // Two fields from IndexInfo of the zip
                                      // resource index.
   uint32_t zipIndexRootOffset;
-}
-#ifndef _MSC_VER
-__attribute__( ( packed ) )
-#endif
-;
+};
+static_assert( alignof( IdxHeader ) == 1 );
+#pragma pack( pop )
 
 bool indexIsOldOrBad( string const & indexFile, bool hasZipFile )
 {

--- a/src/dict/gls.cc
+++ b/src/dict/gls.cc
@@ -313,7 +313,7 @@ struct IdxHeader
   uint32_t zipSupportVersion;     // Zip support version -- narrows down reindexing
                                   // when it changes only for dictionaries with the
                                   // zip files
-  uint32_t glsEncoding;                // Which encoding is used for the file indexed
+  uint32_t glsEncoding;           // Which encoding is used for the file indexed
   uint32_t chunksOffset;          // The offset to chunks' storage
   uint32_t indexBtreeMaxElements; // Two fields from IndexInfo
   uint32_t indexRootOffset;

--- a/src/dict/lsa.cc
+++ b/src/dict/lsa.cc
@@ -49,6 +49,8 @@ enum {
   CurrentFormatVersion = 5
 };
 
+#pragma pack( push, 1 )
+
 struct IdxHeader
 {
   uint32_t signature;             // First comes the signature, BGLX
@@ -57,11 +59,9 @@ struct IdxHeader
   uint32_t vorbisOffset;          // Offset of the vorbis file which contains all snds
   uint32_t indexBtreeMaxElements; // Two fields from IndexInfo
   uint32_t indexRootOffset;
-}
-#ifndef _MSC_VER
-__attribute__( ( packed ) )
-#endif
-;
+};
+static_assert( alignof( IdxHeader ) == 1 );
+#pragma pack( pop )
 
 bool indexIsOldOrBad( string const & indexFile )
 {

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -62,6 +62,8 @@ enum {
 
 DEF_EX( exCorruptDictionary, "dictionary file was tampered or corrupted", std::exception )
 
+#pragma pack( push, 1 )
+
 struct IdxHeader
 {
   uint32_t signature;     // First comes the signature, MDIC
@@ -92,11 +94,9 @@ struct IdxHeader
 
   uint32_t mddIndexInfosOffset; // address of IndexInfos for resource files (.mdd)
   uint32_t mddIndexInfosCount;  // count of IndexInfos for resource files
-}
-#ifndef _MSC_VER
-__attribute__( ( packed ) )
-#endif
-;
+};
+static_assert( alignof( IdxHeader ) == 1 );
+#pragma pack( pop )
 
 // A helper method to read resources from .mdd file
 class IndexedMdd: public BtreeIndexing::BtreeIndex

--- a/src/dict/sdict.cc
+++ b/src/dict/sdict.cc
@@ -68,22 +68,14 @@ struct DCT_header
   uint32_t shortIndexOffset;
   uint32_t fullIndexOffset;
   uint32_t articlesOffset;
-}
-#ifndef _MSC_VER
-__attribute__( ( packed ) )
-#endif
-;
+};
 
 struct IndexElement
 {
   uint16_t nextWord;
   uint16_t previousWord;
   uint32_t articleOffset;
-}
-#ifndef _MSC_VER
-__attribute__( ( packed ) )
-#endif
-;
+};
 
 enum {
   Signature            = 0x43494453, // SDIC on little-endian, CIDS on big-endian
@@ -102,12 +94,8 @@ struct IdxHeader
   uint32_t compressionType; // Data compression in file. 0 - no compression, 1 - zip, 2 - bzip2
   uint32_t langFrom;        // Source language
   uint32_t langTo;          // Target language
-}
-#ifndef _MSC_VER
-__attribute__( ( packed ) )
-#endif
-;
-
+};
+static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
 
 bool indexIsOldOrBad( string const & indexFile )

--- a/src/dict/sdict.cc
+++ b/src/dict/sdict.cc
@@ -69,6 +69,7 @@ struct DCT_header
   uint32_t fullIndexOffset;
   uint32_t articlesOffset;
 };
+static_assert( alignof( DCT_header ) == 1 );
 
 struct IndexElement
 {
@@ -76,6 +77,7 @@ struct IndexElement
   uint16_t previousWord;
   uint32_t articleOffset;
 };
+static_assert( alignof( IndexElement ) == 1 );
 
 enum {
   Signature            = 0x43494453, // SDIC on little-endian, CIDS on big-endian

--- a/src/dict/slob.cc
+++ b/src/dict/slob.cc
@@ -62,13 +62,13 @@ DEF_EX_STR( exNoCodecFound, "No text codec found", Dictionary::Ex )
 DEF_EX( exUserAbort, "User abort", Dictionary::Ex )
 DEF_EX( exNoResource, "No resource found", Dictionary::Ex )
 
-  #pragma pack( push, 1 )
 
 enum {
   Signature            = 0x58424C53, // SLBX on little-endian, XBLS on big-endian
   CurrentFormatVersion = 2 + BtreeIndexing::FormatVersion + Folding::Version
 };
 
+#pragma pack( push, 1 )
 struct IdxHeader
 {
   quint32 signature;             // First comes the signature, SLBX
@@ -81,13 +81,9 @@ struct IdxHeader
   quint32 articleCount;
   quint32 langFrom; // Source language
   quint32 langTo;   // Target language
-}
-  #ifndef _MSC_VER
-__attribute__( ( packed ) )
-  #endif
-;
-
-  #pragma pack( pop )
+};
+static_assert( alignof( IdxHeader ) == 1 );
+#pragma pack( pop )
 
 const char SLOB_MAGIC[ 8 ] = { 0x21, 0x2d, 0x31, 0x53, 0x4c, 0x4f, 0x42, 0x1f };
 

--- a/src/dict/sounddir.cc
+++ b/src/dict/sounddir.cc
@@ -36,6 +36,7 @@ enum {
   CurrentFormatVersion = 1 + BtreeIndexing::FormatVersion + Folding::Version
 };
 
+#pragma pack( push, 1 )
 struct IdxHeader
 {
   uint32_t signature;             // First comes the signature, SDRX
@@ -44,11 +45,9 @@ struct IdxHeader
   uint32_t chunksOffset;          // The offset to chunks' storage
   uint32_t indexBtreeMaxElements; // Two fields from IndexInfo
   uint32_t indexRootOffset;
-}
-#ifndef _MSC_VER
-__attribute__( ( packed ) )
-#endif
-;
+};
+static_assert( alignof( IdxHeader ) == 1 );
+#pragma pack( pop )
 
 bool indexIsOldOrBad( string const & indexFile )
 {

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -93,6 +93,7 @@ enum {
   CurrentFormatVersion = 9 + BtreeIndexing::FormatVersion + Folding::Version
 };
 
+#pragma pack( push, 1 )
 struct IdxHeader
 {
   uint32_t signature;             // First comes the signature, SIDX
@@ -110,10 +111,10 @@ struct IdxHeader
   uint32_t zipIndexBtreeMaxElements; // Two fields from IndexInfo of the zip
                                      // resource index.
   uint32_t zipIndexRootOffset;
-}
-#ifndef _MSC_VER
-__attribute__( ( packed ) )
-#endif
+};
+static_assert( alignof( IdxHeader ) == 1 );
+#pragma pack( pop )
+
 ;
 
 bool indexIsOldOrBad( string const & indexFile )

--- a/src/dict/xdxf.cc
+++ b/src/dict/xdxf.cc
@@ -94,6 +94,7 @@ enum ArticleFormat {
   Logical = 2
 };
 
+#pragma pack( push, 1 )
 struct IdxHeader
 {
   uint32_t signature;             // First comes the signature, XDXF
@@ -118,11 +119,9 @@ struct IdxHeader
                                      // resource index.
   uint32_t zipIndexRootOffset;
   uint32_t revisionNumber; // Format revision
-}
-#ifndef _MSC_VER
-__attribute__( ( packed ) )
-#endif
-;
+};
+static_assert( alignof( IdxHeader ) == 1 );
+#pragma pack( pop )
 
 bool indexIsOldOrBad( string const & indexFile )
 {

--- a/src/dict/zim.cc
+++ b/src/dict/zim.cc
@@ -66,13 +66,13 @@ DEF_EX( exUserAbort, "User abort", Dictionary::Ex )
 using ZimFile = zim::Archive;
 
 
-  #pragma pack( push, 1 )
 
 enum {
   Signature            = 0x584D495A, // ZIMX on little-endian, XMIZ on big-endian
   CurrentFormatVersion = 4 + BtreeIndexing::FormatVersion + Folding::Version
 };
 
+#pragma pack( push, 1 )
 struct IdxHeader
 {
   quint32 signature;             // First comes the signature, ZIMX
@@ -87,13 +87,9 @@ struct IdxHeader
   quint32 descriptionPtr;
   quint32 langFrom; // Source language
   quint32 langTo;   // Target language
-}
-  #ifndef _MSC_VER
-__attribute__( ( packed ) )
-  #endif
-;
-
-  #pragma pack( pop )
+};
+static_assert( alignof( IdxHeader ) == 1 );
+#pragma pack( pop )
 
 // Some supporting functions
 bool indexIsOldOrBad( string const & indexFile )

--- a/src/dict/zim.cc
+++ b/src/dict/zim.cc
@@ -66,13 +66,12 @@ DEF_EX( exUserAbort, "User abort", Dictionary::Ex )
 using ZimFile = zim::Archive;
 
 
-
 enum {
   Signature            = 0x584D495A, // ZIMX on little-endian, XMIZ on big-endian
   CurrentFormatVersion = 4 + BtreeIndexing::FormatVersion + Folding::Version
 };
 
-#pragma pack( push, 1 )
+  #pragma pack( push, 1 )
 struct IdxHeader
 {
   quint32 signature;             // First comes the signature, ZIMX
@@ -89,7 +88,7 @@ struct IdxHeader
   quint32 langTo;   // Target language
 };
 static_assert( alignof( IdxHeader ) == 1 );
-#pragma pack( pop )
+  #pragma pack( pop )
 
 // Some supporting functions
 bool indexIsOldOrBad( string const & indexFile )

--- a/src/dict/zipsounds.cc
+++ b/src/dict/zipsounds.cc
@@ -45,6 +45,7 @@ enum {
   CurrentFormatVersion = 6 + BtreeIndexing::FormatVersion
 };
 
+#pragma pack( push, 1 )
 struct IdxHeader
 {
   uint32_t signature;             // First comes the signature, ZIPS
@@ -53,11 +54,9 @@ struct IdxHeader
   uint32_t indexBtreeMaxElements; // Two fields from IndexInfo
   uint32_t indexRootOffset;
   uint32_t chunksOffset; // The offset to chunks' storage
-}
-#ifndef _MSC_VER
-__attribute__( ( packed ) )
-#endif
-;
+};
+static_assert( alignof( IdxHeader ) == 1 );
+#pragma pack( pop )
 
 bool indexIsOldOrBad( string const & indexFile )
 {


### PR DESCRIPTION
close https://github.com/xiaoyifang/goldendict-ng/issues/1576

This PR does absolutely nothing technically, because removing these packing compiler directives is OK 😅😅😅.

In both 32 & 64 bits machines, a `struct` with all 32bit fields will be already “packed” (This doesn't appear to be in the standard, but it is what all 3 major compilers do).

However, this PR makes code's purpose clear (Not really, because only after reading the code, one would know that GD is using this trick to read/write multiple fields at once) and reduce inconsistency (It is pretty weird to see the inconsistency as showed in https://github.com/xiaoyifang/goldendict-ng/issues/1576.).

---

This PR also removes gcc and clang's `__attribute__((packed))__` because they both of them supports `#pragma pack(push, 1) -> #pragma pack(pop)` since ages ago (In fact, clang has a warning about incomplete pair of push/pop).

I tested this code https://godbolt.org/z/YvWvsf9ad for compilers that we care (the one in Debian stable & Ubuntu 22.04 and some older ones). To ensure this certainly works, I added a harmless `static_assert` for every `idxHeader`.

---

This PR corrected 2 inconsistent `int` in `dsl.cc` and `gsl.cc`. This change is correct because based on this table the `int` type is 32bit anyway (https://en.cppreference.com/w/cpp/language/types#Properties).