### PR TITLE
feature: rename the [Enable Scanning] to a more accurate tooltip

### DIFF
--- a/locale/ar_SA.ts
+++ b/locale/ar_SA.ts
@@ -3051,17 +3051,17 @@ the application.</source>
       <translation>الخط الأحادي الفضاء</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>منبثقة الا&amp;ستكشاف</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>يحدّد إن كان وضع منبثقة الاستكشاف ممكّن افتراضيًّا أو لا. إن عُلِّم،
 سيبدأ البرنامج دائمًا ومنبثقة الاستكشاف نشطة.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>ابدأ و منبثقة الاستكشاف تعمل</translation>
     </message>
     <message>
@@ -3179,7 +3179,7 @@ in the pressed state when the word selection changes.</source>
       <translation>انطق تلقائيًّا الكلمات في النافذة الرئيسية</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>انطق تلقائيًّا الكلمات في منبثقة الاستكشاف</translation>
     </message>
     <message>
@@ -3708,7 +3708,7 @@ from Stardict, Babylon and GLS dictionaries</source>
       <translation>فرض ترجمة الكلمة في النافذة الرئيسية</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>قم بتبديل قائمة الفحص المنبثقة.</translation>
     </message>
     <message>

--- a/locale/ay_BO.ts
+++ b/locale/ay_BO.ts
@@ -3136,19 +3136,19 @@ Aka jakhu mayjacham jach&apos;a menus jithiqañataki.</translation>
       <translation>Monoespacio ukax Fuente ukawa</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Uñstir wintanampi ullaña</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Habilitar escaneo en una ventana emergente cuando inicia.
 
 Jisa uskum thaqhañataki jan walikitaki janiwa.
 Akasti marcado, thaqhawi ist&apos;araskaniwa.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Mä uñstiri wintananxa escaneo uk naktayaña, qalltkis ukja</translation>
     </message>
     <message>
@@ -3274,7 +3274,7 @@ Uñstir wintana uñachañatakixa salta ukan mä klik luram. </translation>
       <translation>Nayrir wintanan justupak arunak arst&apos;awi</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Uñstiri wintanan justupak arunak arst&apos;awi</translation>
     </message>
     <message>
@@ -3833,7 +3833,7 @@ Activar esta opción para realizar búsquedas adicionales con listas de sinónim
       <translation>Jaqukipaña aru jach’a ventanana ch’amañchaña</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Toggle escaneo ukax mä popup uñt’ayatawa.</translation>
     </message>
     <message>

--- a/locale/be_BY.ts
+++ b/locale/be_BY.ts
@@ -3045,17 +3045,17 @@ the application.</source>
       <translation>Монашырынны шрыфт</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Апрацоўванне ў выплыўных вокнах</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Вызначае, ці будзе прадвызначана ўключаная функцыя апрацоўвання ў выплыўных вокнах. Калі адзначана,
 праграма заўсёды будзе запускацца з актываванай функцыяй.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Запускаць з уключанай функцыяй апрацоўвання ў выплыўных вокнах</translation>
     </message>
     <message>
@@ -3172,7 +3172,7 @@ in the pressed state when the word selection changes.</source>
       <translation>Аўтаматычна вымаўляць словы ў галоўным акне</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Аўтаматычна вымаўляць словы ў выплыўных вокнах</translation>
     </message>
     <message>
@@ -3698,7 +3698,7 @@ from Stardict, Babylon and GLS dictionaries</source>
       <translation>Прымусова перакласці слова ў галоўным акне</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Уключыць або адключыць апрацоўванне ў выплыўных вокнах.</translation>
     </message>
     <message>

--- a/locale/bg_BG.ts
+++ b/locale/bg_BG.ts
@@ -3053,17 +3053,17 @@ the application.</source>
       <translation>Монопространствен шрифт</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Изскачащ прозорец</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Избран ли е, Изкачащ прозорец по подразб. или не. Ако е проверено,
 програмата винаги ще стартира с активен Изкачащ прозорец.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Пускане с включен изскачащ прозорец</translation>
     </message>
     <message>
@@ -3181,7 +3181,7 @@ in the pressed state when the word selection changes.</source>
       <translation>Автоматично произнасяне на думите в главния прозорец</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Автоматично произнасяне на думите в изскачащия прозорец</translation>
     </message>
     <message>
@@ -3710,7 +3710,7 @@ from Stardict, Babylon and GLS dictionaries</source>
       <translation>Принудете думата да бъде преведена в главния прозорец</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Превключване на изскачащия прозорец за сканиране.</translation>
     </message>
     <message>

--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -3037,16 +3037,16 @@ the application.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Scan Popup</source>
+        <source>&amp;Popup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+        <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Start with scan popup turned on</source>
+        <source>Start with popup turned on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3163,7 +3163,7 @@ in the pressed state when the word selection changes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto-pronounce words in scan popup</source>
+        <source>Auto-pronounce words in popup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3680,7 +3680,7 @@ from Stardict, Babylon and GLS dictionaries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Toggle scan popup.</source>
+        <source>Toggle popup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/locale/cs_CZ.ts
+++ b/locale/cs_CZ.ts
@@ -3051,17 +3051,17 @@ ukončení aplikace.</translation>
       <translation>Jednoprostorové písmo</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>Vy&amp;skakovací okno</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Určuje, zda je vyskakovací okno automaticky povoleno nebo zakázáno. Pokud
 zaškrtnuto, program bude automaticky startovat s aktivovaným vyskakovacím oknem.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Spouštět s povoleným vyskakovacím oknem</translation>
     </message>
     <message>
@@ -3179,7 +3179,7 @@ zvolené klávesy stisknuty při změně výběru.</translation>
       <translation>Automaticky vyslovovat slova v hlavním okně</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Automaticky vyslovovat slova ve vyskakovacím okně</translation>
     </message>
     <message>
@@ -3708,7 +3708,7 @@ ze Stardict, Babylon a GLS slovníků</translation>
       <translation>Vynutit překlad slova v hlavním okně</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Přepnout vyskakovací okno.</translation>
     </message>
     <message>

--- a/locale/de_CH.ts
+++ b/locale/de_CH.ts
@@ -3045,18 +3045,18 @@ the application.</source>
       <translation>Monospace-Schriftart</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>Popup &amp;scannen</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
-      <translation>Gibt an, ob der Scan Popup Modus standardmässig aktiviert ist oder nicht. 
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
+      <translation>Gibt an, ob der Popup Modus standardmässig aktiviert ist oder nicht. 
 Falls aktiviert, wird das Programm immer mit aktiviertem Modus gestartet.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
-      <translation>Mit aktiviertem Scan Popup starten</translation>
+      <source>Start with popup turned on</source>
+      <translation>Mit aktiviertem Popup starten</translation>
     </message>
     <message>
       <source>Send translated word to main window instead of to show it in popup window</source>
@@ -3081,7 +3081,7 @@ Falls aktiviert, wird das Programm immer mit aktiviertem Modus gestartet.</trans
     <message>
       <source>With this enabled, the popup would only show up if all chosen keys are
 in the pressed state when the word selection changes.</source>
