### PR TITLE
fix: dictd's description display (00databaseinfo)

### DIFF
--- a/src/dict/dictdfiles.cc
+++ b/src/dict/dictdfiles.cc
@@ -426,8 +426,7 @@ QString const & DictdDictionary::getDescription()
   sptr< Dictionary::DataRequest > req = getArticle( U"00databaseinfo", vector< wstring >(), wstring(), false );
 
   if ( req->dataSize() > 0 ) {
-    dictionaryDescription = Html::unescape( QString::fromUtf8( req->getFullData().data(), req->getFullData().size() ),
-                                            Html::HtmlOption::Keep );
+    dictionaryDescription = QString::fromUtf8( req->getFullData().data(), req->getFullData().size() );
   }
   else {
     dictionaryDescription = "NONE";


### PR DESCRIPTION
Amend https://github.com/xiaoyifang/goldendict-ng/pull/398

After

<img width="400" src="https://github.com/user-attachments/assets/0130161f-e747-4fb8-b144-d1abd2e94c6f">

Before

<img width="400" src="https://github.com/user-attachments/assets/91bac868-062c-4d05-b18f-5fe3df239cc0">
