### PR TITLE
fix: init icon size is not normal due to missing null check

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -1157,8 +1157,10 @@ Class load()
 
   c.showingDictBarNames = ( root.namedItem( "showingDictBarNames" ).toElement().text() == "1" );
 
-  c.usingToolbarsIconSize =
-    ( static_cast< ToolbarsIconSize >( root.namedItem( "usingToolbarsIconSize" ).toElement().text().toInt() ) );
+  QDomNode usingToolbarsIconSize = root.namedItem( "usingToolbarsIconSize" );
+  if ( !usingToolbarsIconSize.isNull() ) {
+    c.usingToolbarsIconSize = static_cast< ToolbarsIconSize >( usingToolbarsIconSize.toElement().text().toInt() );
+  }
 
   if ( !root.namedItem( "historyExportPath" ).isNull() )
     c.historyExportPath = root.namedItem( "historyExportPath" ).toElement().text();


### PR DESCRIPTION
fix https://github.com/xiaoyifang/goldendict-ng/pull/1789#discussion_r1780651552

