### PR TITLE
clean: purge undocumented and useless `editDictionaryCommandLine` 

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -1171,9 +1171,6 @@ Class load()
   if ( !root.namedItem( "articleSavePath" ).isNull() )
     c.articleSavePath = root.namedItem( "articleSavePath" ).toElement().text();
 
-  if ( !root.namedItem( "editDictionaryCommandLine" ).isNull() )
-    c.editDictionaryCommandLine = root.namedItem( "editDictionaryCommandLine" ).toElement().text();
-
   if ( !root.namedItem( "maxHeadwordSize" ).isNull() ) {
     unsigned int value = root.namedItem( "maxHeadwordSize" ).toElement().text().toUInt();
     if ( value != 0 ) // 0 is invalid value for our purposes
@@ -2175,10 +2172,6 @@ void save( Class const & c )
       opt.appendChild( dd.createTextNode( c.articleSavePath ) );
       root.appendChild( opt );
     }
-
-    opt = dd.createElement( "editDictionaryCommandLine" );
-    opt.appendChild( dd.createTextNode( c.editDictionaryCommandLine ) );
-    root.appendChild( opt );
 
     opt = dd.createElement( "maxHeadwordSize" );
     opt.appendChild( dd.createTextNode( QString::number( c.maxHeadwordSize ) ) );

--- a/src/config.hh
+++ b/src/config.hh
@@ -884,9 +884,7 @@ struct Class
   unsigned int maxHeadwordsToExpand;
 
   HeadwordsDialog headwordsDialog;
-
-  QString editDictionaryCommandLine; // Command line to call external editor for dictionary
-
+  
   Class():
     lastMainGroupId( 0 ),
     lastPopupGroupId( 0 ),

--- a/src/config.hh
+++ b/src/config.hh
@@ -884,7 +884,7 @@ struct Class
   unsigned int maxHeadwordsToExpand;
 
   HeadwordsDialog headwordsDialog;
-  
+
   Class():
     lastMainGroupId( 0 ),
     lastPopupGroupId( 0 ),

--- a/src/ui/dictinfo.cc
+++ b/src/ui/dictinfo.cc
@@ -27,9 +27,6 @@ void DictInfo::showInfo( sptr< Dictionary::Class > dict )
   ui.dictionaryTranslatesTo->setText( Language::localizedStringForId( dict->getLangTo() ) );
 
   ui.openFolder->setVisible( dict->isLocalDictionary() );
-  ui.editDictionary->setVisible( dict->isLocalDictionary() && !dict->getMainFilename().isEmpty()
-                                 && !cfg.editDictionaryCommandLine.isEmpty() );
-  ui.editDictionary->setToolTip( tr( "Edit the dictionary via command:\n%1" ).arg( cfg.editDictionaryCommandLine ) );
 
   if ( dict->getWordCount() == 0 )
     ui.headwordsButton->setVisible( false );
@@ -61,11 +58,6 @@ void DictInfo::showInfo( sptr< Dictionary::Class > dict )
 void DictInfo::savePos( int )
 {
   cfg.dictInfoGeometry = saveGeometry();
-}
-
-void DictInfo::on_editDictionary_clicked()
-{
-  done( EDIT_DICTIONARY );
 }
 
 void DictInfo::on_openFolder_clicked()

--- a/src/ui/dictinfo.hh
+++ b/src/ui/dictinfo.hh
@@ -16,7 +16,6 @@ public:
     REJECTED,
     ACCEPTED,
     OPEN_FOLDER,
-    EDIT_DICTIONARY,
     SHOW_HEADWORDS
   };
 
@@ -28,7 +27,6 @@ private:
   Config::Class & cfg;
 private slots:
   void savePos( int );
-  void on_editDictionary_clicked();
   void on_openFolder_clicked();
   void on_OKButton_clicked();
   void on_headwordsButton_clicked();

--- a/src/ui/dictinfo.ui
+++ b/src/ui/dictinfo.ui
@@ -23,16 +23,6 @@
       <string/>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="4">
