### PR TITLE
clean: minor deprecation fixes

### DIFF
--- a/src/dict/dictionary.cc
+++ b/src/dict/dictionary.cc
@@ -516,7 +516,8 @@ string makeDictionaryId( vector< string > const & dictionaryFiles ) noexcept
   QCryptographicHash hash( QCryptographicHash::Md5 );
 
   for ( const auto & i : sortedList ) {
-    hash.addData( i.c_str(), i.size() + 1 );
+    // Note: a null byte at the end is a must
+    hash.addData( { i.c_str(), static_cast< qsizetype >( i.size() + 1 ) } );
   }
 
   return hash.result().toHex().data();

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -1389,7 +1389,7 @@ void ArticleView::playSound()
         return link;})();         )";
 
   webview->page()->runJavaScript( variable, [ this ]( const QVariant & result ) {
-    if ( result.type() == QVariant::String ) {
+    if ( result.typeId() == qMetaTypeId< QString >() ) {
       QString soundScript = result.toString();
       if ( !soundScript.isEmpty() )
         openLink( QUrl::fromEncoded( soundScript.toUtf8() ), webview->url() );


### PR DESCRIPTION
Fix 2 deprecation notices as in https://github.com/xiaoyifang/goldendict-ng/actions/runs/11204695739/job/31143387827

* It appears that QVariant's type system got replaced by something more powerful https://www.qt.io/blog/whats-new-in-qmetatype-qvariant

* QByteArrayView, similar reasons for using std::string_view