-      <translation>Fallt aktiviert, wird das Scan Popup bei Änderung der Wortauswahl nur angezeigt, wenn alle ausgewählten Tasten gedrückt sind.</translation>
+      <translation>Fallt aktiviert, wird das Popup bei Änderung der Wortauswahl nur angezeigt, wenn alle ausgewählten Tasten gedrückt sind.</translation>
     </message>
     <message>
       <source>Only tack selection when all selected keys are kept pressed:</source>
@@ -3172,8 +3172,8 @@ in the pressed state when the word selection changes.</source>
       <translation>Wörter im Hauptfenster automatisch aussprechen</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
-      <translation>Wörter im Scan Popup automatisch aussprechen</translation>
+      <source>Auto-pronounce words in popup</source>
+      <translation>Wörter im Popup automatisch aussprechen</translation>
     </message>
     <message>
       <source>Playback</source>
@@ -3697,7 +3697,7 @@ Stardict, Babylon und GLS Wörterbüchern wünschen.</translation>
       <translation>Erzwinge das Wort im Hauptfenster zu übersetzen</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Wechsle ScanPopUp.</translation>
     </message>
     <message>

--- a/locale/de_DE.ts
+++ b/locale/de_DE.ts
@@ -3049,18 +3049,18 @@ the application.</source>
       <translation>Monospace-Schriftart</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>Popup &amp;scannen</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
-      <translation>Gibt an, ob der Scan Popup Modus standardmäßig aktiviert ist oder nicht. Falls aktiviert,
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
+      <translation>Gibt an, ob der Popup Modus standardmäßig aktiviert ist oder nicht. Falls aktiviert,
 wird das Programm immer mit aktiviertem Modus gestartet.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
-      <translation>Mit aktiviertem Scan Popup starten</translation>
+      <source>Start with popup turned on</source>
+      <translation>Mit aktiviertem Popup starten</translation>
     </message>
     <message>
       <source>Send translated word to main window instead of to show it in popup window</source>
@@ -3085,7 +3085,7 @@ wird das Programm immer mit aktiviertem Modus gestartet.</translation>
     <message>
       <source>With this enabled, the popup would only show up if all chosen keys are
 in the pressed state when the word selection changes.</source>
-      <translation>Fallt aktiviert, wird das Scan Popup bei Änderung der Wortauswahl nur angezeigt, wenn alle ausgewählten Tasten gedrückt sind.</translation>
+      <translation>Fallt aktiviert, wird das Popup bei Änderung der Wortauswahl nur angezeigt, wenn alle ausgewählten Tasten gedrückt sind.</translation>
     </message>
     <message>
       <source>Only tack selection when all selected keys are kept pressed:</source>
@@ -3176,8 +3176,8 @@ in the pressed state when the word selection changes.</source>
       <translation>Wörter im Hauptfenster automatisch aussprechen</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
-      <translation>Wörter im Scan Popup automatisch aussprechen</translation>
+      <source>Auto-pronounce words in popup</source>
+      <translation>Wörter im Popup automatisch aussprechen</translation>
     </message>
     <message>
       <source>Playback</source>
@@ -3703,7 +3703,7 @@ from Stardict, Babylon and GLS dictionaries</source>
       <translation>Erzwingen Sie die Übersetzung des Wortes im Hauptfenster</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Scan-Popup umschalten.</translation>
     </message>
     <message>

--- a/locale/de_DE.ts
+++ b/locale/de_DE.ts
@@ -3704,7 +3704,7 @@ from Stardict, Babylon and GLS dictionaries</source>
     </message>
     <message>
       <source>Toggle popup.</source>
-      <translation>Scan-Popup umschalten.</translation>
+      <translation>Popup umschalten.</translation>
     </message>
     <message>
       <source>Print version and diagnosis info.</source>

--- a/locale/el_GR.ts
+++ b/locale/el_GR.ts
@@ -3053,18 +3053,18 @@ the application.</source>
       <translation>Γραμματοσειρά Monospace</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>Ανα&amp;δυόμενο παράθυρο</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Καθορίζει αν θα είναι προεπιλεγμένη η λειτουργία αναδυόμενου παραθύρου.
 Αν σημειώσετε την επιλογή, η εφαρμογή θα εκκινείται πάντα με το αναδυόμενο 
 παράθυρο ενεργοποιημένο.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Εκκίνηση με το αναδυόμενο παράθυρο ενεργοποιημένο</translation>
     </message>
     <message>
@@ -3182,7 +3182,7 @@ in the pressed state when the word selection changes.</source>
       <translation>Αυτόματη εκφώνηση λημμάτων στο κύριο παράθυρο</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Αυτόματη εκφώνηση λημμάτων στο αναδυόμενο παράθυρο</translation>
     </message>
     <message>
@@ -3713,7 +3713,7 @@ from Stardict, Babylon and GLS dictionaries</source>
       <translation>Αναγκάστε να μεταφραστεί η λέξη στο κύριο παράθυρο</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Εναλλαγή αναδυόμενου παραθύρου σάρωσης.</translation>
     </message>
     <message>

--- a/locale/eo_UY.ts
+++ b/locale/eo_UY.ts
@@ -3053,17 +3053,17 @@ la aplikaĵon.</translation>
       <translation>Monospaca Tiparo</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Skani Ŝprucfenestron</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Elektas ĉu la skana ŝprucfenestra reĝimo estas ŝaltita defaŭlte aŭ ne. Se markite,
 la programo ĉiam komenciĝus kun la skana ŝprucfenestro aktiva.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Komencu kun skanado ŝprucfenestron ŝaltita</translation>
     </message>
     <message>
@@ -3181,7 +3181,7 @@ en la premita stato kiam la vortelekto ŝanĝiĝas.</translation>
       <translation>Aŭtomate prononcu vortojn en ĉefa fenestro</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Aŭtomate prononcu vortojn en skana ŝprucfenestro</translation>
     </message>
     <message>
@@ -3711,7 +3711,7 @@ el Stardict, Babylon kaj GLS-vortaroj</translation>
       <translation>Devigu la vorton esti tradukita en la ĉeffenestro</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Baskuligi skanadon ŝprucfenestron.</translation>
     </message>
     <message>

--- a/locale/es_AR.ts
+++ b/locale/es_AR.ts
@@ -3055,17 +3055,17 @@ the application.</source>
       <translation>Fuente monoespaciada</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Ventana emergente de lectura</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Elige si la ventana emergente de lectura se activará por defecto o no. Si estuviera tildada, 
 el programa siempre se iniciará con la ventana emergente de lectura activa.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Iniciar con la ventana emergente de lectura activada</translation>
     </message>
     <message>
@@ -3182,7 +3182,7 @@ in the pressed state when the word selection changes.</source>
       <translation>Auto-pronunciar palabras en la ventana principal</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Auto-pronunciar palabras en la ventana emergente de lectura</translation>
     </message>
     <message>
@@ -3710,7 +3710,7 @@ de los diccionarios Stardict, Babylon y GLS.</translation>
       <translation>Forzar la traducción de la palabra en la ventana principal.</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Alternar ventana emergente de escaneo.</translation>
     </message>
     <message>

--- a/locale/es_BO.ts
+++ b/locale/es_BO.ts
@@ -3050,17 +3050,17 @@ the application.</source>
       <translation>Fuente monoespaciada</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Escanear con ventana emergente</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Selecciona si el modo de escaneo está activado por defecto o no. Si está
 marcado, el programa siempre iniciará con el modo de escaneo habilitado.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Habilitar escaneo en una ventana emergente cuando inicia</translation>
     </message>
     <message>
