### PR TITLE
feat: macOS, check and request Accessibility permission for Cmd+C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,15 @@ include(FeatureSummary)
 project(goldendict-ng
         VERSION 24.11.0
         LANGUAGES CXX C)
+        
+if (APPLE)
+    enable_language(OBJCXX)
+    set(CMAKE_OBJCXX_STANDARD 17)
+endif ()
+
+set(CMAKE_C_STANDARD 17)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(GOLDENDICT "goldendict") # binary/executable name
 if (USE_ALTERNATIVE_NAME )
@@ -58,8 +67,6 @@ if (APPLE)
     set(GOLDENDICT "GoldenDict-ng")
 endif()
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 #### Qt
 


### PR DESCRIPTION
Related https://github.com/xiaoyifang/goldendict-ng/issues/325

Tell user what's wrong, and what to do :)

Auxiliary changes

* Document how Cmd+C+C is implemented.
* Build the `.mm` file as Objective-C++17.
  * Surprisingly, despite the file is named `.mm`, it doesn't use Obj-C feature, and it was getting compiled as C++ file (https://cmake.org/cmake/help/latest/release/3.16.html#languages)?
  * Anyway, I am going to turn it on to make life easier.

Demo:

https://github.com/user-attachments/assets/d794250e-30d5-47db-853f-7645a329f152

