### PR TITLE
fix: set scanPopup flags to what's is needed instead of Qt::Popup

### DIFF
--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -22,14 +22,13 @@
 #endif
 #include "base_type.hh"
 
-/// We use different window flags under Windows and X11 due to slight differences
-/// in their behavior on those platforms.
+
 static const Qt::WindowFlags defaultUnpinnedWindowFlags =
 
 #if defined( Q_OS_WIN )
   Qt::Tool | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint
 #else
-  Qt::Popup
+  Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint
 #endif
   ;
 


### PR DESCRIPTION
This fixes https://github.com/xiaoyifang/goldendict-ng/issues/1803 and also works for Linux.

The root issue is that the behavior of `Qt::Popup` is underspecified, complex and may evolve overtime.

---

Someone else did notice a similar issue on Linux, but whatever he concluded is :hankey:.

* https://github.com/goldendict/goldendict/commit/15dfdee49ff0400f22903c621562d89ca604f983
* https://github.com/goldendict/goldendict/issues/645