@@ -3178,7 +3178,7 @@ seleccionadas estén oprimidas cuando la selección de la palabra cambie.</trans
       <translation>Pronuncia palabras automáticamente en la ventana principal</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Pronunciar palabras automáticamente a escanear con la ventana emergente</translation>
     </message>
     <message>
@@ -3706,7 +3706,7 @@ de los diccionarios Stardict, Babylon y GLS.</translation>
       <translation>Forzar la traducción de la palabra en la ventana principal.</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Alternar ventana emergente de escaneo.</translation>
     </message>
     <message>

--- a/locale/es_ES.ts
+++ b/locale/es_ES.ts
@@ -3051,17 +3051,17 @@ en lugar de cerrrarse.</translation>
       <translation>Fuente monoespaciada</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Ventana emergente de búsqueda</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Elige si la ventana emergente de búsqueda está habilitada por defecto o no. Si se marca,
 el programa empezará siempre con la ventana emergente de búsqueda activada.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Empezar con la ventana emergente de búsqueda activada</translation>
     </message>
     <message>
@@ -3179,7 +3179,7 @@ las teclas elegidas cuando cambia la palabra seleccionada.</translation>
       <translation>Pronunciar palabras automáticamente en la ventana principal</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Pronunciar palabras automáticamente en la ventana emergente de búsqueda</translation>
     </message>
     <message>
@@ -3708,7 +3708,7 @@ de diccionarios Stardict, Babylon y GLS</translation>
       <translation>Forzar la traducción de la palabra en la ventana principal.</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Cambiar ventana emergente de escaneo.</translation>
     </message>
     <message>

--- a/locale/fa_IR.ts
+++ b/locale/fa_IR.ts
@@ -3051,17 +3051,17 @@ the application.</source>
       <translation>فونت Monospace</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>پویش &amp;واشو</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>برگزینید که آیا حالت پویش واشو به‌طور پیش‌فرض روشن باشد یا نه. اگر
 به‌کار افتاده باشد، برنامه همیشه با فعال بودن پویش واشو آغاز می‌شود.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>آغاز با روشن بودن پویش واشو</translation>
     </message>
     <message>
@@ -3179,7 +3179,7 @@ in the pressed state when the word selection changes.</source>
       <translation>بیان خودکار واژه‌ها در پنجره اصلی</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>بیان خودکار واژه‌ها در پویش واشو</translation>
     </message>
     <message>
@@ -3708,7 +3708,7 @@ from Stardict, Babylon and GLS dictionaries</source>
       <translation>مجبور کنید کلمه را در پنجره اصلی ترجمه کنید</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>جابجایی پنجره اسکن</translation>
     </message>
     <message>

--- a/locale/fi_FI.ts
+++ b/locale/fi_FI.ts
@@ -3053,17 +3053,17 @@ sovellus.</translation>
       <translation>Monospace fontti</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Kartoita Ponnahdusikkuna</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Valitsee onko skannaus ponnahdusikkuna oletusarvoisesti päällä vai ei. Jos valittuna,
 ohjelma alkaisi aina skannauksen ponnahdusikkunan ollessa aktiivinen.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Aloita skannaus ponnahdusikkuna otettu käyttöön</translation>
     </message>
     <message>
@@ -3181,7 +3181,7 @@ painettuna tilassa, kun sana valinta muuttuu.</translation>
       <translation>Ääntää sanat automaattisesti pääikkunassa</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Ääntää automaattisesti sanoja skannauksessa</translation>
     </message>
     <message>
@@ -3711,7 +3711,7 @@ alkaen alkaen alkupisteestä, Babylonista ja GLS-sanakirjoista</translation>
       <translation>Pakota sana käännettäväksi pääikkunassa</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Vaihda skannauksen ponnahdusikkuna.</translation>
     </message>
     <message>

--- a/locale/fr_FR.ts
+++ b/locale/fr_FR.ts
@@ -3051,17 +3051,17 @@ the application.</source>
       <translation>Police Monospace</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>Fenêtre de &amp;scan</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Définit si la fonctionnalité de scan par fenêtre pop-up est activée par défaut ou non.
 Si cette option est active, GoldenDict démarrera toujours avec la fenêtre de scan activée.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Démarrer avec la fenêtre de scan activée</translation>
     </message>
     <message>
@@ -3178,7 +3178,7 @@ in the pressed state when the word selection changes.</source>
       <translation>Prononciation automatique dans la fenêtre principale</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Prononciation automatique dans la fenêtre de scan</translation>
     </message>
     <message>
@@ -3707,7 +3707,7 @@ des dictionnaires Stardict, Babylon et GLS</translation>
       <translation>Forcer la traduction du mot dans la fenêtre principale</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Activer/désactiver la popup d'analyse.</translation>
     </message>
     <message>

--- a/locale/hi_IN.ts
+++ b/locale/hi_IN.ts
@@ -3045,18 +3045,18 @@ the application.</source>
       <translation>मोनोस्पेस फ़ॉन्ट</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;स्कैन पॉपअप</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>यह चुनता है कि स्कैन पॉपअप पद्धति औत्सर्गिक रूप से चालू है या नहीं। अगर जाँचा हुआ हो,
 तो प्रोग्राम हमेशा स्कैन पॉपअप सक्रिय के साथ शुरू होगा।
 </translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>स्कैन पॉपअप चालू के साथ शुरू करें</translation>
     </message>
     <message>
@@ -3173,7 +3173,7 @@ in the pressed state when the word selection changes.</source>
       <translation>मुख्य खिडकी में शब्दों का स्वतः उच्चारण करें</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>स्कैन पॉपअप में शब्दों का स्वतः उच्चारण करें</translation>
     </message>
     <message>
@@ -3695,7 +3695,7 @@ from Stardict, Babylon and GLS dictionaries</source>
       <translation>शब्द को मुख्य विंडो में अनुवादित करने के लिए बाध्य करें</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>स्कैन पॉपअप टॉगल करें.</translation>
     </message>
     <message>

--- a/locale/hu_HU.ts
+++ b/locale/hu_HU.ts
@@ -3053,17 +3053,17 @@ való kilépés helyett.</translation>
       <translation>Fix szélességű betűkészlet</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>Fordító felugró&amp;ablak</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Megadja, hogy a fordító felugróablak a program indításakor be vagy ki
 legyen kapcsolva.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Indulás bekapcsolt felugróablakkal</translation>
     </message>
     <message>
@@ -3181,7 +3181,7 @@ kijelölésekor, ha a kiválasztott billentyűk mindegyike le van nyomva.</trans
       <translation>Szavak automatikus kimondása a főablakban</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Szavak automatikus kimondása a felugróablakban</translation>
     </message>
     <message>
@@ -3710,7 +3710,7 @@ is felhasználja további szócikkek felfedezéséhez</translation>
       <translation>A lefordított szó kényszerített beküldése a főablakba</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Fordító felugróablak ki- vagy bekapcsolása.</translation>
     </message>
     <message>

--- a/locale/ie_001.ts
+++ b/locale/ie_001.ts
@@ -3053,17 +3053,17 @@ the application.</translation>
       <translation type="unfinished">Monospace Font</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Monitor</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