-       <widget class="QPushButton" name="editDictionary">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>Edit dictionary</string>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="3">
        <widget class="QLabel" name="dictionaryTranslatesTo">
         <property name="text">

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -135,7 +135,6 @@ void DictionaryBar::showContextMenu( QContextMenuEvent * event, bool extended )
           headwordsAction = menu.addAction( tr( "Dictionary headwords" ) );
 
         openDictFolderAction = menu.addAction( tr( "Open dictionary folder" ) );
-
       }
     }
   }

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -11,12 +11,10 @@ using std::vector;
 
 DictionaryBar::DictionaryBar( QWidget * parent,
                               Config::Events & events,
-                              QString const & _editDictionaryCommand,
                               unsigned short const & maxDictionaryRefsInContextMenu_ ):
   QToolBar( tr( "&Dictionary Bar" ), parent ),
   mutedDictionaries( nullptr ),
   configEvents( events ),
-  editDictionaryCommand( _editDictionaryCommand ),
   maxDictionaryRefsInContextMenu( maxDictionaryRefsInContextMenu_ )
 {
   normalIconSize = { this->iconSize().height(), this->iconSize().height() };
@@ -115,7 +113,6 @@ void DictionaryBar::showContextMenu( QContextMenuEvent * event, bool extended )
 
   const QAction * infoAction           = nullptr;
   const QAction * headwordsAction      = nullptr;
-  const QAction * editDictAction       = nullptr;
   const QAction * openDictFolderAction = nullptr;
   QString dictFilename;
 
@@ -139,12 +136,6 @@ void DictionaryBar::showContextMenu( QContextMenuEvent * event, bool extended )
 
         openDictFolderAction = menu.addAction( tr( "Open dictionary folder" ) );
 
-        if ( !editDictionaryCommand.isEmpty() ) {
-          if ( !pDict->getMainFilename().isEmpty() ) {
-            dictFilename   = pDict->getMainFilename();
-            editDictAction = menu.addAction( tr( "Edit dictionary" ) );
-          }
-        }
       }
     }
   }
@@ -199,13 +190,6 @@ void DictionaryBar::showContextMenu( QContextMenuEvent * event, bool extended )
     QString const id = dictAction->data().toString();
     emit openDictionaryFolder( id );
     return;
-  }
-
-  if ( result && result == editDictAction ) {
-    QString command( editDictionaryCommand );
-    command.replace( "%GDDICT%", QString( R"("%1")" ).arg( dictFilename ) );
-    if ( !QProcess::startDetached( command, QStringList() ) )
-      QApplication::beep();
   }
 
   if ( result && result == maxDictionaryRefsAction ) {

--- a/src/ui/dictionarybar.hh
+++ b/src/ui/dictionarybar.hh
@@ -18,9 +18,7 @@ class DictionaryBar: public QToolBar
 public:
 
   /// Constructs an empty dictionary bar
-  DictionaryBar( QWidget * parent,
-                 Config::Events &,
-                 unsigned short const & maxDictionaryRefsInContextMenu_ );
+  DictionaryBar( QWidget * parent, Config::Events &, unsigned short const & maxDictionaryRefsInContextMenu_ );
 
   /// Sets dictionaries to be displayed in the bar. Their statuses (enabled/
   /// disabled) are taken from the configuration data.

--- a/src/ui/dictionarybar.hh
+++ b/src/ui/dictionarybar.hh
@@ -20,7 +20,6 @@ public:
   /// Constructs an empty dictionary bar
   DictionaryBar( QWidget * parent,
                  Config::Events &,
-                 QString const & _editDictionaryCommand,
                  unsigned short const & maxDictionaryRefsInContextMenu_ );
 
   /// Sets dictionaries to be displayed in the bar. Their statuses (enabled/
@@ -68,7 +67,7 @@ private:
   Config::MutedDictionaries storedMutedSet;
 
   bool enterSoloMode = false;
-  QString editDictionaryCommand;
+
   // how many dictionaries should be shown in the context menu:
   unsigned short const & maxDictionaryRefsInContextMenu;
   std::vector< sptr< Dictionary::Class > > allDictionaries;

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -155,7 +155,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   addTab( this ),
   cfg( cfg_ ),
   history( History::Load(), cfg_.preferences.maxStringsInHistory, cfg_.maxHeadwordSize ),
-  dictionaryBar( this, configEvents, cfg.editDictionaryCommandLine, cfg.preferences.maxDictionaryRefsInContextMenu ),
+  dictionaryBar( this, configEvents, cfg.preferences.maxDictionaryRefsInContextMenu ),
   articleMaker( dictionaries, groupInstances, cfg.preferences ),
   articleNetMgr( this,
                  dictionaries,
@@ -4021,9 +4021,6 @@ void MainWindow::showDictionaryInfo( const QString & id )
       if ( result == DictInfo::OPEN_FOLDER ) {
         openDictionaryFolder( id );
       }
-      else if ( result == DictInfo::EDIT_DICTIONARY ) {
-        editDictionary( dictionaries[ x ].get() );
-      }
       else if ( result == DictInfo::SHOW_HEADWORDS ) {
         showDictionaryHeadwords( dictionaries[ x ].get() );
       }
@@ -4100,21 +4097,6 @@ void MainWindow::stopAudio()
   }
 }
 
