### PR TITLE
actions: bump `runs-on` to macos-13 because homebrew no longer supports macos-12

### DIFF
--- a/.github/workflows/PR-check-cmake.yml
+++ b/.github/workflows/PR-check-cmake.yml
@@ -45,7 +45,7 @@ jobs:
           cmake --build ./build_dir 
   job_macos_build_check:
     name: macos Build and analyze
-    runs-on: macos-12
+    runs-on: macos-13
     steps:             
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-macos-homebrew.yml
+++ b/.github/workflows/release-macos-homebrew.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12,macos-14]
+        os: [macos-13,macos-14]
         qt_ver: [ 6.7.3,6.6.3 ]
         qt_arch: [clang_64]
     env:


### PR DESCRIPTION
Probably needs to drop macos-12 support.

Homebrew stops supporting it.

Once the packages are updated ("old bottles are removed from homebrew's serve?"), older mac have to build from source.

This takes forever to finish:

https://github.com/xiaoyifang/goldendict-ng/actions/runs/11113891897/job/30879229991?pr=1792