-      <translation type="unfinished">Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</translation>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
+      <translation type="unfinished">Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Activar li monitor al inicie</translation>
     </message>
     <message>
@@ -3181,8 +3181,8 @@ in the pressed state when the word selection changes.</translation>
       <translation>Auto-pronunciar paroles in li principal fenestre</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
-      <translation type="unfinished">Auto-pronounce words in scan popup</translation>
+      <source>Auto-pronounce words in popup</source>
+      <translation type="unfinished">Auto-pronounce words in popup</translation>
     </message>
     <message>
       <source>Playback</source>
@@ -3711,8 +3711,8 @@ from Stardict, Babylon and GLS dictionaries</translation>
       <translation type="unfinished">Force the word to be translated in the mainwindow</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
-      <translation type="unfinished">Toggle scan popup.</translation>
+      <source>Toggle popup.</source>
+      <translation type="unfinished">Toggle popup.</translation>
     </message>
     <message>
       <source>Print version and diagnosis info.</source>

--- a/locale/it_IT.ts
+++ b/locale/it_IT.ts
@@ -3051,18 +3051,18 @@ ne causerà soltanto l&apos;iconizzazione nella barra di notifica.</translation>
       <translation>Carattere monospazio</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Puntamento</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Spuntando questa casella, si attiva sin dall&apos;inizio l&apos;attività di scansione e traduzione delle parole puntate.
 Le parole tradotte verranno mostrate in una finestra di dialogo a comparsa.
 Al contrario se si deseleziona questa casella, scansione e traduzione vengono disabilitate.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>abilita l&apos;attività di scansione e traduzione delle parole puntate fin dall&apos;avvio del programma</translation>
     </message>
     <message>
@@ -3181,7 +3181,7 @@ Le parole tradotte verranno mostrate in una finestra di dialogo a comparsa.</tra
       <translation>pronuncia automaticamente le parole dalla finestra principale</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>pronuncia automaticamente le parole puntate</translation>
     </message>
     <message>
@@ -3709,7 +3709,7 @@ dai dizionari di Stardict, Babylon e GLS</translation>
       <translation>Forza la traduzione della parola nella finestra principale</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Attiva/disattiva popup di scansione.</translation>
     </message>
     <message>

--- a/locale/ja_JP.ts
+++ b/locale/ja_JP.ts
@@ -3053,17 +3053,17 @@ the application.</source>
       <translation>等幅フォント</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>スキャン ポップアップ(&amp;S)</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>スキャン ポップアップ モードを既定でオンにするかを選択します。チェックされている場合、
 プログラムは常にスキャン ポップアップがアクティブで起動します。</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>スキャン ポップアップをオンにして起動する</translation>
     </message>
     <message>
@@ -3181,7 +3181,7 @@ in the pressed state when the word selection changes.</source>
       <translation>メイン ウィンドウで単語を自動的に発音する</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>スキャン ポップアップで単語を自動的に発音する</translation>
     </message>
     <message>
@@ -3710,7 +3710,7 @@ from Stardict, Babylon and GLS dictionaries</source>
       <translation>メインウィンドウで単語を強制的に翻訳する</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>スキャンポップアップの切り替え。</translation>
     </message>
     <message>

--- a/locale/jbo_EN.ts
+++ b/locale/jbo_EN.ts
@@ -3053,18 +3053,18 @@ the application.</translation>
       <translation type="unfinished">Monospace Font</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
-      <translation type="unfinished">&amp;Scan Popup</translation>
+      <source>&amp;Popup</source>
+      <translation type="unfinished">&amp;Popup</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
-      <translation type="unfinished">Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</translation>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
+      <translation type="unfinished">Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
-      <translation type="unfinished">Start with scan popup turned on</translation>
+      <source>Start with popup turned on</source>
+      <translation type="unfinished">Start with popup turned on</translation>
     </message>
     <message>
       <source>Send translated word to main window instead of to show it in popup window</source>
@@ -3181,8 +3181,8 @@ in the pressed state when the word selection changes.</translation>
       <translation type="unfinished">Auto-pronounce words in main window</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
-      <translation type="unfinished">Auto-pronounce words in scan popup</translation>
+      <source>Auto-pronounce words in popup</source>
+      <translation type="unfinished">Auto-pronounce words in popup</translation>
     </message>
     <message>
       <source>Playback</source>
@@ -3711,8 +3711,8 @@ from Stardict, Babylon and GLS dictionaries</translation>
       <translation type="unfinished">Force the word to be translated in the mainwindow</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
-      <translation type="unfinished">Toggle scan popup.</translation>
+      <source>Toggle popup.</source>
+      <translation type="unfinished">Toggle popup.</translation>
     </message>
     <message>
       <source>Print version and diagnosis info.</source>

--- a/locale/ko_KR.ts
+++ b/locale/ko_KR.ts
@@ -3051,17 +3051,17 @@ the application.</source>
       <translation>모노스페이스 글꼴</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>스캔팝업(&amp;S)</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>기본값으로 스캔팝업모드를 켤 것인지 설정합니다. 이 항목을 선택하면,
 프로그램이 시작할 때 항상 스캔팝업기능이 활성화됩니다.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>프로그램 시작시 스캔팝업 활성화</translation>
     </message>
     <message>
@@ -3179,7 +3179,7 @@ in the pressed state when the word selection changes.</source>
       <translation>메인창에서 발음 자동 재생</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>스캔팝업창에서 발음 자동 재생</translation>
     </message>
     <message>
@@ -3707,7 +3707,7 @@ from Stardict, Babylon and GLS dictionaries</source>
       <translation>메인 창에서 단어가 강제로 번역되도록 합니다.</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>스캔 팝업을 전환합니다.</translation>
     </message>
     <message>

--- a/locale/lt_LT.ts
+++ b/locale/lt_LT.ts
@@ -3053,17 +3053,17 @@ tiesiog paslepiama.</translation>
       <translation>Monospace šriftas</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Iškylantis langas</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Nurodykite, ar ši iškylančių langų funkcija yra numatytoji.
 Jei pažymėta, iškylančių langų funkcija bus įjungta vos paleistoje programoje.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Paleisti su įjungta iškylančių langų funkcija</translation>
     </message>
     <message>
@@ -3181,7 +3181,7 @@ po to, kai pasikeis pažymėtas žodis.</translation>
       <translation>Automatiškai ištarti pagrindinio lango žodžius</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Automatiškai ištarti iškylančio lango žodžius</translation>
     </message>
     <message>
@@ -3708,7 +3708,7 @@ from Stardict, Babylon and GLS dictionaries</source>
       <translation>Priverskite žodį išversti pagrindiniame lange</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Perjungti nuskaitymo iššokantįjį langą.</translation>
     </message>
     <message>

--- a/locale/mk_MK.ts
+++ b/locale/mk_MK.ts
@@ -3055,16 +3055,16 @@ the application.</source>
       <translation>Моноспејс фонт</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Скан попап </translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Вклучи или не вклучи попап прозорец кога програмот стартува.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Овозможи попап прозорец при стартување</translation>
     </message>
     <message>
@@ -3182,7 +3182,7 @@ in the pressed state when the word selection changes.</source>
       <translation>Автоматски изговари зборови во главниот прозорец</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Автоматски изговори зборови во скокачки прозорец</translation>
     </message>
     <message>