-void MainWindow::editDictionary( Dictionary::Class * dict )
-{
-  QString dictFilename = dict->getMainFilename();
-  if ( !cfg.editDictionaryCommandLine.isEmpty() && !dictFilename.isEmpty() ) {
-    QString command( cfg.editDictionaryCommandLine );
-    command.replace( "%GDDICT%", "\"" + dictFilename + "\"" );
-    if ( command.contains( "%GDWORD%" ) ) {
-      QString headword = unescapeTabHeader( ui.tabWidget->tabText( ui.tabWidget->currentIndex() ) );
-      command.replace( "%GDWORD%", headword );
-    }
-    if ( !QProcess::startDetached( command, QStringList() ) )
-      QApplication::beep();
-  }
-}
-
 void MainWindow::openDictionaryFolder( const QString & id )
 {
   for ( unsigned x = 0; x < dictionaries.size(); x++ ) {
@@ -4161,12 +4143,6 @@ void MainWindow::foundDictsContextMenuRequested( const QPoint & pos )
 
       QAction * openDictFolderAction = menu.addAction( tr( "Open dictionary folder" ) );
 
-      QAction * editAction = nullptr;
-
-      QString dictFilename = pDict->getMainFilename();
-      if ( !cfg.editDictionaryCommandLine.isEmpty() && !dictFilename.isEmpty() )
-        editAction = menu.addAction( tr( "Edit dictionary" ) );
-
       QAction * result = menu.exec( ui.dictsList->mapToGlobal( pos ) );
 
       if ( result && result == infoAction ) {
@@ -4185,9 +4161,6 @@ void MainWindow::foundDictsContextMenuRequested( const QPoint & pos )
       }
       else if ( result && result == openDictFolderAction ) {
         openDictionaryFolder( id );
-      }
-      else if ( result && result == editAction ) {
-        editDictionary( pDict );
       }
     }
   }

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -290,8 +290,6 @@ private slots:
 
   void openDictionaryFolder( QString const & id );
 
-  void editDictionary( Dictionary::Class * dict );
-
   void showFTSIndexingName( QString const & name );
 
   void handleAddToFavoritesButton();

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -80,7 +80,7 @@ ScanPopup::ScanPopup( QWidget * parent,
   stopAudioAction( this ),
   openSearchAction( this ),
   wordFinder( this ),
-  dictionaryBar( this, configEvents, cfg.editDictionaryCommandLine, cfg.preferences.maxDictionaryRefsInContextMenu ),
+  dictionaryBar( this, configEvents, cfg.preferences.maxDictionaryRefsInContextMenu ),
   hideTimer( this )
 {
   ui.setupUi( this );


### PR DESCRIPTION
### close https://github.com/xiaoyifang/goldendict-ng/issues/1780

There are a few mentions on internet about `editDictionaryCommandLine`.

But what's the point? If a user wants to edit DSL/XDXF files directly, then just open it with an editor, there is little to no reason to open it via GD and waste time to discover this thing.

It is not fully implemented anyway (if it doesn't work, user cannot know why it doesn't work).

To enable it, user have to edit `config`'s `editDictionaryCommandLine` with `${editor name} %GDDICT%`. This is impossible to be discovered.

