### PR TITLE
clean: delete `MainWindow::fillWordListFromHistory` and  `LangCoder::icon`

### DIFF
--- a/src/langcoder.cc
+++ b/src/langcoder.cc
@@ -215,16 +215,6 @@ bool LangCoder::code2Exists( const QString & _code )
   return LANG_CODE_MAP.contains( _code );
 }
 
-QIcon LangCoder::icon( quint32 _code )
-{
-  if ( auto code = intToCode2( _code ); code2Exists( code ) ) {
-    const GDLangCode & lc = LANG_CODE_MAP[ code ];
-    return QIcon( ":/flags/" + QString( lc.code2 ) + ".png" );
-  }
-
-  return {};
-}
-
 QString LangCoder::intToCode2( quint32 val )
 {
   if ( !val || val == 0xFFffFFff )

--- a/src/langcoder.hh
+++ b/src/langcoder.hh
@@ -47,8 +47,6 @@ public:
 
   /// Returns decoded name of language or empty string if not found.
   static QString decode( quint32 _code );
-  /// Returns icon for language or empty string if not found.
-  static QIcon icon( quint32 code );
 
   /// Return true for RTL languages
   static bool isLanguageRTL( quint32 code );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -3959,25 +3959,6 @@ void MainWindow::on_importFavorites_triggered()
   mainStatusBar->showMessage( tr( "Favorites import complete" ), 5000 );
 }
 
-void MainWindow::fillWordListFromHistory()
-{
-  ui.wordList->setUpdatesEnabled( false );
-  ui.wordList->clear();
-
-  QList< History::Item > const & items = history.getItems();
-  for ( const auto & item : items ) {
-    History::Item const * i = &item;
-    auto s                  = new QListWidgetItem( i->word, ui.wordList );
-    if ( s->text().at( 0 ).direction() == QChar::DirR )
-      s->setTextAlignment( Qt::AlignRight );
-    if ( s->text().at( 0 ).direction() == QChar::DirL )
-      s->setTextAlignment( Qt::AlignLeft );
-    ui.wordList->addItem( s );
-  }
-
-  ui.wordList->setUpdatesEnabled( true );
-}
-
 void MainWindow::focusWordList()
 {
   if ( ui.wordList->count() > 0 )

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -243,8 +243,6 @@ private:
   ArticleView * getCurrentArticleView();
   void ctrlTabPressed();
 
-  void fillWordListFromHistory();
-
   QString unescapeTabHeader( QString const & header );
 
   void respondToTranslationRequest( QString const & word,


### PR DESCRIPTION
* `MainWindow::fillWordListFromHistor` is staff from Qt3 era -> https://github.com/goldendict/goldendict/commit/54bba79c60aacdac451f55ec384f1fede15d7f0b Unused (even in the original GD).
* `LangCoder::icon` leftover of https://github.com/xiaoyifang/goldendict-ng/issues/537