@@ -3713,7 +3713,7 @@ from Stardict, Babylon and GLS dictionaries</source>
       <translation>Принудете го зборот да се преведе во главниот прозорец</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Вклучете го скокачкиот прозорец за скенирање.</translation>
     </message>
     <message>

--- a/locale/nl_NL.ts
+++ b/locale/nl_NL.ts
@@ -3052,18 +3052,18 @@ the application.</source>
       <translation>Monospace-lettertype</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>Scan &amp;Popup</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
-      <translation>Hier kunt u aangeven of de Scan Popup modus standaard in- of uitgeschakeld is.
-Het programma start met de Scan Popup modus ingeschakeld als dit geselecteerd is.</translation>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
+      <translation>Hier kunt u aangeven of de Popup modus standaard in- of uitgeschakeld is.
+Het programma start met de Popup modus ingeschakeld als dit geselecteerd is.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
-      <translation>Starten met Scan Popup ingeschakeld</translation>
+      <source>Start with popup turned on</source>
+      <translation>Starten met Popup ingeschakeld</translation>
     </message>
     <message>
       <source>Send translated word to main window instead of to show it in popup window</source>
@@ -3180,8 +3180,8 @@ toetsen zijn ingedrukt wanneer de woordselectie verandert.</translation>
       <translation>Woorden in hoofdvenster automatisch uitspreken</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
-      <translation>Woorden in Scan Popup automatisch uitspreken</translation>
+      <source>Auto-pronounce words in popup</source>
+      <translation>Woorden in Popup automatisch uitspreken</translation>
     </message>
     <message>
       <source>Playback</source>
@@ -3707,8 +3707,8 @@ van Stardict, Babylon en GLS woordenboeken</translation>
       <translation>Forceer dat het woord in het hoofdvenster wordt vertaald</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
-      <translation>Toggle scan popup.</translation>
+      <source>Toggle popup.</source>
+      <translation>Toggle popup.</translation>
     </message>
     <message>
       <source>Print version and diagnosis info.</source>

--- a/locale/pl_PL.ts
+++ b/locale/pl_PL.ts
@@ -3051,17 +3051,17 @@ prowadzi do jego ukrycia, a nie do zamknięcia aplikacji.</translation>
       <translation>Czcionka o stałej szerokości</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Skanowanie automatyczne</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Wskazuje, czy tryb skanowania automatycznego jest domyślnie włączony, czy nie. Zaznaczenie
 tej opcji powoduje, że program uruchamia się z włączonym skanowaniem automatycznym.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Uruchamiaj z włączoną funkcją skanowania automatycznego</translation>
     </message>
     <message>
@@ -3179,7 +3179,7 @@ kiedy zaznaczenie słowa ulega zmianie przy naciśniętych wszystkich wybranych 
       <translation>Automatycznie wymawiaj słowa znajdujące się w oknie głównym</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Automatycznie wymawiaj słowa znajdujące się w okienku wyskakującym</translation>
     </message>
     <message>
@@ -3710,7 +3710,7 @@ ze słowników Stardict, Babylon i GLS</translation>
       <translation>Wymuś przetłumaczenie słowa w oknie głównym</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Przełącz wyskakujące okienko skanowania.</translation>
     </message>
     <message>

--- a/locale/pt_BR.ts
+++ b/locale/pt_BR.ts
@@ -3059,16 +3059,16 @@ ser fechado.</translation>
       <translation>Fonte monoespaçada</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Janela de Definições/Tradução Semiautomáticas</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Permite especificar se a janela secundária de definições/tradução semiautomáticas deve ficar ativa por padrão. Se habilitada esta opção, o programa será sempre executado com a janela secundária ativada.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Executar o GoldenDict com a janela de definições/tradução semiautomáticas habilitada</translation>
     </message>
     <message>
@@ -3187,7 +3187,7 @@ em qualquer situação ou contexto, desde que o GoldenDict esteja em execução.
       <translation>Pronunciar palavras na janela principal automaticamente</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Pronunciar automaticamente palavras da janela de definições/tradução semiautomáticas</translation>
     </message>
     <message>
@@ -3716,7 +3716,7 @@ dos dicionários Stardict, Babylon e GLS</translation>
       <translation>Forçar a palavra a ser traduzida na janela principal</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Alternar pop-up de verificação.</translation>
     </message>
     <message>

--- a/locale/pt_PT.ts
+++ b/locale/pt_PT.ts
@@ -3053,17 +3053,17 @@ a aplicação.</translation>
       <translation>Fonte monoespaçada</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Escanear pop-up</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Escolha se o modo popup está ativado por padrão. Se selecionado,
 o programa sempre iniciará com o popup de verificação ativo.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Iniciar com o popup de verificação ativado</translation>
     </message>
     <message>
@@ -3181,7 +3181,7 @@ no estado pressionado quando a seleção de palavras mudar.</translation>
       <translation>Auto-pronunciar palavras na janela principal</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Auto-pronunciar palavras em pop-up de verificação</translation>
     </message>
     <message>
@@ -3711,7 +3711,7 @@ no Stardict, Babilônia e dicionários GLS</translation>
       <translation>Forçar a palavra a ser traduzida na janela principal</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Alternar pop-up de verificação.</translation>
     </message>
     <message>

--- a/locale/qu_PE.ts
+++ b/locale/qu_PE.ts
@@ -3051,17 +3051,17 @@ cerrar la aplicación.</translation>
       <translation>Monoespacio nisqa qillqa</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Juch&apos;uy qhawanapi mask&apos;ay</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Selecciona si el modo de escaneo está activado por defecto o no. Si está
 marcado, el programa siempre iniciará con el modo de escaneo habilitado.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Qallarinapaq escaneo popup llank’achisqawan</translation>
     </message>
     <message>
@@ -3179,7 +3179,7 @@ seleccionadas estén oprimidas cuando la selección de la palabra cambie.</trans
       <translation>Qhapaq qhawanapi kunanpacha simikunata parlachiy</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Juch&apos;uy qhawanapi kunanpacha simikunata parlachiy</translation>
     </message>
     <message>
@@ -3707,7 +3707,7 @@ kaqninta Stardict, Babylon chaymanta GLS simi pirwakunamanta</translation>
       <translation>Hatun ventanata t’ikranapaq simita kallpachay</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Toggle escaneo nisqa popup nisqa.</translation>
     </message>
     <message>

--- a/locale/ru_RU.ts
+++ b/locale/ru_RU.ts
@@ -3057,16 +3057,16 @@ the application.</source>
       <translation>Моноширинный шрифт</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Всплывающее окно</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Включать или нет режим всплывающего окна при запуске программы.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Включить режим всплывающего окна при запуске</translation>
     </message>
     <message>
@@ -3184,7 +3184,7 @@ in the pressed state when the word selection changes.</source>
       <translation>Автоматически произносить слова в главном окне</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Автоматически произносить слова во всплывающем окне</translation>
     </message>
     <message>
@@ -3716,7 +3716,7 @@ from Stardict, Babylon and GLS dictionaries</source>
       <translation>Принудительно перевести слово в главном окне</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Переключить всплывающее окно сканирования.</translation>
     </message>
     <message>

--- a/locale/sk_SK.ts
+++ b/locale/sk_SK.ts
@@ -3049,17 +3049,17 @@ skryje program namiesto jeho ukončenia.</translation>
       <translation>Jednopriestorové písmo</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>Vys&amp;kakovacie okno</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Určuje, či vyskakovacie okno je automaticky povolené, alebo zakázané. Pokiaľ je zaškrtnuté,
 program sa bude spúšťať s automaticky aktivovaným vyskakovacím oknom.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Spustiť s povoleným vyskakovacím oknom</translation>
     </message>
     <message>
@@ -3176,7 +3176,7 @@ in the pressed state when the word selection changes.</source>
       <translation>Automaticky vysloviť slová v hlavnom okne</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Automaticky vysloviť slová vo vyskakovacom okne</translation>
     </message>
     <message>
@@ -3704,7 +3704,7 @@ zo slovníkov Stardict, Babylon a GLS.</translation>
       <translation>Vynútiť preklad slova v hlavnom okne</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Prepnúť kontextové okno skenovania.</translation>
     </message>
     <message>

--- a/locale/sq_AL.ts
+++ b/locale/sq_AL.ts
@@ -3047,17 +3047,17 @@ the application.</source>
       <translation>Fonti Monospace</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Skanimi i jashtëm</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Zgjedh nëse mënyra standarde e skanimit të jashtëm është ndezur apo jo.
 Kur e zgjedh, programi nis gjithmonë me skanimin e jashtëm aktiv.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Nis me skanuesin e ndezur</translation>
     </message>
     <message>
@@ -3175,7 +3175,7 @@ janë në gjendjen e shtypur.</translation>
       <translation>Autoshqiptoj fjalët në dritaren kryesore</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Autoshqiptoj fjalët e skanuara</translation>
     </message>
     <message>
@@ -3703,7 +3703,7 @@ nga fjalorët Stardict, Babylon dhe GLS</translation>
       <translation>Detyrojeni fjalën të përkthehet në dritaren kryesore</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Ndrysho dritaren kërcyese të skanimit.</translation>
     </message>
     <message>

--- a/locale/sr_SP.ts
+++ b/locale/sr_SP.ts
@@ -3055,16 +3055,16 @@ the application.</source>
       <translation>Моноспаце Фонт</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Искачући прозор</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Укључите или не укључити искачући прозор када програм почиње.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Омогући искачући прозор при покретању</translation>
     </message>
     <message>
@@ -3182,7 +3182,7 @@ in the pressed state when the word selection changes.</source>
       <translation>Аутоматски изговари речи у главном прозору</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Аутоматски изговорити речи у искачућем прозору</translation>
     </message>
     <message>
@@ -3713,7 +3713,7 @@ from Stardict, Babylon and GLS dictionaries</source>
       <translation>Присилите да се реч преведе у главном прозору</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Укључите искачући прозор за скенирање.</translation>
     </message>
     <message>

--- a/locale/sv_SE.ts
+++ b/locale/sv_SE.ts
@@ -3052,17 +3052,17 @@ minimera fönstret till meddelandefältet istället för att avsluta programmet.
       <translation>Monospace teckensnitt</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Sökpopupruta</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Avgör om sökpopuprutelägets standardinställning är PÅ eller AV. Om kryss-
 rutan är markerad startar programmet alltid med sökpopuprutan påslagen.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Starta med sökpopuprutan påslagen</translation>
     </message>
     <message>
@@ -3180,7 +3180,7 @@ angivna tangenterna är nedtryckta när ordet markeras.</translation>
       <translation>Läs automatiskt upp ord i huvudfönstret</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Läs automatiskt upp ord i popuprutan</translation>
     </message>
     <message>
@@ -3713,7 +3713,7 @@ från Stardict, Babylon och GLS ordböcker</translation>
       <translation>Tvinga ordet att översättas i huvudfönstret</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Växla skanning popup.</translation>
     </message>
     <message>

--- a/locale/tg_TJ.ts
+++ b/locale/tg_TJ.ts
@@ -3053,17 +3053,17 @@ the application.</source>
       <translation>Шрифти Monospace</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Тарҷумаи пайдошаванда</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Барои фаъол ё хомӯш кардани тарҷумаи пайдошаванда, имконоти зеринро истифода баред.
 Агар ин имконотро интихоб мекунед, тарҷумаи пайдошаванда ба худкор фаъол мешавад.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Барномаро бо хусусияти тарҷумаи пайдошаванда оғоз кардан</translation>
     </message>
     <message>
@@ -3181,7 +3181,7 @@ in the pressed state when the word selection changes.</source>
       <translation>Талаффузи худкори калимаҳо дар равзанаи асосӣ</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Талаффузи худкори калимаҳо дар тарҷумаи пайдошаванда</translation>
     </message>
     <message>
@@ -3711,7 +3711,7 @@ from Stardict, Babylon and GLS dictionaries</source>
       <translation>Маҷбур кардани калима дар равзанаи асосӣ тарҷума карда шавад</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Ивазкунандаи поп-апаи скан.</translation>
     </message>
     <message>

--- a/locale/tk_TM.ts
+++ b/locale/tk_TM.ts
@@ -3052,17 +3052,17 @@ programmany ýapmagyň ýerine ony gizlärdi.</translation>
       <translation>Monospace şrifti</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Skan popup</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Skaner açylýan re modeimiň deslapkydygyny ýa-da ýokdugyny saýlaýar. Barlanylsa,
 programma elmydama skananyň açylmagy bilen işjeň başlar.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Skan ýüze çykarmany işledip başlat</translation>
     </message>
     <message>
@@ -3180,7 +3180,7 @@ basylan ýagdaýynda görkeziler.</translation>
       <translation>Baş penjirede sözleriň awto-aýdylyşy</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Skan popup-dan sözleriň awto-aýdylyşy</translation>
     </message>
     <message>
@@ -3710,7 +3710,7 @@ arkaly goşmaça makalalary gözlemek üçin bu opsiýany açyň</translation>
       <translation>Sözü esasy setirde terjime etmäge mejbur ediň</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Açylýan paneli açyň.</translation>
     </message>
     <message>

--- a/locale/tr_TR.ts
+++ b/locale/tr_TR.ts
@@ -3050,17 +3050,17 @@ yerine onu gizler.</translation>
       <translation>Tek Aralıklı Yazı Tipi</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Ekranda Kelime Yakala</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Ekranda kelime yakala kipinin öntanımlı olarak etkin olup olmadığını gösterir.
 Etkinse, program her zaman aktif kip ile başlar.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Ekranda Kelime Yakala&apos;mayı açık olarak başlat</translation>
     </message>
     <message>
@@ -3178,7 +3178,7 @@ Aksi halde fare, sözcüğün üzerine geldiğinde çeviri yapılır.</translati
       <translation>Ana penceredeki kelimeleri otomatik telaffuz et</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Ekranda Kelime Yakalarken kelimeleri otomatik seslendir</translation>
     </message>
     <message>
@@ -3706,7 +3706,7 @@ eşanlamlı listeleri aracılığıyla ekstra makale aramasını etkinleştirmek
       <translation>Ana pencerede çevrilecek kelimeyi zorla</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Tarama açılır penceresini aç / kapat.</translation>
     </message>
     <message>

--- a/locale/uk_UA.ts
+++ b/locale/uk_UA.ts
@@ -3053,17 +3053,17 @@ the application.</source>
       <translation>Моноширинний шрифт</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Контекстне вікно</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Визначає, чи типово ввімкнуті контекстні вікна, чи ні. Якщо це відмічено,
 програма завжди запускатиметься з контекстними меню.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Увімкнути контекстні меню при запуску</translation>
     </message>
     <message>
@@ -3182,7 +3182,7 @@ in the pressed state when the word selection changes.</source>
       <translation>Автоматично вимовляти слово в головному меню</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Автоматично вимовляти слова в контекстному меню</translation>
     </message>
     <message>
@@ -3712,7 +3712,7 @@ from Stardict, Babylon and GLS dictionaries</source>
       <translation>Примусово перекласти слово в головному вікні</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Увімкнути або вимкнути вікно сканування.</translation>
     </message>
     <message>

--- a/locale/vi_VN.ts
+++ b/locale/vi_VN.ts
@@ -3050,17 +3050,17 @@ the application.</source>
       <translation>Phông chữ đơn cách</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>&amp;Quét Popup</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>Chọn bật chế độ quét popup mặc định. Nếu chọn, chương trình sẽ khởi động
 với tính năng quét popup được bật.</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>Khởi động với quét popup được bật</translation>
     </message>
     <message>
@@ -3177,7 +3177,7 @@ in the pressed state when the word selection changes.</source>
       <translation>Tự động phát âm trong cửa sổ chính</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>Tự động phát âm trong quét popup</translation>
     </message>
     <message>
@@ -3704,7 +3704,7 @@ từ các từ điển Stardict, Babylon và GLS</translation>
       <translation>Buộc dịch từ trong cửa sổ chính</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>Chuyển đổi cửa sổ bật lên quét.</translation>
     </message>
     <message>

--- a/locale/zh_CN.ts
+++ b/locale/zh_CN.ts
@@ -3044,16 +3044,16 @@ the application.</source>
       <translation>等宽字体</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>屏幕取词(&amp;S)</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>选择是否默认启用屏幕取词模式。如果选中，程序启动时将会自动激活屏幕取词功能。</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>启动程序时同时启动屏幕取词</translation>
     </message>
     <message>
@@ -3170,7 +3170,7 @@ in the pressed state when the word selection changes.</source>
       <translation>自动朗读主窗口中的词条</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>自动朗读屏幕取词弹出窗口中的词条</translation>
     </message>
     <message>
@@ -3694,7 +3694,7 @@ from Stardict, Babylon and GLS dictionaries</source>
       <translation>强制在主窗口中翻译该单词</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>切换扫描弹出窗口。</translation>
     </message>
     <message>

--- a/locale/zh_TW.ts
+++ b/locale/zh_TW.ts
@@ -3047,16 +3047,16 @@ the application.</source>
       <translation>等寬字體</translation>
     </message>
     <message>
-      <source>&amp;Scan Popup</source>
+      <source>&amp;Popup</source>
       <translation>螢幕取詞(&amp;S)</translation>
     </message>
     <message>
-      <source>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</source>
+      <source>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</source>
       <translation>選擇是否預設啟用螢幕取詞模式。如果選用，程式啟動時將會自動啟用螢幕取詞功能。</translation>
     </message>
     <message>
-      <source>Start with scan popup turned on</source>
+      <source>Start with popup turned on</source>
       <translation>啟動程式時同時啟動螢幕取詞</translation>
     </message>
     <message>
@@ -3173,7 +3173,7 @@ in the pressed state when the word selection changes.</source>
       <translation>自動朗讀主視窗中的單字</translation>
     </message>
     <message>
-      <source>Auto-pronounce words in scan popup</source>
+      <source>Auto-pronounce words in popup</source>
       <translation>自動朗讀螢幕取詞彈出視窗中的單字</translation>
     </message>
     <message>
@@ -3700,7 +3700,7 @@ from Stardict, Babylon and GLS dictionaries</source>
       <translation>強制在主視窗中翻譯該單字</translation>
     </message>
     <message>
-      <source>Toggle scan popup.</source>
+      <source>Toggle popup.</source>
       <translation>切換彈出窗口。</translation>
     </message>
     <message>

--- a/src/main.cc
+++ b/src/main.cc
@@ -233,7 +233,7 @@ void processCommandLine( QCoreApplication * app, GDOptions * result )
 
   QCommandLineOption togglePopupOption( QStringList() << "t"
                                                       << "toggle-scan-popup",
-                                        QObject::tr( "Toggle scan popup." ) );
+                                        QObject::tr( "Toggle popup." ) );
 
   QCommandLineOption printVersion( QStringList() << "v"
                                                  << "version",
@@ -575,7 +575,7 @@ int main( int argc, char ** argv )
     app.installTranslator( &webengineTs );
   }
 
-  // Prevent app from quitting spontaneously when it works with scan popup
+  // Prevent app from quitting spontaneously when it works with popup
   // and with the main window closed.
   app.setQuitOnLastWindowClosed( false );
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -232,7 +232,7 @@ void processCommandLine( QCoreApplication * app, GDOptions * result )
                                               QObject::tr( "Force the word to be translated in the mainwindow" ) );
 
   QCommandLineOption togglePopupOption( QStringList() << "t"
-                                                      << "toggle-scan-popup",
+                                                      << "toggle-popup",
                                         QObject::tr( "Toggle popup." ) );
 
   QCommandLineOption printVersion( QStringList() << "v"

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -244,7 +244,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   translateBoxLayout->addWidget( translateBox );
   translateBoxToolBarAction = navToolbar->addWidget( translateBoxWidget );
 
-  // scan popup
+  // popup
   navToolbar->addSeparator();
 
   enableScanningAction = navToolbar->addAction( QIcon( ":/icons/wizard.svg" ), tr( "Toggle clipboard monitoring" ) );
@@ -3457,7 +3457,7 @@ void MainWindow::applyZoomFactor()
 
   // Scaling article views asynchronously dramatically improves performance when
   // a zoom action is triggered repeatedly while many or large articles are open
-  // in the main window or in scan popup.
+  // in the main window or in popup.
   // Multiple zoom action signals are processed before (often slow) article view
   // scaling is requested. Multiple scaling requests then ask for the same zoom factor,
   // so all of them except for the first one don't change anything and run very fast.

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -247,7 +247,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   // scan popup
   navToolbar->addSeparator();
 
-  enableScanningAction = navToolbar->addAction( QIcon( ":/icons/wizard.svg" ), tr( "Enable Scanning" ) );
+  enableScanningAction = navToolbar->addAction( QIcon( ":/icons/wizard.svg" ), tr( "Toggle clipboard monitoring" ) );
   enableScanningAction->setCheckable( true );
 
   navToolbar->widgetForAction( enableScanningAction )->setObjectName( "scanPopupButton" );
@@ -2878,7 +2878,7 @@ void MainWindow::installHotKeys()
     if ( cfg.preferences.enableMainWindowHotkey )
       hotkeyWrapper->setGlobalKey( cfg.preferences.mainWindowHotkey, 0 );
 
-    if ( cfg.preferences.enableClipboardHotkey && !enableScanningAction->isChecked() ) {
+    if ( cfg.preferences.enableClipboardHotkey ) {
       hotkeyWrapper->setGlobalKey( cfg.preferences.clipboardHotkey, 1 );
     }
 
@@ -3607,7 +3607,7 @@ void MainWindow::messageFromAnotherInstanceReceived( QString const & message )
     }
     else {
       //default logic
-      if ( scanPopup && enableScanningAction->isChecked() )
+      if ( scanPopup )
         scanPopup->translateWord( word );
       else
         wordReceived( word );

--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -523,17 +523,17 @@ the application.</string>
         <normaloff>:/icons/wizard.svg</normaloff>:/icons/wizard.svg</iconset>
       </attribute>
       <attribute name="title">
-       <string>&amp;Scan Popup</string>
+       <string>&amp;Popup</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_10">
        <item>
         <widget class="QCheckBox" name="startWithScanPopupOn">
          <property name="toolTip">
-          <string>Chooses whether the scan popup mode is on by default or not. If checked,
-the program would always start with the scan popup active.</string>
+          <string>Chooses whether the popup mode is on by default or not. If checked,
+the program would always start with the popup active.</string>
          </property>
          <property name="text">
-          <string>Start with scan popup turned on</string>
+          <string>Start with popup turned on</string>
          </property>
         </widget>
        </item>
@@ -891,7 +891,7 @@ in the pressed state when the word selection changes.</string>
           <item>
            <widget class="QCheckBox" name="pronounceOnLoadPopup">
             <property name="text">
-             <string>Auto-pronounce words in scan popup</string>
+             <string>Auto-pronounce words in popup</string>
             </property>
            </widget>
           </item>

--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -529,11 +529,10 @@ the application.</string>
        <item>
         <widget class="QCheckBox" name="startWithScanPopupOn">
          <property name="toolTip">
-          <string>Chooses whether the popup mode is on by default or not. If checked,
-the program would always start with the popup active.</string>
+          <string>Chooses whether the clipboard monitoring will be turned on by default at the program's startup.</string>
          </property>
          <property name="text">
-          <string>Start with popup turned on</string>
+          <string>Start with clipboard monitoring turned on</string>
          </property>
         </widget>
        </item>
@@ -891,7 +890,7 @@ in the pressed state when the word selection changes.</string>
           <item>
            <widget class="QCheckBox" name="pronounceOnLoadPopup">
             <property name="text">
-             <string>Auto-pronounce words in popup</string>
+             <string>Auto-pronounce words in the popup</string>
             </property>
            </widget>
           </item>

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -34,9 +34,9 @@ static const Qt::WindowFlags defaultUnpinnedWindowFlags =
 
 static const Qt::WindowFlags pinnedWindowFlags =
 #ifdef HAVE_X11
-  /// With the Qt::Dialog flag, scan popup is always on top of the main window
+  /// With the Qt::Dialog flag, popup is always on top of the main window
   /// on Linux/X11 with Qt 4, Qt 5 since version 5.12.1 (QTBUG-74309).
-  /// Qt::Window allows to use the scan popup and the main window independently.
+  /// Qt::Window allows to use the popup and the main window independently.
   Qt::Window
 #else
   Qt::Dialog
@@ -454,7 +454,7 @@ void ScanPopup::showEngagePopup()
   auto sanitizedPhrase = cfg.preferences.sanitizeInputPhrase( str );
 
   if ( isVisible() && sanitizedPhrase == pendingWord ) {
-    // Attempt to translate the same word we already have shown in scan popup.
+    // Attempt to translate the same word we already have shown in popup.
     // Ignore it, as it is probably a spurious mouseover event.
     return;
   }

--- a/website/docs/topic_wayland.md
+++ b/website/docs/topic_wayland.md
@@ -3,14 +3,14 @@ Environment variable `GOLDENDICT_FORCE_WAYLAND` can be used to force GD to run i
 !!! danger "Don't use unless you know!"
     This flag only guarantees GD to run in wayland mode and won't crash, but nothing more.
 
-    Enable this will break scan popup, global hotkeys and probably other things.
+    Enable this will break popup, global hotkeys and probably other things.
 
 ## Current reality
 
 !!! note "Help wanted"
-    Need help to redesign scan popup for wayland.
+    Need help to redesign popup for wayland.
 
-Scan popup is implemented with `querying mouse cursor's position` and `setting a window's absolute global position`.
+Popup is implemented with `querying mouse cursor's position` and `setting a window's absolute global position`.
 Wayland does not support both by design and philosophy.
 
 Wayland does not support registering global hotkeys until very recently, but a reasonable wayland desktop environment should provide some way to bind keys to commands globally.

--- a/website/docs/ui_popup.md
+++ b/website/docs/ui_popup.md
@@ -2,17 +2,13 @@
 
 Popup is a mini window for rapid translation.
 
-Enable it by click the 💡 (enable clipboard trakcing) on the toolbar or using the context menu of tray icon.
+Enable it by enabling the 💡 (enable clipboard trakcing) on the toolbar or using the context menu of tray icon.
 
-When copying text, a popup window will show up.
+A popup window will show up wen copying text.
 
 ### Linux
 
 On linux/X11, the text selection can also trigger popup window. You have to enable it in preferences.
-
-### Notes
-
-The popup will also be shown if it is enabled and you use command line `goldendict <word>`.
 
 ## OCR
 

--- a/website/docs/ui_popup.md
+++ b/website/docs/ui_popup.md
@@ -2,11 +2,11 @@
 
 Popup is a mini window for rapid translation.
 
-Enable it by enabling the 💡 (enable clipboard trakcing) on the toolbar or using the context menu of tray icon.
+Enable it by clicking the 💡 (enable clipboard trakcing) on the toolbar or using the context menu of tray icon.
 
-A popup window will show up wen copying text.
+A popup window will show up when copying text.
 
-### Linux
+## Linux
 
 On linux/X11, the text selection can also trigger popup window. You have to enable it in preferences.
 

--- a/website/docs/ui_popup.md
+++ b/website/docs/ui_popup.md
@@ -1,11 +1,10 @@
 ![popup window](img/popup.webp)
 
-Popup window is a mini window can be used for rapid translation.
+Popup is a mini window for rapid translation.
 
-Enable it by click the 💡 (enable scanning) on the toolbar or using the context menu of tray icon.
+Enable it by click the 💡 (enable clipboard trakcing) on the toolbar or using the context menu of tray icon.
 
-When copying text (clipboard changed), the popup will be displayed near your cursor. 
-
+When copying text, a popup window will show up.
 
 ### Linux
 
@@ -15,22 +14,6 @@ On linux/X11, the text selection can also trigger popup window. You have to enab
 
 The popup will also be shown if it is enabled and you use command line `goldendict <word>`.
 
-## Using Popup in conjunction with other applications
+## OCR
 
-!!! note "Help wanted to expand this section"
-
-### capture2text
-
-TODO
-
-### AutoHotKey?
-
-TODO
-
-### macOS applescript? hammerspoon?
-
-TODO
-
-### kde/gnome command shortcuts?
-
-TODO
+See [How to use GoldenDict with OCR](howto/ocr.md).


### PR DESCRIPTION
fix #1808

currently the clipboard still bind with popup which can be in another PR
https://github.com/xiaoyifang/goldendict-ng/blob/c5ce1cae2090566ba87d744b50198c615d41b61c/src/ui/mainwindow.cc#L997-L1001

next time ,the icon 
![image](https://github.com/user-attachments/assets/b378cbcf-cd69-4ca7-bdd0-eb1e0e80a758)
 can be changed also.
