### PR TITLE
clean: mass apply clang-tidy's `readability-braces-around-statements`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -33,7 +33,6 @@ Checks: >
   -modernize-deprecated-headers,
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
-  -readability-braces-around-statements,
   -readability-function-cognitive-complexity,
   -readability-identifier-length,
   -readability-magic-numbers,

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -9,3 +9,6 @@ b5349478cfb0dc2dd0de8c8e8aeebdd24cf7ac6b
 # replace QVector & QPair
 3273f39dd73f4dba07fa95be2be74061f2690b2c
 44853544f850e1de90b341780168c04d089c37a1
+
+# mass apply clang-tidy's readability-braces-around-statements
+a11c9e3aeca4329e1982d8fe26bacbb21ab50ddf

--- a/src/article_netmgr.cc
+++ b/src/article_netmgr.cc
@@ -120,8 +120,9 @@ QNetworkReply * ArticleNetworkAccessManager::getArticleReply( QNetworkRequest co
 
   auto dr = getResource( url, contentType );
 
-  if ( dr.get() )
+  if ( dr.get() ) {
     return new ArticleResourceReply( this, req, dr, contentType );
+  }
 
   //dr.get() can be null. code continue to execute.
 
@@ -214,8 +215,9 @@ sptr< Dictionary::DataRequest > ArticleNetworkAccessManager::getResource( QUrl c
 
     contentType = "text/html";
 
-    if ( Utils::Url::queryItemValue( url, "blank" ) == "1" )
+    if ( Utils::Url::queryItemValue( url, "blank" ) == "1" ) {
       return articleMaker.makeEmptyPage();
+    }
 
     QString word = Utils::Url::queryItemValue( url, "word" ).trimmed();
 
@@ -243,8 +245,9 @@ sptr< Dictionary::DataRequest > ArticleNetworkAccessManager::getResource( QUrl c
 
     bool ignoreDiacritics = Utils::Url::queryItemValue( url, "ignore_diacritics" ) == "1";
 
-    if ( groupIsValid && !word.isEmpty() ) // Require group and phrase to be passed
+    if ( groupIsValid && !word.isEmpty() ) { // Require group and phrase to be passed
       return articleMaker.makeDefinitionFor( word, group, contexts, mutedDicts, QStringList(), ignoreDiacritics );
+    }
   }
 
   if ( ( url.scheme() == "bres" || url.scheme() == "gdau" || url.scheme() == "gdvideo" || url.scheme() == "gico" )
@@ -253,12 +256,12 @@ sptr< Dictionary::DataRequest > ArticleNetworkAccessManager::getResource( QUrl c
 
     QMimeType mineType = db.mimeTypeForUrl( url );
     contentType        = mineType.name();
-    string id = url.host().toStdString();
+    string id          = url.host().toStdString();
 
     bool search = ( id == "search" );
 
     if ( !search ) {
-      for ( const auto & dictionary : dictionaries )
+      for ( const auto & dictionary : dictionaries ) {
         if ( dictionary->getId() == id ) {
           if ( url.scheme() == "gico" ) {
             QByteArray bytes;
@@ -279,6 +282,7 @@ sptr< Dictionary::DataRequest > ArticleNetworkAccessManager::getResource( QUrl c
             return {};
           }
         }
+      }
     }
   }
 
@@ -297,8 +301,9 @@ ArticleResourceReply::ArticleResourceReply( QObject * parent,
   setOpenMode( ReadOnly );
   setUrl( netReq.url() );
 
-  if ( contentType.size() )
+  if ( contentType.size() ) {
     setHeader( QNetworkRequest::ContentTypeHeader, contentType );
+  }
 
   connect( req.get(), &Dictionary::Request::updated, this, &ArticleResourceReply::reqUpdated );
 
@@ -345,8 +350,9 @@ qint64 ArticleResourceReply::bytesAvailable() const
 {
   qint64 const avail = req->dataSize();
 
-  if ( avail < 0 )
+  if ( avail < 0 ) {
     return 0;
+  }
 
   qint64 const availBytes = avail - alreadyRead + QNetworkReply::bytesAvailable();
   if ( availBytes == 0 && !req->isFinished() ) {
@@ -366,22 +372,25 @@ qint64 ArticleResourceReply::readData( char * out, qint64 maxSize )
 {
   // From the doc: "This function might be called with a maxSize of 0,
   // which can be used to perform post-reading operations".
-  if ( maxSize == 0 )
+  if ( maxSize == 0 ) {
     return 0;
+  }
 
   bool const finished = req->isFinished();
 
   qint64 const avail = req->dataSize();
 
-  if ( avail < 0 )
+  if ( avail < 0 ) {
     return finished ? -1 : 0;
+  }
 
 
   qint64 const left = avail - alreadyRead;
 
   qint64 const toRead = maxSize < left ? maxSize : left;
-  if ( !toRead && finished )
+  if ( !toRead && finished ) {
     return -1;
+  }
   GD_DPRINTF( "====reading  %d of (%lld) bytes . Finished: %d", (int)toRead, avail, finished );
 
   try {
@@ -393,10 +402,12 @@ qint64 ArticleResourceReply::readData( char * out, qint64 maxSize )
 
   alreadyRead += toRead;
 
-  if ( !toRead && finished )
+  if ( !toRead && finished ) {
     return -1;
-  else
+  }
+  else {
     return toRead;
+  }
 }
 
 void ArticleResourceReply::readyReadSlot()

--- a/src/audiolink.cc
+++ b/src/audiolink.cc
@@ -11,8 +11,9 @@ std::string addAudioLink( std::string const & url, std::string const & dictionar
 
 std::string addAudioLink( QString const & url, std::string const & dictionaryId )
 {
-  if ( url.isEmpty() || url.length() < 2 )
+  if ( url.isEmpty() || url.length() < 2 ) {
     return {};
+  }
   GlobalBroadcaster::instance()->pronounce_engine.sendAudio( dictionaryId, url.mid( 1, url.length() - 2 ) );
 
   return std::string( "<script type=\"text/javascript\">" + makeAudioLinkScript( url.toStdString(), dictionaryId )
@@ -31,8 +32,9 @@ std::string makeAudioLinkScript( std::string const & url, std::string const & di
       escaped = false;
       continue;
     }
-    if ( ch == '\'' )
+    if ( ch == '\'' ) {
       ref += '\\';
+    }
     ref += ch;
     escaped = ( ch == '\\' );
   }

--- a/src/audiooutput.cc
+++ b/src/audiooutput.cc
@@ -53,7 +53,7 @@ public:
 #if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
   using AudioOutput = QAudioOutput;
 #else
-  using AudioOutput      = QAudioSink;
+  using AudioOutput = QAudioSink;
 #endif
   AudioOutput * audioOutput = nullptr;
   QByteArray buffer;
@@ -73,18 +73,21 @@ public:
 
   qint64 readData( char * data, qint64 len ) override
   {
-    if ( !len )
+    if ( !len ) {
       return 0;
+    }
 
     QMutexLocker locker( &mutex );
     qint64 bytesWritten = 0;
     while ( len && !quit ) {
       if ( buffer.isEmpty() ) {
         // Wait for more frames
-        if ( bytesWritten == 0 )
+        if ( bytesWritten == 0 ) {
           cond.wait( &mutex );
-        if ( buffer.isEmpty() )
+        }
+        if ( buffer.isEmpty() ) {
           break;
+        }
       }
 
       auto sampleData   = buffer.data();
@@ -123,8 +126,9 @@ public:
   {
     if ( !audioOutput || ( fmt.isValid() && audioOutput->format() != fmt )
          || audioOutput->state() == QAudio::StoppedState ) {
-      if ( audioOutput )
+      if ( audioOutput ) {
         audioOutput->deleteLater();
+      }
       audioOutput = new AudioOutput( fmt );
       QObject::connect( audioOutput, &AudioOutput::stateChanged, audioOutput, [ & ]( QAudio::State state ) {
         switch ( state ) {
@@ -141,8 +145,9 @@ public:
       } );
 
       audioOutput->start( this );
-      if ( audioOutput && audioOutput->state() == QAudio::StoppedState )
+      if ( audioOutput && audioOutput->state() == QAudio::StoppedState ) {
         quit = true;
+      }
     }
 
     //    audioOutput->setVolume(volume);
@@ -155,8 +160,9 @@ public:
       cond.wait( &mutex, 10 );
       auto fmt = sampleRate == 0 ? QAudioFormat() : format( sampleRate, channels );
       locker.unlock();
-      if ( fmt.isValid() )
+      if ( fmt.isValid() ) {
         init( fmt );
+      }
       QCoreApplication::processEvents();
     }
     if ( audioOutput ) {
@@ -202,8 +208,9 @@ AudioOutput::~AudioOutput()
 bool AudioOutput::play( const uint8_t * data, qint64 len )
 {
   Q_D( AudioOutput );
-  if ( d->quit )
+  if ( d->quit ) {
     return false;
+  }
 
   QMutexLocker locker( &d->mutex );
   auto cuint = const_cast< uint8_t * >( data );

--- a/src/audioplayerfactory.cc
+++ b/src/audioplayerfactory.cc
@@ -32,10 +32,12 @@ void AudioPlayerFactory::setPreferences( Config::Preferences const & p )
   else if ( !useInternalPlayer && p.audioPlaybackProgram != audioPlaybackProgram ) {
     audioPlaybackProgram                       = p.audioPlaybackProgram;
     ExternalAudioPlayer * const externalPlayer = qobject_cast< ExternalAudioPlayer * >( playerPtr.data() );
-    if ( externalPlayer )
+    if ( externalPlayer ) {
       setAudioPlaybackProgram( *externalPlayer );
-    else
+    }
+    else {
       gdWarning( "External player was expected, but it does not exist.\n" );
+    }
   }
 }
 
@@ -52,15 +54,17 @@ void AudioPlayerFactory::reset()
               && "Adjust the code below after changing the default backend." );
 
     if ( !internalPlayerBackend.isQtmultimedia() ) {
-      if ( !playerPtr || !qobject_cast< Ffmpeg::AudioPlayer * >( playerPtr.data() ) )
+      if ( !playerPtr || !qobject_cast< Ffmpeg::AudioPlayer * >( playerPtr.data() ) ) {
         playerPtr.reset( new Ffmpeg::AudioPlayer );
+      }
       return;
     }
 #endif
 
 #ifdef MAKE_QTMULTIMEDIA_PLAYER
-    if ( !playerPtr || !qobject_cast< MultimediaAudioPlayer * >( playerPtr.data() ) )
+    if ( !playerPtr || !qobject_cast< MultimediaAudioPlayer * >( playerPtr.data() ) ) {
       playerPtr.reset( new MultimediaAudioPlayer );
+    }
     return;
 #endif
   }

--- a/src/common/filetype.cc
+++ b/src/common/filetype.cc
@@ -26,21 +26,25 @@ string simplifyString( string const & str, bool lowercase )
 
   size_t beginPos = 0;
 
-  while ( beginPos < str.size() && Utf8::isspace( str[ beginPos ] ) )
+  while ( beginPos < str.size() && Utf8::isspace( str[ beginPos ] ) ) {
     ++beginPos;
+  }
 
   size_t endPos = str.size();
 
-  while ( endPos && Utf8::isspace( str[ endPos - 1 ] ) )
+  while ( endPos && Utf8::isspace( str[ endPos - 1 ] ) ) {
     --endPos;
+  }
 
-  if ( endPos <= beginPos )
+  if ( endPos <= beginPos ) {
     return string();
+  }
 
   result.reserve( endPos - beginPos );
 
-  while ( beginPos < endPos )
+  while ( beginPos < endPos ) {
     result.push_back( lowercase ? tolower( str[ beginPos++ ] ) : str[ beginPos++ ] );
+  }
 
   return result;
 }

--- a/src/common/folding.cc
+++ b/src/common/folding.cc
@@ -51,8 +51,9 @@ wstring apply( wstring const & in, bool preserveWildcards )
 
   wchar buf[ foldCaseMaxOut ];
 
-  for ( size_t left = withoutDiacritics.size(); left--; )
+  for ( size_t left = withoutDiacritics.size(); left--; ) {
     caseFolded.append( buf, foldCase( *nextChar++, buf ) );
+  }
 
   return caseFolded;
 }
@@ -65,8 +66,9 @@ wstring applySimpleCaseOnly( wstring const & in )
 
   out.reserve( in.size() );
 
-  for ( size_t left = in.size(); left--; )
+  for ( size_t left = in.size(); left--; ) {
     out.push_back( foldCaseSimple( *nextChar++ ) );
+  }
 
   return out;
 }
@@ -93,8 +95,9 @@ wstring applyFullCaseOnly( wstring const & in )
 
   wchar buf[ foldCaseMaxOut ];
 
-  for ( size_t left = in.size(); left--; )
+  for ( size_t left = in.size(); left--; ) {
     caseFolded.append( buf, foldCase( *nextChar++, buf ) );
+  }
 
   return caseFolded;
 }
@@ -113,9 +116,11 @@ wstring applyPunctOnly( wstring const & in )
 
   out.reserve( in.size() );
 
-  for ( size_t left = in.size(); left--; ++nextChar )
-    if ( !isPunct( *nextChar ) )
+  for ( size_t left = in.size(); left--; ++nextChar ) {
+    if ( !isPunct( *nextChar ) ) {
       out.push_back( *nextChar );
+    }
+  }
 
   return out;
 }
@@ -123,9 +128,11 @@ wstring applyPunctOnly( wstring const & in )
 QString applyPunctOnly( QString const & in )
 {
   QString out;
-  for ( auto c : in )
-    if ( !c.isPunct() )
+  for ( auto c : in ) {
+    if ( !c.isPunct() ) {
       out.push_back( c );
+    }
+  }
 
   return out;
 }
@@ -138,9 +145,11 @@ wstring applyWhitespaceOnly( wstring const & in )
 
   out.reserve( in.size() );
 
-  for ( size_t left = in.size(); left--; ++nextChar )
-    if ( !isWhitespace( *nextChar ) )
+  for ( size_t left = in.size(); left--; ++nextChar ) {
+    if ( !isWhitespace( *nextChar ) ) {
       out.push_back( *nextChar );
+    }
+  }
 
   return out;
 }
@@ -154,8 +163,9 @@ wstring applyWhitespaceAndPunctOnly( wstring const & in )
   out.reserve( in.size() );
 
   for ( size_t left = in.size(); left--; ++nextChar ) {
-    if ( !isWhitespaceOrPunct( *nextChar ) )
+    if ( !isWhitespaceOrPunct( *nextChar ) ) {
       out.push_back( *nextChar );
+    }
   }
 
   return out;
@@ -189,8 +199,9 @@ wstring trimWhitespaceOrPunct( wstring const & in )
   }
 
   // Skip any trailing whitespace
-  while ( wordSize && Folding::isWhitespaceOrPunct( wordBegin[ wordSize - 1 ] ) )
+  while ( wordSize && Folding::isWhitespaceOrPunct( wordBegin[ wordSize - 1 ] ) ) {
     --wordSize;
+  }
 
   return wstring( wordBegin, wordSize );
 }
@@ -218,8 +229,9 @@ QString trimWhitespaceOrPunct( QString const & in )
 
 wstring trimWhitespace( wstring const & in )
 {
-  if ( in.empty() )
+  if ( in.empty() ) {
     return in;
+  }
   wchar const * wordBegin     = in.c_str();
   wstring::size_type wordSize = in.size();
 
@@ -230,8 +242,9 @@ wstring trimWhitespace( wstring const & in )
   }
 
   // Skip any trailing whitespace
-  while ( wordSize && Folding::isWhitespace( wordBegin[ wordSize - 1 ] ) )
+  while ( wordSize && Folding::isWhitespace( wordBegin[ wordSize - 1 ] ) ) {
     --wordSize;
+  }
 
   return wstring( wordBegin, wordSize );
 }

--- a/src/common/htmlescape.cc
+++ b/src/common/htmlescape.cc
@@ -14,7 +14,7 @@ string escape( string const & str )
 {
   string result( str );
 
-  for ( size_t x = result.size(); x--; )
+  for ( size_t x = result.size(); x--; ) {
     switch ( result[ x ] ) {
       case '&':
         result.erase( x, 1 );
@@ -39,6 +39,7 @@ string escape( string const & str )
       default:
         break;
     }
+  }
 
   return result;
 }
@@ -82,16 +83,18 @@ string preformat( string const & str, bool baseRightToLeft )
       continue;
     }
 
-    if ( *nextChar == '\r' )
+    if ( *nextChar == '\r' ) {
       continue; // Just skip all \r
+    }
 
     line.push_back( *nextChar );
 
     leading = false;
   }
 
-  if ( !line.empty() )
+  if ( !line.empty() ) {
     storeLineInDiv( result, line, baseRightToLeft );
+  }
 
   return result;
 }
@@ -100,7 +103,7 @@ string escapeForJavaScript( string const & str )
 {
   string result( str );
 
-  for ( size_t x = result.size(); x--; )
+  for ( size_t x = result.size(); x--; ) {
     switch ( result[ x ] ) {
       case '\\':
       case '"':
@@ -126,6 +129,7 @@ string escapeForJavaScript( string const & str )
       default:
         break;
     }
+  }
 
   return result;
 }

--- a/src/common/iconv.cc
+++ b/src/common/iconv.cc
@@ -14,8 +14,9 @@ char const * const Iconv::Utf8    = "UTF-8";
 Iconv::Iconv( char const * from ):
   state( iconv_open( Utf8, from ) )
 {
-  if ( state == (iconv_t)-1 )
+  if ( state == (iconv_t)-1 ) {
     throw exCantInit( strerror( errno ) );
+  }
 }
 
 Iconv::~Iconv()

--- a/src/common/utf8.cc
+++ b/src/common/utf8.cc
@@ -14,8 +14,9 @@ size_t encode( wchar const * in, size_t inSize, char * out_ )
   unsigned char * out = (unsigned char *)out_;
 
   while ( inSize-- ) {
-    if ( *in < 0x80 )
+    if ( *in < 0x80 ) {
       *out++ = *in++;
+    }
     else if ( *in < 0x800 ) {
       *out++ = 0xC0 | ( *in >> 6 );
       *out++ = 0x80 | ( *in++ & 0x3F );
@@ -49,59 +50,69 @@ long decode( char const * in_, size_t inSize, wchar * out_ )
         if ( *in & 0x20 ) {
           if ( *in & 0x10 ) {
             // Four-byte sequence
-            if ( *in & 8 )
+            if ( *in & 8 ) {
               // This can't be
               return -1;
+            }
 
-            if ( inSize < 3 )
+            if ( inSize < 3 ) {
               return -1;
+            }
 
             inSize -= 3;
 
             result = ( (wchar)*in++ & 7 ) << 18;
 
-            if ( ( *in & 0xC0 ) != 0x80 )
+            if ( ( *in & 0xC0 ) != 0x80 ) {
               return -1;
+            }
             result |= ( (wchar)*in++ & 0x3F ) << 12;
 
-            if ( ( *in & 0xC0 ) != 0x80 )
+            if ( ( *in & 0xC0 ) != 0x80 ) {
               return -1;
+            }
             result |= ( (wchar)*in++ & 0x3F ) << 6;
 
-            if ( ( *in & 0xC0 ) != 0x80 )
+            if ( ( *in & 0xC0 ) != 0x80 ) {
               return -1;
+            }
             result |= (wchar)*in++ & 0x3F;
           }
           else {
             // Three-byte sequence
 
-            if ( inSize < 2 )
+            if ( inSize < 2 ) {
               return -1;
+            }
 
             inSize -= 2;
 
             result = ( (wchar)*in++ & 0xF ) << 12;
 
-            if ( ( *in & 0xC0 ) != 0x80 )
+            if ( ( *in & 0xC0 ) != 0x80 ) {
               return -1;
+            }
             result |= ( (wchar)*in++ & 0x3F ) << 6;
 
-            if ( ( *in & 0xC0 ) != 0x80 )
+            if ( ( *in & 0xC0 ) != 0x80 ) {
               return -1;
+            }
             result |= (wchar)*in++ & 0x3F;
           }
         }
         else {
           // Two-byte sequence
-          if ( !inSize )
+          if ( !inSize ) {
             return -1;
+          }
 
           --inSize;
 
           result = ( (wchar)*in++ & 0x1F ) << 6;
 
-          if ( ( *in & 0xC0 ) != 0x80 )
+          if ( ( *in & 0xC0 ) != 0x80 ) {
             return -1;
+          }
           result |= (wchar)*in++ & 0x3F;
         }
       }
@@ -110,9 +121,10 @@ long decode( char const * in_, size_t inSize, wchar * out_ )
         return -1;
       }
     }
-    else
+    else {
       // One-byte encoding
       result = *in++;
+    }
 
     *out++ = result;
   }
@@ -122,8 +134,9 @@ long decode( char const * in_, size_t inSize, wchar * out_ )
 
 string encode( wstring const & in ) noexcept
 {
-  if ( in.empty() )
+  if ( in.empty() ) {
     return {};
+  }
 
   std::vector< char > buffer( in.size() * 4 );
 
@@ -132,15 +145,17 @@ string encode( wstring const & in ) noexcept
 
 wstring decode( string const & in )
 {
-  if ( in.empty() )
+  if ( in.empty() ) {
     return {};
+  }
 
   std::vector< wchar > buffer( in.size() );
 
   long result = decode( in.data(), in.size(), &buffer.front() );
 
-  if ( result < 0 )
+  if ( result < 0 ) {
     throw exCantDecode( in );
+  }
 
   return wstring( &buffer.front(), result );
 }
@@ -166,8 +181,9 @@ int findFirstLinePosition( char * s1, int s1length, const char * s2, int s2lengt
 {
   char * pos = std::search( s1, s1 + s1length, s2, s2 + s2length );
 
-  if ( pos == s1 + s1length )
+  if ( pos == s1 + s1length ) {
     return pos - s1;
+  }
 
   //the line size.
   return pos - s1 + s2length;
@@ -200,22 +216,30 @@ char const * getEncodingNameFor( Encoding e )
 Encoding getEncodingForName( const QByteArray & _name )
 {
   const auto name = _name.toUpper();
-  if ( name == "UTF-32LE" )
+  if ( name == "UTF-32LE" ) {
     return Utf32LE;
-  if ( name == "UTF-32BE" )
+  }
+  if ( name == "UTF-32BE" ) {
     return Utf32BE;
-  if ( name == "UTF-16LE" )
+  }
+  if ( name == "UTF-16LE" ) {
     return Utf16LE;
-  if ( name == "UTF-16BE" )
+  }
+  if ( name == "UTF-16BE" ) {
     return Utf16BE;
-  if ( name == "WINDOWS-1252" )
+  }
+  if ( name == "WINDOWS-1252" ) {
     return Windows1252;
-  if ( name == "WINDOWS-1251" )
+  }
+  if ( name == "WINDOWS-1251" ) {
     return Windows1251;
-  if ( name == "UTF-8" )
+  }
+  if ( name == "UTF-8" ) {
     return Utf8;
-  if ( name == "WINDOWS-1250" )
+  }
+  if ( name == "WINDOWS-1250" ) {
     return Windows1250;
+  }
   return Utf8;
 }
 

--- a/src/common/utils.cc
+++ b/src/common/utils.cc
@@ -100,8 +100,9 @@ std::string basename( std::string const & str )
 {
   size_t x = str.rfind( separator() );
 
-  if ( x == std::string::npos )
+  if ( x == std::string::npos ) {
     return str;
+  }
 
   return std::string( str, x + 1 );
 }

--- a/src/common/wstring_qt.cc
+++ b/src/common/wstring_qt.cc
@@ -12,8 +12,9 @@ wstring toWString( QString const & in )
 wstring removeTrailingZero( wstring const & v )
 {
   int n = v.size();
-  while ( n > 0 && v[ n - 1 ] == 0 )
+  while ( n > 0 && v[ n - 1 ] == 0 ) {
     n--;
+  }
   return wstring( v.data(), n );
 }
 
@@ -22,10 +23,12 @@ wstring removeTrailingZero( QString const & in )
   QList< unsigned int > v = in.toUcs4();
 
   int n = v.size();
-  while ( n > 0 && v[ n - 1 ] == 0 )
+  while ( n > 0 && v[ n - 1 ] == 0 ) {
     n--;
-  if ( n != v.size() )
+  }
+  if ( n != v.size() ) {
     v.resize( n );
+  }
 
   return wstring( (const wchar *)v.constData(), v.size() );
 }

--- a/src/config.cc
+++ b/src/config.cc
@@ -50,8 +50,9 @@ QString portableHomeDirPath()
 
 QDir getHomeDir()
 {
-  if ( isPortableVersion() )
+  if ( isPortableVersion() ) {
     return QDir( portableHomeDirPath() );
+  }
 
   QDir result;
 
@@ -74,8 +75,9 @@ QDir getHomeDir()
 
   result.mkpath( pathInHome );
 
-  if ( !result.cd( pathInHome ) )
+  if ( !result.cd( pathInHome ) ) {
     throw exCantUseHomeDir();
+  }
 
   return result;
 }
@@ -290,17 +292,21 @@ Romaji::Romaji():
 
 Group * Class::getGroup( unsigned id )
 {
-  for ( auto & group : groups )
-    if ( group.id == id )
+  for ( auto & group : groups ) {
+    if ( group.id == id ) {
       return &group;
+    }
+  }
   return 0;
 }
 
 Group const * Class::getGroup( unsigned id ) const
 {
-  for ( const auto & group : groups )
-    if ( group.id == id )
+  for ( const auto & group : groups ) {
+    if ( group.id == id ) {
       return &group;
+    }
+  }
   return 0;
 }
 
@@ -432,45 +438,54 @@ void applyBoolOption( bool & option, QDomNode const & node )
 {
   QString value = node.toElement().text();
 
-  if ( value == "1" )
+  if ( value == "1" ) {
     option = true;
-  else if ( value == "0" )
+  }
+  else if ( value == "0" ) {
     option = false;
+  }
 }
 
 Group loadGroup( QDomElement grp, unsigned * nextId = 0 )
 {
   Group g;
 
-  if ( grp.hasAttribute( "id" ) )
+  if ( grp.hasAttribute( "id" ) ) {
     g.id = grp.attribute( "id" ).toUInt();
-  else
+  }
+  else {
     g.id = nextId ? ( *nextId )++ : 0;
+  }
 
   g.name            = grp.attribute( "name" );
   g.icon            = grp.attribute( "icon" );
   g.favoritesFolder = grp.attribute( "favoritesFolder" );
 
-  if ( !grp.attribute( "iconData" ).isEmpty() )
+  if ( !grp.attribute( "iconData" ).isEmpty() ) {
     g.iconData = QByteArray::fromBase64( grp.attribute( "iconData" ).toLatin1() );
+  }
 
-  if ( !grp.attribute( "shortcut" ).isEmpty() )
+  if ( !grp.attribute( "shortcut" ).isEmpty() ) {
     g.shortcut = QKeySequence::fromString( grp.attribute( "shortcut" ) );
+  }
 
   QDomNodeList dicts = grp.elementsByTagName( "dictionary" );
 
-  for ( int y = 0; y < dicts.length(); ++y )
+  for ( int y = 0; y < dicts.length(); ++y ) {
     g.dictionaries.push_back(
       DictionaryRef( dicts.item( y ).toElement().text(), dicts.item( y ).toElement().attribute( "name" ) ) );
+  }
 
   QDomNode muted = grp.namedItem( "mutedDictionaries" );
   dicts          = muted.toElement().elementsByTagName( "mutedDictionary" );
-  for ( int x = 0; x < dicts.length(); ++x )
+  for ( int x = 0; x < dicts.length(); ++x ) {
     g.mutedDictionaries.insert( dicts.item( x ).toElement().text() );
+  }
 
   dicts = muted.toElement().elementsByTagName( "popupMutedDictionary" );
-  for ( int x = 0; x < dicts.length(); ++x )
+  for ( int x = 0; x < dicts.length(); ++x ) {
     g.popupMutedDictionaries.insert( dicts.item( x ).toElement().text() );
+  }
 
   return g;
 }
@@ -482,8 +497,9 @@ MutedDictionaries loadMutedDictionaries( const QDomNode & mutedDictionaries )
   if ( !mutedDictionaries.isNull() ) {
     QDomNodeList nl = mutedDictionaries.toElement().elementsByTagName( "mutedDictionary" );
 
-    for ( int x = 0; x < nl.length(); ++x )
+    for ( int x = 0; x < nl.length(); ++x ) {
       result.insert( nl.item( x ).toElement().text() );
+    }
   }
 
   return result;
@@ -504,8 +520,9 @@ void saveMutedDictionaries( QDomDocument & dd, QDomElement & muted, MutedDiction
 
 bool fromConfig2Preference( const QDomNode & node, const QString & expectedValue, bool defaultValue = false )
 {
-  if ( !node.isNull() )
+  if ( !node.isNull() ) {
     return ( node.toElement().text() == expectedValue );
+  }
   return defaultValue;
 }
 
@@ -547,8 +564,9 @@ Class load()
 
     QString possibleMorphologyPath = getProgramDataDir() + "/content/morphology";
 
-    if ( QDir( possibleMorphologyPath ).exists() )
+    if ( QDir( possibleMorphologyPath ).exists() ) {
       c.hunspell.dictionariesPath = possibleMorphologyPath;
+    }
 
     c.mediawikis  = makeDefaultMediaWikis( true );
     c.webSites    = makeDefaultWebSites();
@@ -571,8 +589,9 @@ Class load()
 
   QFile configFile( configName );
 
-  if ( !configFile.open( QFile::ReadOnly ) )
+  if ( !configFile.open( QFile::ReadOnly ) ) {
     throw exCantReadConfigFile();
+  }
 
   QDomDocument dd;
 
@@ -611,9 +630,10 @@ Class load()
   if ( !paths.isNull() ) {
     QDomNodeList nl = paths.toElement().elementsByTagName( "path" );
 
-    for ( int x = 0; x < nl.length(); ++x )
+    for ( int x = 0; x < nl.length(); ++x ) {
       c.paths.push_back(
         Path( nl.item( x ).toElement().text(), nl.item( x ).toElement().attribute( "recursive" ) == "1" ) );
+    }
   }
 
   if ( Config::isPortableVersion() && c.paths.empty() ) {
@@ -626,21 +646,24 @@ Class load()
   if ( !soundDirs.isNull() ) {
     QDomNodeList nl = soundDirs.toElement().elementsByTagName( "sounddir" );
 
-    for ( int x = 0; x < nl.length(); ++x )
+    for ( int x = 0; x < nl.length(); ++x ) {
       c.soundDirs.push_back( SoundDir( nl.item( x ).toElement().text(),
                                        nl.item( x ).toElement().attribute( "name" ),
                                        nl.item( x ).toElement().attribute( "icon" ) ) );
+    }
   }
 
   QDomNode dictionaryOrder = root.namedItem( "dictionaryOrder" );
 
-  if ( !dictionaryOrder.isNull() )
+  if ( !dictionaryOrder.isNull() ) {
     c.dictionaryOrder = loadGroup( dictionaryOrder.toElement() );
+  }
 
   QDomNode inactiveDictionaries = root.namedItem( "inactiveDictionaries" );
 
-  if ( !inactiveDictionaries.isNull() )
+  if ( !inactiveDictionaries.isNull() ) {
     c.inactiveDictionaries = loadGroup( inactiveDictionaries.toElement() );
+  }
 
   QDomNode groups = root.namedItem( "groups" );
 
@@ -663,8 +686,9 @@ Class load()
 
     QDomNodeList nl = hunspell.toElement().elementsByTagName( "enabled" );
 
-    for ( int x = 0; x < nl.length(); ++x )
+    for ( int x = 0; x < nl.length(); ++x ) {
       c.hunspell.enabledDictionaries.push_back( nl.item( x ).toElement().text() );
+    }
   }
 
   QDomNode transliteration = root.namedItem( "transliteration" );
@@ -731,8 +755,9 @@ Class load()
     c.forvo.apiKey        = forvo.namedItem( "apiKey" ).toElement().text();
     c.forvo.languageCodes = forvo.namedItem( "languageCodes" ).toElement().text();
   }
-  else
+  else {
     c.forvo.languageCodes = "en, ru"; // Default demo values
+  }
 
   QDomNode programs = root.namedItem( "programs" );
 
@@ -895,45 +920,56 @@ Class load()
       c.preferences.customFonts = fonts;
     }
 
-    if ( !preferences.namedItem( "doubleClickTranslates" ).isNull() )
+    if ( !preferences.namedItem( "doubleClickTranslates" ).isNull() ) {
       c.preferences.doubleClickTranslates =
         ( preferences.namedItem( "doubleClickTranslates" ).toElement().text() == "1" );
+    }
 
-    if ( !preferences.namedItem( "selectWordBySingleClick" ).isNull() )
+    if ( !preferences.namedItem( "selectWordBySingleClick" ).isNull() ) {
       c.preferences.selectWordBySingleClick =
         ( preferences.namedItem( "selectWordBySingleClick" ).toElement().text() == "1" );
+    }
 
-    if ( !preferences.namedItem( "autoScrollToTargetArticle" ).isNull() )
+    if ( !preferences.namedItem( "autoScrollToTargetArticle" ).isNull() ) {
       c.preferences.autoScrollToTargetArticle =
         ( preferences.namedItem( "autoScrollToTargetArticle" ).toElement().text() == "1" );
+    }
 
-    if ( !preferences.namedItem( "escKeyHidesMainWindow" ).isNull() )
+    if ( !preferences.namedItem( "escKeyHidesMainWindow" ).isNull() ) {
       c.preferences.escKeyHidesMainWindow =
         ( preferences.namedItem( "escKeyHidesMainWindow" ).toElement().text() == "1" );
+    }
 
-    if ( !preferences.namedItem( "darkMode" ).isNull() )
+    if ( !preferences.namedItem( "darkMode" ).isNull() ) {
       c.preferences.darkMode = ( preferences.namedItem( "darkMode" ).toElement().text() == "1" );
+    }
 
-    if ( !preferences.namedItem( "darkReaderMode" ).isNull() )
+    if ( !preferences.namedItem( "darkReaderMode" ).isNull() ) {
       c.preferences.darkReaderMode = ( preferences.namedItem( "darkReaderMode" ).toElement().text() == "1" );
+    }
 
-    if ( !preferences.namedItem( "zoomFactor" ).isNull() )
+    if ( !preferences.namedItem( "zoomFactor" ).isNull() ) {
       c.preferences.zoomFactor = preferences.namedItem( "zoomFactor" ).toElement().text().toDouble();
+    }
 
-    if ( !preferences.namedItem( "helpZoomFactor" ).isNull() )
+    if ( !preferences.namedItem( "helpZoomFactor" ).isNull() ) {
       c.preferences.helpZoomFactor = preferences.namedItem( "helpZoomFactor" ).toElement().text().toDouble();
+    }
 
-    if ( !preferences.namedItem( "wordsZoomLevel" ).isNull() )
+    if ( !preferences.namedItem( "wordsZoomLevel" ).isNull() ) {
       c.preferences.wordsZoomLevel = preferences.namedItem( "wordsZoomLevel" ).toElement().text().toInt();
+    }
 
     applyBoolOption( c.preferences.enableMainWindowHotkey, preferences.namedItem( "enableMainWindowHotkey" ) );
-    if ( !preferences.namedItem( "mainWindowHotkey" ).isNull() )
+    if ( !preferences.namedItem( "mainWindowHotkey" ).isNull() ) {
       c.preferences.mainWindowHotkey =
         QKeySequence::fromString( preferences.namedItem( "mainWindowHotkey" ).toElement().text() );
+    }
     applyBoolOption( c.preferences.enableClipboardHotkey, preferences.namedItem( "enableClipboardHotkey" ) );
-    if ( !preferences.namedItem( "clipboardHotkey" ).isNull() )
+    if ( !preferences.namedItem( "clipboardHotkey" ).isNull() ) {
       c.preferences.clipboardHotkey =
         QKeySequence::fromString( preferences.namedItem( "clipboardHotkey" ).toElement().text() );
+    }
 
     c.preferences.startWithScanPopupOn = ( preferences.namedItem( "startWithScanPopupOn" ).toElement().text() == "1" );
     c.preferences.enableScanPopupModifiers =
@@ -943,8 +979,9 @@ Class load()
       ( preferences.namedItem( "ignoreOwnClipboardChanges" ).toElement().text() == "1" );
     c.preferences.scanToMainWindow = ( preferences.namedItem( "scanToMainWindow" ).toElement().text() == "1" );
     c.preferences.ignoreDiacritics = ( preferences.namedItem( "ignoreDiacritics" ).toElement().text() == "1" );
-    if ( !preferences.namedItem( "ignorePunctuation" ).isNull() )
+    if ( !preferences.namedItem( "ignorePunctuation" ).isNull() ) {
       c.preferences.ignorePunctuation = ( preferences.namedItem( "ignorePunctuation" ).toElement().text() == "1" );
+    }
 
     if ( !preferences.namedItem( "sessionCollapse" ).isNull() ) {
       c.preferences.sessionCollapse = ( preferences.namedItem( "sessionCollapse" ).toElement().text() == "1" );
@@ -962,20 +999,25 @@ Class load()
     c.preferences.pronounceOnLoadPopup = ( preferences.namedItem( "pronounceOnLoadPopup" ).toElement().text() == "1" );
 
     if ( InternalPlayerBackend::anyAvailable() ) {
-      if ( !preferences.namedItem( "useInternalPlayer" ).isNull() )
+      if ( !preferences.namedItem( "useInternalPlayer" ).isNull() ) {
         c.preferences.useInternalPlayer = ( preferences.namedItem( "useInternalPlayer" ).toElement().text() == "1" );
+      }
     }
-    else
+    else {
       c.preferences.useInternalPlayer = false;
+    }
 
-    if ( !preferences.namedItem( "internalPlayerBackend" ).isNull() )
+    if ( !preferences.namedItem( "internalPlayerBackend" ).isNull() ) {
       c.preferences.internalPlayerBackend.setUiName(
         preferences.namedItem( "internalPlayerBackend" ).toElement().text() );
+    }
 
-    if ( !preferences.namedItem( "audioPlaybackProgram" ).isNull() )
+    if ( !preferences.namedItem( "audioPlaybackProgram" ).isNull() ) {
       c.preferences.audioPlaybackProgram = preferences.namedItem( "audioPlaybackProgram" ).toElement().text();
-    else
+    }
+    else {
       c.preferences.audioPlaybackProgram = "mplayer";
+    }
 
     QDomNode proxy = preferences.namedItem( "proxyserver" );
 
@@ -1005,102 +1047,129 @@ Class load()
       c.preferences.ankiConnectServer.sentence = ankiConnectServer.namedItem( "sentence" ).toElement().text();
     }
 
-    if ( !preferences.namedItem( "checkForNewReleases" ).isNull() )
+    if ( !preferences.namedItem( "checkForNewReleases" ).isNull() ) {
       c.preferences.checkForNewReleases = ( preferences.namedItem( "checkForNewReleases" ).toElement().text() == "1" );
+    }
 
-    if ( !preferences.namedItem( "disallowContentFromOtherSites" ).isNull() )
+    if ( !preferences.namedItem( "disallowContentFromOtherSites" ).isNull() ) {
       c.preferences.disallowContentFromOtherSites =
         ( preferences.namedItem( "disallowContentFromOtherSites" ).toElement().text() == "1" );
+    }
 
-    if ( !preferences.namedItem( "hideGoldenDictHeader" ).isNull() )
+    if ( !preferences.namedItem( "hideGoldenDictHeader" ).isNull() ) {
       c.preferences.hideGoldenDictHeader =
         ( preferences.namedItem( "hideGoldenDictHeader" ).toElement().text() == "1" );
+    }
 
-    if ( !preferences.namedItem( "maxNetworkCacheSize" ).isNull() )
+    if ( !preferences.namedItem( "maxNetworkCacheSize" ).isNull() ) {
       c.preferences.maxNetworkCacheSize = preferences.namedItem( "maxNetworkCacheSize" ).toElement().text().toInt();
+    }
 
-    if ( !preferences.namedItem( "clearNetworkCacheOnExit" ).isNull() )
+    if ( !preferences.namedItem( "clearNetworkCacheOnExit" ).isNull() ) {
       c.preferences.clearNetworkCacheOnExit =
         ( preferences.namedItem( "clearNetworkCacheOnExit" ).toElement().text() == "1" );
+    }
 
 
-    if ( !preferences.namedItem( "removeInvalidIndexOnExit" ).isNull() )
+    if ( !preferences.namedItem( "removeInvalidIndexOnExit" ).isNull() ) {
       c.preferences.removeInvalidIndexOnExit =
         ( preferences.namedItem( "removeInvalidIndexOnExit" ).toElement().text() == "1" );
+    }
 
-    if ( !preferences.namedItem( "maxStringsInHistory" ).isNull() )
+    if ( !preferences.namedItem( "maxStringsInHistory" ).isNull() ) {
       c.preferences.maxStringsInHistory = preferences.namedItem( "maxStringsInHistory" ).toElement().text().toUInt();
+    }
 
-    if ( !preferences.namedItem( "storeHistory" ).isNull() )
+    if ( !preferences.namedItem( "storeHistory" ).isNull() ) {
       c.preferences.storeHistory = preferences.namedItem( "storeHistory" ).toElement().text().toUInt();
+    }
 
-    if ( !preferences.namedItem( "alwaysExpandOptionalParts" ).isNull() )
+    if ( !preferences.namedItem( "alwaysExpandOptionalParts" ).isNull() ) {
       c.preferences.alwaysExpandOptionalParts =
         preferences.namedItem( "alwaysExpandOptionalParts" ).toElement().text().toUInt();
+    }
 
-    if ( !preferences.namedItem( "addonStyle" ).isNull() )
+    if ( !preferences.namedItem( "addonStyle" ).isNull() ) {
       c.preferences.addonStyle = preferences.namedItem( "addonStyle" ).toElement().text();
+    }
 
-    if ( !preferences.namedItem( "historyStoreInterval" ).isNull() )
+    if ( !preferences.namedItem( "historyStoreInterval" ).isNull() ) {
       c.preferences.historyStoreInterval = preferences.namedItem( "historyStoreInterval" ).toElement().text().toUInt();
+    }
 
-    if ( !preferences.namedItem( "favoritesStoreInterval" ).isNull() )
+    if ( !preferences.namedItem( "favoritesStoreInterval" ).isNull() ) {
       c.preferences.favoritesStoreInterval =
         preferences.namedItem( "favoritesStoreInterval" ).toElement().text().toUInt();
+    }
 
-    if ( !preferences.namedItem( "confirmFavoritesDeletion" ).isNull() )
+    if ( !preferences.namedItem( "confirmFavoritesDeletion" ).isNull() ) {
       c.preferences.confirmFavoritesDeletion =
         ( preferences.namedItem( "confirmFavoritesDeletion" ).toElement().text() == "1" );
+    }
 
-    if ( !preferences.namedItem( "collapseBigArticles" ).isNull() )
+    if ( !preferences.namedItem( "collapseBigArticles" ).isNull() ) {
       c.preferences.collapseBigArticles = ( preferences.namedItem( "collapseBigArticles" ).toElement().text() == "1" );
+    }
 
-    if ( !preferences.namedItem( "articleSizeLimit" ).isNull() )
+    if ( !preferences.namedItem( "articleSizeLimit" ).isNull() ) {
       c.preferences.articleSizeLimit = preferences.namedItem( "articleSizeLimit" ).toElement().text().toInt();
+    }
 
-    if ( !preferences.namedItem( "limitInputPhraseLength" ).isNull() )
+    if ( !preferences.namedItem( "limitInputPhraseLength" ).isNull() ) {
       c.preferences.limitInputPhraseLength =
         ( preferences.namedItem( "limitInputPhraseLength" ).toElement().text() == "1" );
+    }
 
-    if ( !preferences.namedItem( "inputPhraseLengthLimit" ).isNull() )
+    if ( !preferences.namedItem( "inputPhraseLengthLimit" ).isNull() ) {
       c.preferences.inputPhraseLengthLimit =
         preferences.namedItem( "inputPhraseLengthLimit" ).toElement().text().toInt();
+    }
 
-    if ( !preferences.namedItem( "maxDictionaryRefsInContextMenu" ).isNull() )
+    if ( !preferences.namedItem( "maxDictionaryRefsInContextMenu" ).isNull() ) {
       c.preferences.maxDictionaryRefsInContextMenu =
         preferences.namedItem( "maxDictionaryRefsInContextMenu" ).toElement().text().toUShort();
+    }
 
-    if ( !preferences.namedItem( "synonymSearchEnabled" ).isNull() )
+    if ( !preferences.namedItem( "synonymSearchEnabled" ).isNull() ) {
       c.preferences.synonymSearchEnabled =
         ( preferences.namedItem( "synonymSearchEnabled" ).toElement().text() == "1" );
+    }
 
-    if ( !preferences.namedItem( "stripClipboard" ).isNull() )
+    if ( !preferences.namedItem( "stripClipboard" ).isNull() ) {
       c.preferences.stripClipboard = ( preferences.namedItem( "stripClipboard" ).toElement().text() == "1" );
+    }
 
-    if ( !preferences.namedItem( "raiseWindowOnSearch" ).isNull() )
+    if ( !preferences.namedItem( "raiseWindowOnSearch" ).isNull() ) {
       c.preferences.raiseWindowOnSearch = ( preferences.namedItem( "raiseWindowOnSearch" ).toElement().text() == "1" );
+    }
 
     QDomNode fts = preferences.namedItem( "fullTextSearch" );
 
     if ( !fts.isNull() ) {
-      if ( !fts.namedItem( "searchMode" ).isNull() )
+      if ( !fts.namedItem( "searchMode" ).isNull() ) {
         c.preferences.fts.searchMode = fts.namedItem( "searchMode" ).toElement().text().toInt();
+      }
 
-      if ( !fts.namedItem( "dialogGeometry" ).isNull() )
+      if ( !fts.namedItem( "dialogGeometry" ).isNull() ) {
         c.preferences.fts.dialogGeometry =
           QByteArray::fromBase64( fts.namedItem( "dialogGeometry" ).toElement().text().toLatin1() );
+      }
 
-      if ( !fts.namedItem( "disabledTypes" ).isNull() )
+      if ( !fts.namedItem( "disabledTypes" ).isNull() ) {
         c.preferences.fts.disabledTypes = fts.namedItem( "disabledTypes" ).toElement().text();
+      }
 
-      if ( !fts.namedItem( "enabled" ).isNull() )
+      if ( !fts.namedItem( "enabled" ).isNull() ) {
         c.preferences.fts.enabled = ( fts.namedItem( "enabled" ).toElement().text() == "1" );
+      }
 
-      if ( !fts.namedItem( "maxDictionarySize" ).isNull() )
+      if ( !fts.namedItem( "maxDictionarySize" ).isNull() ) {
         c.preferences.fts.maxDictionarySize = fts.namedItem( "maxDictionarySize" ).toElement().text().toUInt();
+      }
 
-      if ( !fts.namedItem( "parallelThreads" ).isNull() )
+      if ( !fts.namedItem( "parallelThreads" ).isNull() ) {
         c.preferences.fts.parallelThreads = fts.namedItem( "parallelThreads" ).toElement().text().toUInt();
+      }
     }
   }
 
@@ -1109,13 +1178,15 @@ Class load()
 
   QDomNode popupWindowState = root.namedItem( "popupWindowState" );
 
-  if ( !popupWindowState.isNull() )
+  if ( !popupWindowState.isNull() ) {
     c.popupWindowState = QByteArray::fromBase64( popupWindowState.toElement().text().toLatin1() );
+  }
 
   QDomNode popupWindowGeometry = root.namedItem( "popupWindowGeometry" );
 
-  if ( !popupWindowGeometry.isNull() )
+  if ( !popupWindowGeometry.isNull() ) {
     c.popupWindowGeometry = QByteArray::fromBase64( popupWindowGeometry.toElement().text().toLatin1() );
+  }
 
   c.pinPopupWindow = ( root.namedItem( "pinPopupWindow" ).toElement().text() == "1" );
 
@@ -1123,33 +1194,39 @@ Class load()
 
   QDomNode mainWindowState = root.namedItem( "mainWindowState" );
 
-  if ( !mainWindowState.isNull() )
+  if ( !mainWindowState.isNull() ) {
     c.mainWindowState = QByteArray::fromBase64( mainWindowState.toElement().text().toLatin1() );
+  }
 
   QDomNode mainWindowGeometry = root.namedItem( "mainWindowGeometry" );
 
-  if ( !mainWindowGeometry.isNull() )
+  if ( !mainWindowGeometry.isNull() ) {
     c.mainWindowGeometry = QByteArray::fromBase64( mainWindowGeometry.toElement().text().toLatin1() );
+  }
 
   QDomNode dictInfoGeometry = root.namedItem( "dictInfoGeometry" );
 
-  if ( !dictInfoGeometry.isNull() )
+  if ( !dictInfoGeometry.isNull() ) {
     c.dictInfoGeometry = QByteArray::fromBase64( dictInfoGeometry.toElement().text().toLatin1() );
+  }
 
   QDomNode inspectorGeometry = root.namedItem( "inspectorGeometry" );
 
-  if ( !inspectorGeometry.isNull() )
+  if ( !inspectorGeometry.isNull() ) {
     c.inspectorGeometry = QByteArray::fromBase64( inspectorGeometry.toElement().text().toLatin1() );
+  }
 
   QDomNode dictionariesDialogGeometry = root.namedItem( "dictionariesDialogGeometry" );
 
-  if ( !dictionariesDialogGeometry.isNull() )
+  if ( !dictionariesDialogGeometry.isNull() ) {
     c.dictionariesDialogGeometry = QByteArray::fromBase64( dictionariesDialogGeometry.toElement().text().toLatin1() );
+  }
 
   QDomNode timeForNewReleaseCheck = root.namedItem( "timeForNewReleaseCheck" );
 
-  if ( !timeForNewReleaseCheck.isNull() )
+  if ( !timeForNewReleaseCheck.isNull() ) {
     c.timeForNewReleaseCheck = QDateTime::fromString( timeForNewReleaseCheck.toElement().text(), Qt::ISODate );
+  }
 
   c.skippedRelease = root.namedItem( "skippedRelease" ).toElement().text();
 
@@ -1160,14 +1237,17 @@ Class load()
     c.usingToolbarsIconSize = static_cast< ToolbarsIconSize >( usingToolbarsIconSize.toElement().text().toInt() );
   }
 
-  if ( !root.namedItem( "historyExportPath" ).isNull() )
+  if ( !root.namedItem( "historyExportPath" ).isNull() ) {
     c.historyExportPath = root.namedItem( "historyExportPath" ).toElement().text();
+  }
 
-  if ( !root.namedItem( "resourceSavePath" ).isNull() )
+  if ( !root.namedItem( "resourceSavePath" ).isNull() ) {
     c.resourceSavePath = root.namedItem( "resourceSavePath" ).toElement().text();
+  }
 
-  if ( !root.namedItem( "articleSavePath" ).isNull() )
+  if ( !root.namedItem( "articleSavePath" ).isNull() ) {
     c.articleSavePath = root.namedItem( "articleSavePath" ).toElement().text();
+  }
 
   if ( !root.namedItem( "maxHeadwordSize" ).isNull() ) {
     unsigned int value = root.namedItem( "maxHeadwordSize" ).toElement().text().toUInt();
@@ -1177,27 +1257,33 @@ Class load()
     }
   }
 
-  if ( !root.namedItem( "maxHeadwordsToExpand" ).isNull() )
+  if ( !root.namedItem( "maxHeadwordsToExpand" ).isNull() ) {
     c.maxHeadwordsToExpand = root.namedItem( "maxHeadwordsToExpand" ).toElement().text().toUInt();
+  }
 
   QDomNode headwordsDialog = root.namedItem( "headwordsDialog" );
 
   if ( !headwordsDialog.isNull() ) {
-    if ( !headwordsDialog.namedItem( "searchMode" ).isNull() )
+    if ( !headwordsDialog.namedItem( "searchMode" ).isNull() ) {
       c.headwordsDialog.searchMode = headwordsDialog.namedItem( "searchMode" ).toElement().text().toInt();
+    }
 
-    if ( !headwordsDialog.namedItem( "matchCase" ).isNull() )
+    if ( !headwordsDialog.namedItem( "matchCase" ).isNull() ) {
       c.headwordsDialog.matchCase = ( headwordsDialog.namedItem( "matchCase" ).toElement().text() == "1" );
+    }
 
-    if ( !headwordsDialog.namedItem( "autoApply" ).isNull() )
+    if ( !headwordsDialog.namedItem( "autoApply" ).isNull() ) {
       c.headwordsDialog.autoApply = ( headwordsDialog.namedItem( "autoApply" ).toElement().text() == "1" );
+    }
 
-    if ( !headwordsDialog.namedItem( "headwordsExportPath" ).isNull() )
+    if ( !headwordsDialog.namedItem( "headwordsExportPath" ).isNull() ) {
       c.headwordsDialog.headwordsExportPath = headwordsDialog.namedItem( "headwordsExportPath" ).toElement().text();
+    }
 
-    if ( !headwordsDialog.namedItem( "headwordsDialogGeometry" ).isNull() )
+    if ( !headwordsDialog.namedItem( "headwordsDialogGeometry" ).isNull() ) {
       c.headwordsDialog.headwordsDialogGeometry =
         QByteArray::fromBase64( headwordsDialog.namedItem( "headwordsDialogGeometry" ).toElement().text().toLatin1() );
+    }
   }
 
   return c;
@@ -1292,8 +1378,9 @@ void save( Class const & c )
 {
   QSaveFile configFile( getConfigFileName() );
 
-  if ( !configFile.open( QFile::WriteOnly ) )
+  if ( !configFile.open( QFile::WriteOnly ) ) {
     throw exCantWriteConfigFile();
+  }
 
   QDomDocument dd;
 
@@ -2206,8 +2293,9 @@ void save( Class const & c )
   }
 
   configFile.write( dd.toByteArray() );
-  if ( !configFile.commit() )
+  if ( !configFile.commit() ) {
     throw exCantWriteConfigFile();
+  }
 }
 
 QString getConfigFileName()
@@ -2234,8 +2322,9 @@ QString getIndexDir()
 
   result.mkpath( "index" );
 
-  if ( !result.cd( "index" ) )
+  if ( !result.cd( "index" ) ) {
     throw exCantUseIndexDir();
+  }
 
   return result.path() + QDir::separator();
 }
@@ -2293,9 +2382,10 @@ QString getUserQtCssFileName()
 
 QString getProgramDataDir() noexcept
 {
-  if ( isPortableVersion() )
+  if ( isPortableVersion() ) {
     return QCoreApplication::applicationDirPath();
-    // TODO: rewrite this in QStandardPaths::AppDataLocation
+  }
+  // TODO: rewrite this in QStandardPaths::AppDataLocation
 #ifdef PROGRAM_DATA_DIR
   return PROGRAM_DATA_DIR;
 #else
@@ -2305,18 +2395,22 @@ QString getProgramDataDir() noexcept
 
 QString getLocDir() noexcept
 {
-  if ( QDir( getProgramDataDir() ).cd( "locale" ) )
+  if ( QDir( getProgramDataDir() ).cd( "locale" ) ) {
     return getProgramDataDir() + "/locale";
-  else
+  }
+  else {
     return QCoreApplication::applicationDirPath() + "/locale";
+  }
 }
 
 QString getHelpDir() noexcept
 {
-  if ( QDir( getProgramDataDir() ).cd( "help" ) )
+  if ( QDir( getProgramDataDir() ).cd( "help" ) ) {
     return getProgramDataDir() + "/help";
-  else
+  }
+  else {
     return QCoreApplication::applicationDirPath() + "/help";
+  }
 }
 
 #ifdef MAKE_CHINESE_CONVERSION_SUPPORT
@@ -2329,8 +2423,9 @@ QString getOpenCCDir() noexcept
     return QCoreApplication::applicationDirPath() + "/opencc";
   #elif defined( Q_OS_MAC )
   QString path = QCoreApplication::applicationDirPath() + "/opencc";
-  if ( QDir( path ).exists() )
+  if ( QDir( path ).exists() ) {
     return path;
+  }
 
   return QString();
   #else
@@ -2358,18 +2453,22 @@ bool isPortableVersion() noexcept
 
 QString getPortableVersionDictionaryDir() noexcept
 {
-  if ( isPortableVersion() )
+  if ( isPortableVersion() ) {
     return getProgramDataDir() + "/content";
-  else
+  }
+  else {
     return QString();
+  }
 }
 
 QString getPortableVersionMorphoDir() noexcept
 {
-  if ( isPortableVersion() )
+  if ( isPortableVersion() ) {
     return getPortableVersionDictionaryDir() + "/morphology";
-  else
+  }
+  else {
     return QString();
+  }
 }
 
 QString getStylesDir()
@@ -2378,8 +2477,9 @@ QString getStylesDir()
 
   result.mkpath( "styles" );
 
-  if ( !result.cd( "styles" ) )
+  if ( !result.cd( "styles" ) ) {
     return QString();
+  }
 
   return result.path() + QDir::separator();
 }

--- a/src/dict/aard.cc
+++ b/src/dict/aard.cc
@@ -120,16 +120,19 @@ void readJSONValue( string const & source, string & str, string::size_type & pos
   int level = 1;
   char endChar;
   str.push_back( source[ pos ] );
-  if ( source[ pos ] == '{' )
+  if ( source[ pos ] == '{' ) {
     endChar = '}';
-  else if ( source[ pos ] == '[' )
+  }
+  else if ( source[ pos ] == '[' ) {
     endChar = ']';
+  }
   else if ( source[ pos ] == '\"' ) {
     str.clear();
     endChar = '\"';
   }
-  else
+  else {
     endChar = ',';
+  }
 
   pos++;
   char ch     = 0;
@@ -137,13 +140,16 @@ void readJSONValue( string const & source, string & str, string::size_type & pos
   while ( !( ch == endChar && lastCh != '\\' && level == 0 ) && pos < source.size() ) {
     lastCh = ch;
     ch     = source[ pos++ ];
-    if ( ( ch == '{' || ch == '[' ) && lastCh != '\\' )
+    if ( ( ch == '{' || ch == '[' ) && lastCh != '\\' ) {
       level++;
-    if ( ( ch == '}' || ch == ']' ) && lastCh != '\\' )
+    }
+    if ( ( ch == '}' || ch == ']' ) && lastCh != '\\' ) {
       level--;
+    }
 
-    if ( ch == endChar && ( ( ch == '\"' && lastCh != '\\' ) || ch == ',' ) && level == 1 )
+    if ( ch == endChar && ( ( ch == '\"' && lastCh != '\\' ) || ch == ',' ) && level == 1 ) {
       break;
+    }
     str.push_back( ch );
   }
 }
@@ -155,36 +161,45 @@ map< string, string > parseMetaData( string const & metaData )
   string name, value;
   string::size_type n = 0;
 
-  while ( n < metaData.length() && metaData[ n ] != '{' )
+  while ( n < metaData.length() && metaData[ n ] != '{' ) {
     n++;
+  }
   while ( n < metaData.length() ) {
     // Skip to '"'
-    while ( n < metaData.length() && metaData[ n ] != '\"' )
+    while ( n < metaData.length() && metaData[ n ] != '\"' ) {
       n++;
-    if ( ++n >= metaData.length() )
+    }
+    if ( ++n >= metaData.length() ) {
       break;
+    }
 
     // Read name
     while ( n < metaData.length()
-            && !( ( metaData[ n ] == '\"' || metaData[ n ] == '{' ) && metaData[ n - 1 ] != '\\' ) )
+            && !( ( metaData[ n ] == '\"' || metaData[ n ] == '{' ) && metaData[ n - 1 ] != '\\' ) ) {
       name.push_back( metaData[ n++ ] );
+    }
 
     // Skip to ':'
-    if ( ++n >= metaData.length() )
+    if ( ++n >= metaData.length() ) {
       break;
-    while ( n < metaData.length() && metaData[ n ] != ':' )
+    }
+    while ( n < metaData.length() && metaData[ n ] != ':' ) {
       n++;
-    if ( ++n >= metaData.length() )
+    }
+    if ( ++n >= metaData.length() ) {
       break;
+    }
 
     // Find value start after ':'
     while ( n < metaData.length()
             && !( ( metaData[ n ] == '\"' || metaData[ n ] == '{' || metaData[ n ] == '['
                     || ( metaData[ n ] >= '0' && metaData[ n ] <= '9' ) )
-                  && metaData[ n - 1 ] != '\\' ) )
+                  && metaData[ n - 1 ] != '\\' ) ) {
       n++;
-    if ( n >= metaData.length() )
+    }
+    if ( n >= metaData.length() ) {
       break;
+    }
 
     readJSONValue( metaData, value, n );
 
@@ -192,8 +207,9 @@ map< string, string > parseMetaData( string const & metaData )
 
     name.clear();
     value.clear();
-    if ( ++n >= metaData.length() )
+    if ( ++n >= metaData.length() ) {
       break;
+    }
   }
   return data;
 }
@@ -305,8 +321,9 @@ AardDictionary::~AardDictionary()
 
 void AardDictionary::loadIcon() noexcept
 {
-  if ( dictionaryIconLoaded )
+  if ( dictionaryIconLoaded ) {
     return;
+  }
 
   QString fileName = QDir::fromNativeSeparators( QString::fromStdString( getDictionaryFilenames()[ 0 ] ) );
 
@@ -337,15 +354,17 @@ string AardDictionary::convert( const string & in )
         afterEol = true;
         continue;
       }
-      else if ( inCh == 'r' )
+      else if ( inCh == 'r' ) {
         continue;
+      }
     }
     else if ( inCh == ' ' && afterEol ) {
       inConverted.append( "&nbsp;" );
       continue;
     }
-    else
+    else {
       lastCh = inCh;
+    }
     afterEol = false;
     inConverted.push_back( inCh );
   }
@@ -395,8 +414,9 @@ void AardDictionary::loadArticle( quint32 address, string & articleText, bool ra
 
       // Don't try to read and decode too big articles,
       // it is most likely error in dictionary
-      if ( articleSize > 1048576 )
+      if ( articleSize > 1048576 ) {
         break;
+      }
 
       articleBody.resize( articleSize );
       df.read( &articleBody.front(), articleSize );
@@ -409,23 +429,28 @@ void AardDictionary::loadArticle( quint32 address, string & articleText, bool ra
       break;
     }
 
-    if ( articleBody.empty() )
+    if ( articleBody.empty() ) {
       break;
+    }
 
     articleText.clear();
 
     string text = decompressBzip2( articleBody.data(), articleSize );
-    if ( text.empty() )
+    if ( text.empty() ) {
       text = decompressZlib( articleBody.data(), articleSize );
-    if ( text.empty() )
+    }
+    if ( text.empty() ) {
       text = string( articleBody.data(), articleSize );
+    }
 
-    if ( text.empty() || text[ 0 ] != '[' )
+    if ( text.empty() || text[ 0 ] != '[' ) {
       break;
+    }
 
     string::size_type n = text.find( '\"' );
-    if ( n == string::npos )
+    if ( n == string::npos ) {
       break;
+    }
 
     readJSONValue( text, articleText, n );
 
@@ -433,8 +458,9 @@ void AardDictionary::loadArticle( quint32 address, string & articleText, bool ra
       n = text.find( "\"r\"" );
       if ( n != string::npos && n + 3 < text.size() ) {
         n = text.find( '\"', n + 3 );
-        if ( n == string::npos )
+        if ( n == string::npos ) {
           break;
+        }
 
         string link;
         readJSONValue( text, link, n );
@@ -463,20 +489,23 @@ void AardDictionary::loadArticle( quint32 address, string & articleText, bool ra
   }
 
   if ( !articleText.empty() ) {
-    if ( rawText )
+    if ( rawText ) {
       return;
+    }
 
     articleText = convert( articleText );
   }
-  else
+  else {
     articleText = QObject::tr( "Article decoding error" ).toStdString();
+  }
 
   // See Issue #271: A mechanism to clean-up invalid HTML cards.
   const string cleaner = Utils::Html::getHtmlCleaner();
 
   string prefix( "<div class=\"aard\"" );
-  if ( isToLanguageRTL() )
+  if ( isToLanguageRTL() ) {
     prefix += " dir=\"rtl\"";
+  }
   prefix += ">";
 
   articleText = prefix + articleText + cleaner + "</div>";
@@ -484,8 +513,9 @@ void AardDictionary::loadArticle( quint32 address, string & articleText, bool ra
 
 QString const & AardDictionary::getDescription()
 {
-  if ( !dictionaryDescription.isEmpty() )
+  if ( !dictionaryDescription.isEmpty() ) {
     return dictionaryDescription;
+  }
 
   AAR_header dictHeader;
   quint32 size;
@@ -501,21 +531,24 @@ QString const & AardDictionary::getDescription()
   }
 
   string metaStr = decompressBzip2( data.data(), size );
-  if ( metaStr.empty() )
+  if ( metaStr.empty() ) {
     metaStr = decompressZlib( data.data(), size );
+  }
 
   map< string, string > meta = parseMetaData( metaStr );
 
   if ( !meta.empty() ) {
     map< string, string >::const_iterator iter = meta.find( "copyright" );
-    if ( iter != meta.end() )
+    if ( iter != meta.end() ) {
       dictionaryDescription =
         QObject::tr( "Copyright: %1%2" ).arg( QString::fromUtf8( iter->second.c_str() ) ).arg( "\n\n" );
+    }
 
     iter = meta.find( "version" );
-    if ( iter != meta.end() )
+    if ( iter != meta.end() ) {
       dictionaryDescription =
         QObject::tr( "Version: %1%2" ).arg( QString::fromUtf8( iter->second.c_str() ) ).arg( "\n\n" );
+    }
 
     iter = meta.find( "description" );
     if ( iter != meta.end() ) {
@@ -526,8 +559,9 @@ QString const & AardDictionary::getDescription()
     }
   }
 
-  if ( dictionaryDescription.isEmpty() )
+  if ( dictionaryDescription.isEmpty() ) {
     dictionaryDescription = "NONE";
+  }
 
   return dictionaryDescription;
 }
@@ -535,14 +569,17 @@ QString const & AardDictionary::getDescription()
 void AardDictionary::makeFTSIndex( QAtomicInt & isCancelled )
 {
   if ( !( Dictionary::needToRebuildIndex( getDictionaryFilenames(), ftsIdxName )
-          || FtsHelpers::ftsIndexIsOldOrBad( this ) ) )
+          || FtsHelpers::ftsIndexIsOldOrBad( this ) ) ) {
     FTS_index_completed.ref();
+  }
 
-  if ( haveFTSIndex() )
+  if ( haveFTSIndex() ) {
     return;
+  }
 
-  if ( ensureInitDone().size() )
+  if ( ensureInitDone().size() ) {
     return;
+  }
 
 
   gdDebug( "Aard: Building the full-text index for dictionary: %s\n", getName().c_str() );
@@ -648,8 +685,9 @@ void AardArticleRequest::run()
                                    // by only allowing them to appear once.
 
   wstring wordCaseFolded = Folding::applySimpleCaseOnly( word );
-  if ( ignoreDiacritics )
+  if ( ignoreDiacritics ) {
     wordCaseFolded = Folding::applyDiacriticsOnly( wordCaseFolded );
+  }
 
   for ( auto & x : chain ) {
     if ( Utils::AtomicInt::loadAcquire( isCancelled ) ) {
@@ -657,8 +695,9 @@ void AardArticleRequest::run()
       return;
     }
 
-    if ( articlesIncluded.find( x.articleOffset ) != articlesIncluded.end() )
+    if ( articlesIncluded.find( x.articleOffset ) != articlesIncluded.end() ) {
       continue; // We already have this article in the body.
+    }
 
     // Now grab that article
 
@@ -677,8 +716,9 @@ void AardArticleRequest::run()
     // We do the case-folded comparison here.
 
     wstring headwordStripped = Folding::applySimpleCaseOnly( headword );
-    if ( ignoreDiacritics )
+    if ( ignoreDiacritics ) {
       headwordStripped = Folding::applyDiacriticsOnly( headwordStripped );
+    }
 
     multimap< wstring, pair< string, string > > & mapToUse =
       ( wordCaseFolded == headwordStripped ) ? mainArticles : alternateArticles;
@@ -741,8 +781,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
   for ( const auto & fileName : fileNames ) {
     // Skip files with the extensions different to .aar to speed up the
     // scanning
-    if ( !Utils::endsWithIgnoreCase( fileName, ".aar" ) )
+    if ( !Utils::endsWithIgnoreCase( fileName, ".aar" ) ) {
       continue;
+    }
 
     // Got the file -- check if we need to rebuid the index
 
@@ -789,8 +830,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
         data.resize( size );
         df.read( &data.front(), size );
         string metaStr = decompressBzip2( data.data(), size );
-        if ( metaStr.empty() )
+        if ( metaStr.empty() ) {
           metaStr = decompressZlib( data.data(), size );
+        }
 
         map< string, string > meta = parseMetaData( metaStr );
 
@@ -801,18 +843,21 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         string dictName;
         map< string, string >::const_iterator iter = meta.find( "title" );
-        if ( iter != meta.end() )
+        if ( iter != meta.end() ) {
           dictName = iter->second;
+        }
 
         string langFrom;
         iter = meta.find( "index_language" );
-        if ( iter != meta.end() )
+        if ( iter != meta.end() ) {
           langFrom = iter->second;
+        }
 
         string langTo;
         iter = meta.find( "article_language" );
-        if ( iter != meta.end() )
+        if ( iter != meta.end() ) {
           langTo = iter->second;
+        }
 
         if ( ( dictName.compare( "Wikipedia" ) == 0 || dictName.compare( "Wikiquote" ) == 0
                || dictName.compare( "Wiktionary" ) == 0 )
@@ -840,8 +885,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
         idx.write( idxHeader );
 
         idx.write( (quint32)dictName.size() );
-        if ( !dictName.empty() )
+        if ( !dictName.empty() ) {
           idx.write( dictName.data(), dictName.size() );
+        }
 
         IndexedWords indexedWords;
 
@@ -881,19 +927,23 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
           quint16 sizeBE;
           df.read( &sizeBE, sizeof( sizeBE ) );
           quint16 wordSize = qFromBigEndian( sizeBE );
-          if ( data.size() < wordSize )
+          if ( data.size() < wordSize ) {
             data.resize( wordSize );
+          }
           df.read( &data.front(), wordSize );
 
-          if ( articleOffsets.find( articleOffset ) == articleOffsets.end() )
+          if ( articleOffsets.find( articleOffset ) == articleOffsets.end() ) {
             articleOffsets.insert( articleOffset );
+          }
 
           // Insert new entry
           wstring word = Utf8::decode( string( data.data(), wordSize ) );
-          if ( maxHeadwordsToExpand && dictHeader.wordsCount >= maxHeadwordsToExpand )
+          if ( maxHeadwordsToExpand && dictHeader.wordsCount >= maxHeadwordsToExpand ) {
             indexedWords.addSingleWord( word, articleOffset );
-          else
+          }
+          else {
             indexedWords.addWord( word, articleOffset );
+          }
 
           pos += has64bitIndex ? sizeof( IndexElement64 ) : sizeof( IndexElement );
         }
@@ -922,15 +972,19 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         idxHeader.wordCount = wordCount;
 
-        if ( langFrom.size() == 3 )
+        if ( langFrom.size() == 3 ) {
           idxHeader.langFrom = LangCoder::findIdForLanguageCode3( langFrom );
-        else if ( langFrom.size() == 2 )
+        }
+        else if ( langFrom.size() == 2 ) {
           idxHeader.langFrom = LangCoder::code2toInt( langFrom.c_str() );
+        }
 
-        if ( langTo.size() == 3 )
+        if ( langTo.size() == 3 ) {
           idxHeader.langTo = LangCoder::findIdForLanguageCode3( langTo );
-        else if ( langTo.size() == 2 )
+        }
+        else if ( langTo.size() == 2 ) {
           idxHeader.langTo = LangCoder::code2toInt( langTo.c_str() );
+        }
 
         idx.rewind();
 

--- a/src/dict/bgl.cc
+++ b/src/dict/bgl.cc
@@ -100,10 +100,12 @@ string removePostfix( string const & in )
   if ( in.size() && in[ in.size() - 1 ] == '$' ) {
     // Find the end of it and cut it, barring any unexpectedness
     for ( long x = in.size() - 2; x >= 0; x-- ) {
-      if ( in[ x ] == '$' )
+      if ( in[ x ] == '$' ) {
         return in.substr( 0, x );
-      else if ( !isdigit( in[ x ] ) )
+      }
+      else if ( !isdigit( in[ x ] ) ) {
         break;
+      }
     }
   }
 
@@ -116,21 +118,25 @@ void trimWs( string & word )
   if ( word.size() ) {
     unsigned begin = 0;
 
-    while ( begin < word.size() && Utf8::isspace( word[ begin ] ) )
+    while ( begin < word.size() && Utf8::isspace( word[ begin ] ) ) {
       ++begin;
+    }
 
-    if ( begin == word.size() ) // Consists of ws entirely?
+    if ( begin == word.size() ) { // Consists of ws entirely?
       word.clear();
+    }
     else {
       unsigned end = word.size();
 
       // Doesn't consist of ws entirely, so must end with just isspace()
       // condition.
-      while ( Utf8::isspace( word[ end - 1 ] ) )
+      while ( Utf8::isspace( word[ end - 1 ] ) ) {
         --end;
+      }
 
-      if ( end != word.size() || begin )
+      if ( end != word.size() || begin ) {
         word = string( word, begin, end - begin );
+      }
     }
   }
 }
@@ -146,8 +152,9 @@ void addEntryToIndex( string & word,
   // If the word starts with a slash, we drop it. There are quite a lot
   // of them, and they all seem to be redudant duplicates.
 
-  if ( word.size() && word[ 0 ] == '/' )
+  if ( word.size() && word[ 0 ] == '/' ) {
     return;
+  }
 
   // Check the input word for a superscript postfix ($1$, $2$ etc), which
   // signifies different meaning in Bgl files. We emit different meaning
@@ -222,9 +229,10 @@ public:
     if ( metadata_enable_fts.has_value() ) {
       can_FTS = fts.enabled && metadata_enable_fts.value();
     }
-    else
+    else {
       can_FTS = fts.enabled && !fts.disabledTypes.contains( "BGL", Qt::CaseInsensitive )
         && ( fts.maxDictionarySize == 0 || getArticleCount() <= fts.maxDictionarySize );
+    }
   }
 
 protected:
@@ -273,8 +281,9 @@ BglDictionary::BglDictionary( string const & id, string const & indexFile, strin
 
 void BglDictionary::loadIcon() noexcept
 {
-  if ( dictionaryIconLoaded )
+  if ( dictionaryIconLoaded ) {
     return;
+  }
 
   QString fileName = QDir::fromNativeSeparators( QString::fromStdString( getDictionaryFilenames()[ 0 ] ) );
 
@@ -315,8 +324,9 @@ void BglDictionary::loadIcon() noexcept
       }
     }
 
-    if ( dictionaryIcon.isNull() )
+    if ( dictionaryIcon.isNull() ) {
       dictionaryIcon = QIcon( ":/icons/icon32_bgl.png" );
+    }
   }
 
   dictionaryIconLoaded = true;
@@ -339,37 +349,43 @@ void BglDictionary::loadArticle( uint32_t offset, string & headword, string & di
 
 QString const & BglDictionary::getDescription()
 {
-  if ( !dictionaryDescription.isEmpty() )
+  if ( !dictionaryDescription.isEmpty() ) {
     return dictionaryDescription;
+  }
 
-  if ( idxHeader.descriptionSize == 0 )
+  if ( idxHeader.descriptionSize == 0 ) {
     dictionaryDescription = "NONE";
+  }
   else {
     QMutexLocker _( &idxMutex );
     vector< char > chunk;
     char * dictDescription = chunks.getBlock( idxHeader.descriptionAddress, chunk );
     string str( dictDescription );
-    if ( !str.empty() )
+    if ( !str.empty() ) {
       dictionaryDescription += QObject::tr( "Copyright: %1%2" )
                                  .arg( Html::unescape( QString::fromUtf8( str.data(), str.size() ) ) )
                                  .arg( "\n\n" );
+    }
     dictDescription += str.size() + 1;
 
     str = string( dictDescription );
-    if ( !str.empty() )
+    if ( !str.empty() ) {
       dictionaryDescription +=
         QObject::tr( "Author: %1%2" ).arg( QString::fromUtf8( str.data(), str.size() ) ).arg( "\n\n" );
+    }
     dictDescription += str.size() + 1;
 
     str = string( dictDescription );
-    if ( !str.empty() )
+    if ( !str.empty() ) {
       dictionaryDescription +=
         QObject::tr( "E-mail: %1%2" ).arg( QString::fromUtf8( str.data(), str.size() ) ).arg( "\n\n" );
+    }
     dictDescription += str.size() + 1;
 
     str = string( dictDescription );
-    if ( !str.empty() )
+    if ( !str.empty() ) {
       dictionaryDescription += Html::unescape( QString::fromUtf8( str.data(), str.size() ) );
+    }
   }
 
   return dictionaryDescription;
@@ -384,8 +400,9 @@ void BglDictionary::getArticleText( uint32_t articleAddress, QString & headword,
     // Some headword normalization similar while indexing
     trimWs( headwordStr );
 
-    if ( headwordStr.size() && headwordStr[ 0 ] == '/' )
+    if ( headwordStr.size() && headwordStr[ 0 ] == '/' ) {
       headwordStr.erase(); // We will take headword from index later
+    }
 
     if ( headwordStr.size() && headwordStr[ headwordStr.size() - 1 ] == '$' ) {
       headwordStr = removePostfix( headwordStr );
@@ -402,8 +419,9 @@ void BglDictionary::getArticleText( uint32_t articleAddress, QString & headword,
           ( i >= 224 && i <= 250 )
           || ( i >= 192
                && i
-                 <= 210 ) ) // Hebrew chars encoded ecoded as windows-1255 or ISO-8859-8, or as vowel-points of windows-1255
+                 <= 210 ) ) { // Hebrew chars encoded ecoded as windows-1255 or ISO-8859-8, or as vowel-points of windows-1255
           i += 1488 - 224; // Convert to Hebrew unicode
+        }
       }
     }
 
@@ -417,11 +435,13 @@ void BglDictionary::getArticleText( uint32_t articleAddress, QString & headword,
 void BglDictionary::makeFTSIndex( QAtomicInt & isCancelled )
 {
   if ( !( Dictionary::needToRebuildIndex( getDictionaryFilenames(), ftsIdxName )
-          || FtsHelpers::ftsIndexIsOldOrBad( this ) ) )
+          || FtsHelpers::ftsIndexIsOldOrBad( this ) ) ) {
     FTS_index_completed.ref();
+  }
 
-  if ( haveFTSIndex() )
+  if ( haveFTSIndex() ) {
     return;
+  }
 
 
   gdDebug( "Bgl: Building the full-text index for dictionary: %s\n", getName().c_str() );
@@ -521,8 +541,9 @@ sptr< Dictionary::WordSearchRequest > BglDictionary::findHeadwordsForSynonym( ws
 // Converts a $1$-like postfix to a <sup>1</sup> one
 string postfixToSuperscript( string const & in )
 {
-  if ( !in.size() || in[ in.size() - 1 ] != '$' )
+  if ( !in.size() || in[ in.size() - 1 ] != '$' ) {
     return in;
+  }
 
   for ( long x = in.size() - 2; x >= 0; x-- ) {
     if ( in[ x ] == '$' ) {
@@ -532,11 +553,13 @@ string postfixToSuperscript( string const & in )
         // postfix.
         return in.substr( 0, x );
       }
-      else
+      else {
         return in.substr( 0, x ) + "<sup>" + in.substr( x + 1, in.size() - x - 2 ) + "</sup>";
+      }
     }
-    else if ( !isdigit( in[ x ] ) )
+    else if ( !isdigit( in[ x ] ) ) {
       break;
+    }
   }
 
   return in;
@@ -605,8 +628,9 @@ void BglArticleRequest::fixHebString( string & hebStr ) // Hebrew support - conv
       ( i >= 224 && i <= 250 )
       || ( i >= 192
            && i
-             <= 210 ) ) // Hebrew chars encoded ecoded as windows-1255 or ISO-8859-8, or as vowel-points of windows-1255
-      i += 1488 - 224;  // Convert to Hebrew unicode
+             <= 210 ) ) { // Hebrew chars encoded ecoded as windows-1255 or ISO-8859-8, or as vowel-points of windows-1255
+      i += 1488 - 224;    // Convert to Hebrew unicode
+    }
   }
   hebStr = Utf8::encode( hebWStr );
 }
@@ -618,8 +642,9 @@ void BglArticleRequest::fixHebArticle( string & hebArticle ) // Hebrew support -
   for ( nulls = hebArticle.size(); nulls > 0
         && ( ( hebArticle[ nulls - 1 ] <= 32 && hebArticle[ nulls - 1 ] >= 0 )
              || ( hebArticle[ nulls - 1 ] >= 65 && hebArticle[ nulls - 1 ] <= 90 ) );
-        --nulls )
+        --nulls ) {
     ; //special chars and A-Z
+  }
 
   hebArticle.resize( nulls );
 }
@@ -653,8 +678,9 @@ void BglArticleRequest::run()
   set< QByteArray > articleBodiesIncluded;
 
   wstring wordCaseFolded = Folding::applySimpleCaseOnly( word );
-  if ( ignoreDiacritics )
+  if ( ignoreDiacritics ) {
     wordCaseFolded = Folding::applyDiacriticsOnly( wordCaseFolded );
+  }
 
   for ( auto & x : chain ) {
     if ( Utils::AtomicInt::loadAcquire( isCancelled ) ) {
@@ -664,8 +690,9 @@ void BglArticleRequest::run()
 
     try {
 
-      if ( articlesIncluded.find( x.articleOffset ) != articlesIncluded.end() )
+      if ( articlesIncluded.find( x.articleOffset ) != articlesIncluded.end() ) {
         continue; // We already have this article in the body.
+      }
 
       // Now grab that article
 
@@ -679,8 +706,9 @@ void BglArticleRequest::run()
       // We do the case-folded and postfix-less comparison here.
 
       wstring headwordStripped = Folding::applySimpleCaseOnly( removePostfix( headword ) );
-      if ( ignoreDiacritics )
+      if ( ignoreDiacritics ) {
         headwordStripped = Folding::applyDiacriticsOnly( headwordStripped );
+      }
 
       // Hebrew support - fix Hebrew text
       if ( dict.idxHeader.langFrom == hebrew ) {
@@ -696,8 +724,9 @@ void BglArticleRequest::run()
       hash.addData( targetHeadword.data(), targetHeadword.size() + 1 ); // with 0
       hash.addData( articleText.data(), articleText.size() );
 
-      if ( !articleBodiesIncluded.insert( hash.result() ).second )
+      if ( !articleBodiesIncluded.insert( hash.result() ).second ) {
         continue; // Already had this body
+      }
 
       multimap< wstring, pair< string, string > > & mapToUse =
         ( wordCaseFolded == headwordStripped ) ? mainArticles : alternateArticles;
@@ -724,31 +753,39 @@ void BglArticleRequest::run()
 
   string cleaner = Utils::Html::getHtmlCleaner();
   for ( i = mainArticles.begin(); i != mainArticles.end(); ++i ) {
-    if ( dict.isFromLanguageRTL() ) // RTL support
+    if ( dict.isFromLanguageRTL() ) { // RTL support
       result += "<h3 style=\"text-align:right;direction:rtl\">";
-    else
+    }
+    else {
       result += "<h3>";
+    }
     result += postfixToSuperscript( i->second.first );
     result += "</h3>";
-    if ( dict.isToLanguageRTL() )
+    if ( dict.isToLanguageRTL() ) {
       result += "<div class=\"bglrtl\">" + i->second.second + "</div>";
-    else
+    }
+    else {
       result += "<div>" + i->second.second + "</div>";
+    }
     result += cleaner;
   }
 
 
   for ( i = alternateArticles.begin(); i != alternateArticles.end(); ++i ) {
-    if ( dict.isFromLanguageRTL() ) // RTL support
+    if ( dict.isFromLanguageRTL() ) { // RTL support
       result += "<h3 style=\"text-align:right;direction:rtl\">";
-    else
+    }
+    else {
       result += "<h3>";
+    }
     result += postfixToSuperscript( i->second.first );
     result += "</h3>";
-    if ( dict.isToLanguageRTL() )
+    if ( dict.isToLanguageRTL() ) {
       result += "<div class=\"bglrtl\">" + i->second.second + "</div>";
-    else
+    }
+    else {
       result += "<div>" + i->second.second + "</div>";
+    }
     result += cleaner;
   }
   // Do some cleanups in the text
@@ -853,22 +890,25 @@ void BglResourceRequest::run()
 
   string nameLowercased = name;
 
-  for ( char & i : nameLowercased )
+  for ( char & i : nameLowercased ) {
     i = tolower( i );
+  }
 
   QMutexLocker _( &idxMutex );
 
   idx.seek( resourceListOffset );
 
   for ( size_t count = resourcesCount; count--; ) {
-    if ( Utils::AtomicInt::loadAcquire( isCancelled ) )
+    if ( Utils::AtomicInt::loadAcquire( isCancelled ) ) {
       break;
+    }
 
     vector< char > nameData( idx.read< uint32_t >() );
     idx.read( &nameData.front(), nameData.size() );
 
-    for ( size_t x = nameData.size(); x--; )
+    for ( size_t x = nameData.size(); x--; ) {
       nameData[ x ] = tolower( nameData[ x ] );
+    }
 
     uint32_t offset = idx.read< uint32_t >();
 
@@ -895,8 +935,9 @@ void BglResourceRequest::run()
            || decompressedLength != data.size() ) {
         gdWarning( "Failed to decompress resource \"%s\", ignoring it.\n", name.c_str() );
       }
-      else
+      else {
         hasAnyData = true;
+      }
 
       break;
     }
@@ -1013,8 +1054,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
   for ( const auto & fileName : fileNames ) {
     // Skip files with the extensions different to .bgl to speed up the
     // scanning
-    if ( !Utils::endsWithIgnoreCase( fileName, ".bgl" ) )
+    if ( !Utils::endsWithIgnoreCase( fileName, ".bgl" ) ) {
       continue;
+    }
 
     // Got the file -- check if we need to rebuid the index
 
@@ -1032,8 +1074,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
       try {
         Babylon b( fileName );
 
-        if ( !b.open() )
+        if ( !b.open() ) {
           continue;
+        }
 
         std::string sourceCharset, targetCharset;
 
@@ -1102,8 +1145,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
         for ( ;; ) {
           bgl_entry e = b.readEntry( &resourceHandler );
 
-          if ( e.headword.empty() )
+          if ( e.headword.empty() ) {
             break;
+          }
 
           // Save the article's body itself first
 
@@ -1117,8 +1161,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
           addEntryToIndex( e.headword, articleAddress, indexedWords, wcharBuffer );
 
-          for ( auto & alternate : e.alternates )
+          for ( auto & alternate : e.alternates ) {
             addEntryToIndex( alternate, articleAddress, indexedWords, wcharBuffer );
+          }
 
           wordCount += 1 + e.alternates.size();
           ++articleCount;

--- a/src/dict/chinese.cc
+++ b/src/dict/chinese.cc
@@ -63,8 +63,9 @@ CharacterConversionDictionary::CharacterConversionDictionary( std::string const 
 CharacterConversionDictionary::~CharacterConversionDictionary()
 {
   // #ifdef Q_OS_MAC
-  if ( converter != NULL && converter != reinterpret_cast< opencc_t >( -1 ) )
+  if ( converter != NULL && converter != reinterpret_cast< opencc_t >( -1 ) ) {
     opencc_close( converter );
+  }
   // #else
   //   if ( converter != NULL )
   //     delete converter;
@@ -89,8 +90,9 @@ std::vector< gd::wstring > CharacterConversionDictionary::getAlternateWritings( 
           output = std::string( tmp );
           opencc_convert_utf8_free( tmp );
         }
-        else
+        else {
           gdWarning( "OpenCC: conversion failed %s\n", opencc_error() );
+        }
       }
       // #else
       //       output = converter->Convert( input );
@@ -101,8 +103,9 @@ std::vector< gd::wstring > CharacterConversionDictionary::getAlternateWritings( 
       gdWarning( "OpenCC: conversion failed %s\n", ex.what() );
     }
 
-    if ( !result.empty() && result != folded )
+    if ( !result.empty() && result != folded ) {
       results.push_back( result );
+    }
   }
 
   return results;
@@ -117,8 +120,9 @@ std::vector< sptr< Dictionary::Class > > makeDictionaries( Config::Chinese const
   QString configDir = "";
 #else
   QString configDir = Config::getOpenCCDir();
-  if ( !configDir.isEmpty() )
+  if ( !configDir.isEmpty() ) {
     configDir += "/";
+  }
 #endif
 
   if ( cfg.enable ) {

--- a/src/dict/dictionary.cc
+++ b/src/dict/dictionary.cc
@@ -75,16 +75,18 @@ WordMatch WordSearchRequest::operator[]( size_t index )
 {
   QMutexLocker _( &dataMutex );
 
-  if ( index >= matches.size() )
+  if ( index >= matches.size() ) {
     throw exIndexOutOfRange();
+  }
 
   return matches[ index ];
 }
 
 vector< WordMatch > & WordSearchRequest::getAllMatches()
 {
-  if ( !isFinished() )
+  if ( !isFinished() ) {
     throw exRequestUnfinished();
+  }
 
   return matches;
 }
@@ -92,12 +94,15 @@ vector< WordMatch > & WordSearchRequest::getAllMatches()
 void WordSearchRequest::addMatch( WordMatch const & match )
 {
   unsigned n;
-  for ( n = 0; n < matches.size(); n++ )
-    if ( matches[ n ].word.compare( match.word ) == 0 )
+  for ( n = 0; n < matches.size(); n++ ) {
+    if ( matches[ n ].word.compare( match.word ) == 0 ) {
       break;
+    }
+  }
 
-  if ( n >= matches.size() )
+  if ( n >= matches.size() ) {
     matches.push_back( match );
+  }
 }
 
 ////////////// DataRequest
@@ -141,16 +146,18 @@ void DataRequest::getDataSlice( size_t offset, size_t size, void * buffer )
   }
   QMutexLocker _( &dataMutex );
 
-  if ( !hasAnyData )
+  if ( !hasAnyData ) {
     throw exSliceOutOfRange();
+  }
 
   memcpy( buffer, &data[ offset ], size );
 }
 
 vector< char > & DataRequest::getFullData()
 {
-  if ( !isFinished() )
+  if ( !isFinished() ) {
     throw exRequestUnfinished();
+  }
 
   return data;
 }
@@ -194,8 +201,9 @@ QString Class::getContainingFolder() const
 {
   if ( !dictionaryFiles.empty() ) {
     auto fileInfo = QFileInfo( QString::fromStdString( dictionaryFiles[ 0 ] ) );
-    if ( fileInfo.isDir() )
+    if ( fileInfo.isDir() ) {
       return fileInfo.absoluteFilePath();
+    }
     return fileInfo.absolutePath();
   }
 
@@ -225,8 +233,9 @@ QString Class::getMainFilename()
 
 QIcon const & Class::getIcon() noexcept
 {
-  if ( !dictionaryIconLoaded )
+  if ( !dictionaryIconLoaded ) {
     loadIcon();
+  }
   return dictionaryIcon;
 }
 
@@ -245,8 +254,9 @@ bool Class::loadIconFromFile( QString const & _filename, bool isFullName )
   QFileInfo info;
   QString fileName( _filename );
 
-  if ( isFullName )
+  if ( isFullName ) {
     info = QFileInfo( fileName );
+  }
   else {
     fileName += "bmp";
     info = QFileInfo( fileName );
@@ -285,8 +295,9 @@ bool Class::loadIconFromFile( QString const & _filename, bool isFullName )
 
 bool Class::loadIconFromText( QString iconUrl, QString const & text )
 {
-  if ( text.isEmpty() )
+  if ( text.isEmpty() ) {
     return false;
+  }
   QImage img( iconUrl );
 
   if ( !img.isNull() ) {
@@ -323,15 +334,17 @@ bool Class::loadIconFromText( QString iconUrl, QString const & text )
 
 QString Class::getAbbrName( QString const & text )
 {
-  if ( text.isEmpty() )
+  if ( text.isEmpty() ) {
     return {};
+  }
   //remove whitespace,number,mark,puncuation,symbol
   QString simplified = text;
   simplified.remove(
     QRegularExpression( R"([\p{Z}\p{N}\p{M}\p{P}\p{S}])", QRegularExpression::UseUnicodePropertiesOption ) );
 
-  if ( simplified.isEmpty() )
+  if ( simplified.isEmpty() ) {
     return {};
+  }
   int index = qHash( simplified ) % simplified.size();
 
   QString abbrName;
@@ -352,8 +365,9 @@ QString Class::getAbbrName( QString const & text )
 
 void Class::isolateCSS( QString & css, QString const & wrapperSelector )
 {
-  if ( css.isEmpty() )
+  if ( css.isEmpty() ) {
     return;
+  }
 
   //comment syntax like:/* */
   QRegularExpression reg1( R"(\/\*(?:.(?!\*\/))*.?\*\/)", QRegularExpression::DotMatchesEverythingOption );
@@ -365,8 +379,9 @@ void Class::isolateCSS( QString & css, QString const & wrapperSelector )
   QString newCSS;
   QString prefix( "#gdfrom-" );
   prefix += QString::fromLatin1( getId().c_str() );
-  if ( !wrapperSelector.isEmpty() )
+  if ( !wrapperSelector.isEmpty() ) {
     prefix += " " + wrapperSelector;
+  }
 
   // Strip comments
   css.replace( reg1, QString() );
@@ -375,8 +390,9 @@ void Class::isolateCSS( QString & css, QString const & wrapperSelector )
   css.replace( QRegularExpression( R"(:root\s*{)" ), "html{" );
 
   for ( ;; ) {
-    if ( currentPos >= css.length() )
+    if ( currentPos >= css.length() ) {
       break;
+    }
     QChar ch = css[ currentPos ];
 
     if ( ch == '@' ) {
@@ -390,8 +406,9 @@ void Class::isolateCSS( QString & css, QString const & wrapperSelector )
         // Copy rule as is.
         n      = css.indexOf( ';', currentPos );
         int n2 = css.indexOf( '{', currentPos );
-        if ( n2 > 0 && n > n2 )
+        if ( n2 > 0 && n > n2 ) {
           n = n2 - 1;
+        }
       }
       else if ( css.mid( currentPos, 6 ).compare( "@media", Qt::CaseInsensitive ) == 0 ) {
         // We must to parse it content to isolate it.
@@ -401,8 +418,9 @@ void Class::isolateCSS( QString & css, QString const & wrapperSelector )
       else if ( css.mid( currentPos, 5 ).compare( "@page", Qt::CaseInsensitive ) == 0 ) {
         // Don't copy rule. GD use own page layout.
         n = css.indexOf( '}', currentPos );
-        if ( n < 0 )
+        if ( n < 0 ) {
           break;
+        }
         currentPos = n + 1;
         continue;
       }
@@ -413,8 +431,9 @@ void Class::isolateCSS( QString & css, QString const & wrapperSelector )
 
       newCSS.append( css.mid( currentPos, n < 0 ? n : n - currentPos + 1 ) );
 
-      if ( n < 0 )
+      if ( n < 0 ) {
         break;
+      }
 
       currentPos = n + 1;
       continue;
@@ -426,8 +445,9 @@ void Class::isolateCSS( QString & css, QString const & wrapperSelector )
 
       int n = css.indexOf( '}', currentPos );
       newCSS.append( css.mid( currentPos, n == -1 ? n : n - currentPos + 1 ) );
-      if ( n < 0 )
+      if ( n < 0 ) {
         break;
+      }
       currentPos = n + 1;
       continue;
     }
@@ -438,8 +458,10 @@ void Class::isolateCSS( QString & css, QString const & wrapperSelector )
         QChar chr;
         for ( int i = currentPos; i < css.length(); i++ ) {
           chr = css[ i ];
-          if ( chr.isLetterOrNumber() || chr.isMark() || chr == '_' || chr == '-' || ( chr == '*' && i == currentPos ) )
+          if ( chr.isLetterOrNumber() || chr.isMark() || chr == '_' || chr == '-'
+               || ( chr == '*' && i == currentPos ) ) {
             continue;
+          }
 
           if ( chr == '|' ) {
             // Namespace prefix found, copy it as is
@@ -448,8 +470,9 @@ void Class::isolateCSS( QString & css, QString const & wrapperSelector )
           }
           break;
         }
-        if ( chr == '|' )
+        if ( chr == '|' ) {
           continue;
+        }
       }
 
       // This is some selector.
@@ -474,8 +497,9 @@ void Class::isolateCSS( QString & css, QString const & wrapperSelector )
       n = css.indexOf( reg3, currentPos );
       s = css.mid( currentPos, n < 0 ? n : n - currentPos );
       newCSS.append( s );
-      if ( n < 0 )
+      if ( n < 0 ) {
         break;
+      }
       currentPos = n;
       continue;
     }
@@ -499,8 +523,9 @@ string makeDictionaryId( vector< string > const & dictionaryFiles ) noexcept
     for ( const auto & full : dictionaryFiles ) {
       QFileInfo fileInfo( QString::fromStdString( full ) );
 
-      if ( fileInfo.isAbsolute() )
+      if ( fileInfo.isAbsolute() ) {
         sortedList.push_back( dictionariesDir.relativeFilePath( fileInfo.filePath() ).toStdString() );
+      }
       else {
         // Well, it's relative. We don't technically support those, but
         // what the heck
@@ -508,8 +533,9 @@ string makeDictionaryId( vector< string > const & dictionaryFiles ) noexcept
       }
     }
   }
-  else
+  else {
     sortedList = dictionaryFiles;
+  }
 
   std::sort( sortedList.begin(), sortedList.end() );
 
@@ -536,30 +562,35 @@ bool needToRebuildIndex( vector< string > const & dictionaryFiles, string const 
     QFileInfo fileInfo( name );
     unsigned long ts;
 
-    if ( fileInfo.isDir() )
+    if ( fileInfo.isDir() ) {
       continue;
+    }
 
     if ( name.toLower().endsWith( ".zip" ) ) {
       ZipFile::SplitZipFile zf( name );
-      if ( !zf.exists() )
+      if ( !zf.exists() ) {
         return true;
+      }
       ts = zf.lastModified().toSecsSinceEpoch();
     }
     else {
-      if ( !fileInfo.exists() )
+      if ( !fileInfo.exists() ) {
         continue;
+      }
       ts = fileInfo.lastModified().toSecsSinceEpoch();
     }
 
-    if ( ts > lastModified )
+    if ( ts > lastModified ) {
       lastModified = ts;
+    }
   }
 
 
   QFileInfo fileInfo( indexFile.c_str() );
 
-  if ( !fileInfo.exists() )
+  if ( !fileInfo.exists() ) {
     return true;
+  }
 
   return fileInfo.lastModified().toSecsSinceEpoch() < lastModified;
 }
@@ -581,8 +612,9 @@ QMap< std::string, sptr< Dictionary::Class > > dictToMap( std::vector< sptr< Dic
 {
   QMap< std::string, sptr< Dictionary::Class > > dictMap;
   for ( auto & dict : dicts ) {
-    if ( !dict )
+    if ( !dict ) {
       continue;
+    }
     dictMap.insert( dict.get()->getId(), dict );
   }
   return dictMap;

--- a/src/dict/dictionary.hh
+++ b/src/dict/dictionary.hh
@@ -401,8 +401,8 @@ public:
     auto newProgress = getIndexingFtsProgress();
     if ( newProgress != lastProgress ) {
       lastProgress = newProgress;
-      emit GlobalBroadcaster::instance()->indexingDictionary(
-        QString( "%1......%%2" ).arg( QString::fromStdString( getName() ) ).arg( newProgress ) );
+      emit GlobalBroadcaster::instance()
+        -> indexingDictionary( QString( "%1......%%2" ).arg( QString::fromStdString( getName() ) ).arg( newProgress ) );
     }
   }
 

--- a/src/dict/dictserver.cc
+++ b/src/dict/dictserver.cc
@@ -45,8 +45,9 @@ enum class DictServerState {
 
 void disconnectFromServer( QTcpSocket & socket )
 {
-  if ( socket.state() == QTcpSocket::ConnectedState )
+  if ( socket.state() == QTcpSocket::ConnectedState ) {
     socket.write( QByteArray( "QUIT\r\n" ) );
+  }
 
   socket.disconnectFromHost();
 }
@@ -79,8 +80,9 @@ public:
   void run( std::function< void() > callback )
   {
     int pos = url.indexOf( "://" );
-    if ( pos < 0 )
+    if ( pos < 0 ) {
       url = "dict://" + url;
+    }
 
     QUrl serverUrl( url );
     quint16 port = serverUrl.port( DefaultPort );
@@ -124,8 +126,9 @@ public:
             authCommand += serverUrl.userInfo().left( pos );
             authString += serverUrl.userInfo().mid( pos + 1 );
           }
-          else
+          else {
             authCommand += serverUrl.userInfo();
+          }
 
           authCommand += " ";
           authCommand += QCryptographicHash::hash( authString.toUtf8(), QCryptographicHash::Md5 ).toHex();
@@ -199,16 +202,19 @@ public:
     langId( 0 )
   {
     int pos = url.indexOf( "://" );
-    if ( pos < 0 )
+    if ( pos < 0 ) {
       url = "dict://" + url;
+    }
 
     databases = database_.split( QRegularExpression( "[ ,;]" ), Qt::SkipEmptyParts );
-    if ( databases.isEmpty() )
+    if ( databases.isEmpty() ) {
       databases.append( "*" );
+    }
 
     strategies = strategies_.split( QRegularExpression( "[ ,;]" ), Qt::SkipEmptyParts );
-    if ( strategies.isEmpty() )
+    if ( strategies.isEmpty() ) {
       strategies.append( "prefix" );
+    }
     QUrl serverUrl( url );
     quint16 port = serverUrl.port( DefaultPort );
     QString reply;
@@ -257,8 +263,9 @@ public:
               return;
             }
 
-            if ( !reply.isEmpty() )
+            if ( !reply.isEmpty() ) {
               serverDatabases.append( reply );
+            }
           }
 
           qDebug() << "db count:" << x;
@@ -279,8 +286,9 @@ public:
 
           reply = reply.trimmed();
 
-          if ( !reply.isEmpty() )
+          if ( !reply.isEmpty() ) {
             serverDatabases.append( reply );
+          }
 
           reply = socket.readLine();
         }
@@ -343,16 +351,19 @@ signals:
 
 void DictServerDictionary::loadIcon() noexcept
 {
-  if ( dictionaryIconLoaded )
+  if ( dictionaryIconLoaded ) {
     return;
+  }
 
   if ( !icon.isEmpty() ) {
     QFileInfo fInfo( QDir( Config::getConfigDir() ), icon );
-    if ( fInfo.isFile() )
+    if ( fInfo.isFile() ) {
       loadIconFromFile( fInfo.absoluteFilePath(), true );
+    }
   }
-  if ( dictionaryIcon.isNull() )
+  if ( dictionaryIcon.isNull() ) {
     dictionaryIcon = QIcon( ":/icons/network.svg" );
+  }
   dictionaryIconLoaded = true;
 }
 
@@ -361,16 +372,18 @@ QString const & DictServerDictionary::getDescription()
   if ( dictionaryDescription.isEmpty() ) {
     dictionaryDescription = QCoreApplication::translate( "DictServer", "Url: " ) + url + "<br>";
     dictionaryDescription += QCoreApplication::translate( "DictServer", "Databases: " ) + "<br>";
-    for ( const auto & serverDatabase : databases )
+    for ( const auto & serverDatabase : databases ) {
       dictionaryDescription += serverDatabase + "<br>";
+    }
     dictionaryDescription +=
       QCoreApplication::translate( "DictServer", "Search strategies: " ) + strategies.join( ", " );
     if ( !serverDatabases.isEmpty() ) {
       dictionaryDescription += "<br><br>";
       dictionaryDescription += QCoreApplication::translate( "DictServer", "Server databases" ) + " ("
         + QString::number( serverDatabases.size() ) + "):" + "<br>";
-      for ( const auto & serverDatabase : serverDatabases )
+      for ( const auto & serverDatabase : serverDatabases ) {
         dictionaryDescription += serverDatabase + "<br>";
+      }
     }
   }
   return dictionaryDescription;
@@ -410,8 +423,9 @@ public:
 
       if ( countn ) {
         QMutexLocker _( &dataMutex );
-        for ( int x = 0; x < countn; x++ )
+        for ( int x = 0; x < countn; x++ ) {
           matches.emplace_back( gd::toWString( matchesList.at( x ) ) );
+        }
       }
       finish();
     } );
@@ -521,10 +535,12 @@ void DictServerWordSearchRequest::readMatchData( QByteArray & reply )
     int pos = reply.indexOf( ' ' );
     if ( pos >= 0 ) {
       QString word = reply.mid( pos + 1 );
-      if ( word.endsWith( '\"' ) )
+      if ( word.endsWith( '\"' ) ) {
         word.chop( 1 );
-      if ( word[ 0 ] == '\"' )
+      }
+      if ( word[ 0 ] == '\"' ) {
         word = word.mid( 1 );
+      }
 
       this->addMatchedWord( word );
     }
@@ -588,10 +604,12 @@ public:
       static QRegularExpression tags( "<[^>]*>", QRegularExpression::CaseInsensitiveOption );
 
       string articleStr;
-      if ( contentInHtml )
+      if ( contentInHtml ) {
         articleStr = articleText.toUtf8().data();
-      else
+      }
+      else {
         articleStr = Html::preformat( articleText.toUtf8().data() );
+      }
 
       articleText = QString::fromUtf8( articleStr.c_str(), articleStr.size() );
       int pos;
@@ -750,8 +768,9 @@ void DictServerArticleRequest::run()
       QByteArray reply = dictImpl->socket.readLine();
       qDebug() << "receive define data:" << reply;
       while ( true ) {
-        if ( reply.isEmpty() )
+        if ( reply.isEmpty() ) {
           return;
+        }
         readData( reply );
         reply = dictImpl->socket.readLine();
       }
@@ -766,21 +785,25 @@ void DictServerArticleRequest::run()
 
 void DictServerArticleRequest::readData( QByteArray reply )
 {
-  if ( reply.isEmpty() )
+  if ( reply.isEmpty() ) {
     return;
+  }
 
-  if ( reply.left( 3 ) == "250" )
+  if ( reply.left( 3 ) == "250" ) {
     return;
+  }
 
   if ( reply.left( 3 ) == "151" ) {
     int pos = 4;
     int endPos;
 
     // Skip requested word
-    if ( reply[ pos ] == '\"' )
+    if ( reply[ pos ] == '\"' ) {
       endPos = reply.indexOf( '\"', pos + 1 ) + 1;
-    else
+    }
+    else {
       endPos = reply.indexOf( ' ', pos );
+    }
 
     if ( endPos < pos ) {
       // It seems mailformed string
@@ -804,10 +827,12 @@ void DictServerArticleRequest::readData( QByteArray reply )
     // Retrieve database ID
     pos    = endPos + 1;
     endPos = reply.indexOf( ' ', pos );
-    if ( reply[ pos ] == '\"' )
+    if ( reply[ pos ] == '\"' ) {
       endPos = reply.indexOf( '\"', pos + 1 ) + 1;
-    else
+    }
+    else {
       endPos = reply.indexOf( ' ', pos );
+    }
 
     if ( endPos < pos ) {
       // It seems mailformed string
@@ -815,10 +840,12 @@ void DictServerArticleRequest::readData( QByteArray reply )
     }
 
     dbName = reply.mid( pos, endPos - pos );
-    if ( dbName.endsWith( '\"' ) )
+    if ( dbName.endsWith( '\"' ) ) {
       dbName.chop( 1 );
-    if ( dbName[ 0 ] == '\"' )
+    }
+    if ( dbName[ 0 ] == '\"' ) {
       dbName = dbName.mid( 1 );
+    }
 
     articleData += string( "<div class=\"dictserver_from\">" ) + dbName.toUtf8().data() + "[" + dbID.toUtf8().data()
       + "]" + "</div>";
@@ -830,15 +857,18 @@ void DictServerArticleRequest::readData( QByteArray reply )
 
     for ( ;; ) {
       reply = dictImpl->socket.readLine();
-      if ( reply.isEmpty() )
+      if ( reply.isEmpty() ) {
         return;
+      }
 
-      if ( reply == "\r\n" )
+      if ( reply == "\r\n" ) {
         break;
+      }
 
       QRegularExpressionMatch match = contentTypeExpr.match( reply );
-      if ( match.hasMatch() )
+      if ( match.hasMatch() ) {
         contentInHtml = true;
+      }
     }
     QString articleText;
     // Retrieve article text
@@ -846,8 +876,9 @@ void DictServerArticleRequest::readData( QByteArray reply )
     articleText.clear();
     for ( ;; ) {
       reply = dictImpl->socket.readLine();
-      if ( reply.isEmpty() )
+      if ( reply.isEmpty() ) {
         return;
+      }
 
       qDebug() << "reply data:" << reply;
       if ( reply == ".\r\n" ) {
@@ -877,8 +908,9 @@ sptr< WordSearchRequest > DictServerDictionary::prefixMatch( wstring const & wor
 
     return std::make_shared< WordSearchRequestInstant >();
   }
-  else
+  else {
     return std::make_shared< DictServerWordSearchRequest >( word, *this );
+  }
 }
 
 sptr< DataRequest >
@@ -890,8 +922,9 @@ DictServerDictionary::getArticle( wstring const & word, vector< wstring > const 
 
     return std::make_shared< DataRequestInstant >( false );
   }
-  else
+  else {
     return std::make_shared< DictServerArticleRequest >( word, *this );
+  }
 }
 
 } // namespace
@@ -902,13 +935,14 @@ vector< sptr< Dictionary::Class > > makeDictionaries( Config::DictServers const 
   vector< sptr< Dictionary::Class > > result;
 
   for ( const auto & server : servers ) {
-    if ( server.enabled )
+    if ( server.enabled ) {
       result.push_back( std::make_shared< DictServerDictionary >( server.id.toStdString(),
                                                                   server.name.toUtf8().data(),
                                                                   server.url,
                                                                   server.databases,
                                                                   server.strategies,
                                                                   server.iconFilename ) );
+    }
   }
 
   return result;

--- a/src/dict/dsl.cc
+++ b/src/dict/dsl.cc
@@ -234,14 +234,16 @@ public:
 
   void setFTSParameters( Config::FullTextSearch const & fts ) override
   {
-    if ( ensureInitDone().size() )
+    if ( ensureInitDone().size() ) {
       return;
+    }
     if ( metadata_enable_fts.has_value() ) {
       can_FTS = fts.enabled && metadata_enable_fts.value();
     }
-    else
+    else {
       can_FTS = fts.enabled && !fts.disabledTypes.contains( "DSL", Qt::CaseInsensitive )
         && ( fts.maxDictionarySize == 0 || getArticleCount() <= fts.maxDictionarySize );
+    }
   }
 
   uint32_t getFtsIndexVersion() override
@@ -315,8 +317,9 @@ DslDictionary::DslDictionary( string const & id, string const & indexFile, vecto
 
   resourceDir1 = getDictionaryFilenames()[ 0 ] + ".files" + Utils::Fs::separator();
   QString s    = QString::fromStdString( getDictionaryFilenames()[ 0 ] );
-  if ( s.endsWith( QString::fromLatin1( ".dz" ), Qt::CaseInsensitive ) )
+  if ( s.endsWith( QString::fromLatin1( ".dz" ), Qt::CaseInsensitive ) ) {
     s.chop( 3 );
+  }
   resourceDir2 = s.toStdString() + ".files" + Utils::Fs::separator();
 
   // Everything else would be done in deferred init
@@ -330,8 +333,9 @@ DslDictionary::~DslDictionary()
   // if ( deferredInitRunnableStarted )
   //   deferredInitRunnableExited.acquire();
 
-  if ( dz )
+  if ( dz ) {
     dict_data_close( dz );
+  }
 }
 
 //////// DslDictionary::deferredInit()
@@ -341,8 +345,9 @@ void DslDictionary::deferredInit()
   if ( !Utils::AtomicInt::loadAcquire( deferredInitDone ) ) {
     QMutexLocker _( &deferredInitMutex );
 
-    if ( Utils::AtomicInt::loadAcquire( deferredInitDone ) )
+    if ( Utils::AtomicInt::loadAcquire( deferredInitDone ) ) {
       return;
+    }
 
     if ( !deferredInitRunnableStarted ) {
       QThreadPool::globalInstance()->start(
@@ -369,8 +374,9 @@ void DslDictionary::doDeferredInit()
   if ( !Utils::AtomicInt::loadAcquire( deferredInitDone ) ) {
     QMutexLocker _( &deferredInitMutex );
 
-    if ( Utils::AtomicInt::loadAcquire( deferredInitDone ) )
+    if ( Utils::AtomicInt::loadAcquire( deferredInitDone ) ) {
       return;
+    }
 
     // Do deferred init
 
@@ -386,8 +392,9 @@ void DslDictionary::doDeferredInit()
       DZ_ERRORS error;
       dz = dict_data_open( getDictionaryFilenames()[ 0 ].c_str(), &error, 0 );
 
-      if ( !dz )
+      if ( !dz ) {
         throw exDictzipError( string( dz_error_str( error ) ) + "(" + getDictionaryFilenames()[ 0 ] + ")" );
+      }
 
       // Read the abrv, if any
 
@@ -434,8 +441,9 @@ void DslDictionary::doDeferredInit()
 
         QString zipName = QDir::fromNativeSeparators( getDictionaryFilenames().back().c_str() );
 
-        if ( zipName.endsWith( ".zip", Qt::CaseInsensitive ) ) // Sanity check
+        if ( zipName.endsWith( ".zip", Qt::CaseInsensitive ) ) { // Sanity check
           resourceZip.openZipFile( zipName );
+        }
       }
     }
     catch ( std::exception & e ) {
@@ -452,16 +460,19 @@ void DslDictionary::doDeferredInit()
 
 void DslDictionary::loadIcon() noexcept
 {
-  if ( dictionaryIconLoaded )
+  if ( dictionaryIconLoaded ) {
     return;
+  }
 
   QString fileName = QDir::fromNativeSeparators( getDictionaryFilenames()[ 0 ].c_str() );
 
   // Remove the extension
-  if ( fileName.endsWith( ".dsl.dz", Qt::CaseInsensitive ) )
+  if ( fileName.endsWith( ".dsl.dz", Qt::CaseInsensitive ) ) {
     fileName.chop( 6 );
-  else
+  }
+  else {
     fileName.chop( 3 );
+  }
 
   if ( !loadIconFromFile( fileName ) ) {
     // Load failed -- use default icons
@@ -561,8 +572,9 @@ void DslDictionary::loadArticle( uint32_t address,
 
     pos = articleData.find_first_of( U"\n\r", begin );
 
-    if ( pos == wstring::npos )
+    if ( pos == wstring::npos ) {
       pos = articleData.size();
+    }
 
     if ( !foundDisplayedHeadword ) {
       // Process the headword
@@ -576,14 +588,17 @@ void DslDictionary::loadArticle( uint32_t address,
           wstring head = Folding::trimWhitespace( rawHeadword.substr( hpos + 1 ) );
           hpos         = head.find( L'~' );
           while ( hpos != string::npos ) {
-            if ( hpos == 0 || head[ hpos ] != L'\\' )
+            if ( hpos == 0 || head[ hpos ] != L'\\' ) {
               break;
+            }
             hpos = head.find( L'~', hpos + 1 );
           }
-          if ( hpos == string::npos )
+          if ( hpos == string::npos ) {
             rawHeadword = head;
-          else
+          }
+          else {
             rawHeadword.clear();
+          }
         }
       }
 
@@ -596,8 +611,9 @@ void DslDictionary::loadArticle( uint32_t address,
 
           expandOptionalParts( tildeValue, &lst );
 
-          if ( lst.size() ) // Should always be
+          if ( lst.size() ) { // Should always be
             tildeValue = lst.front();
+          }
 
           tildeValueWithUnsorted = tildeValue;
 
@@ -605,8 +621,9 @@ void DslDictionary::loadArticle( uint32_t address,
         }
         wstring str = rawHeadword;
 
-        if ( hadFirstHeadword )
+        if ( hadFirstHeadword ) {
           expandTildes( str, tildeValueWithUnsorted );
+        }
 
         processUnsortedParts( str, true );
 
@@ -623,16 +640,19 @@ void DslDictionary::loadArticle( uint32_t address,
           normalizeHeadword( i );
 
           bool found;
-          if ( ignoreDiacritics )
+          if ( ignoreDiacritics ) {
             found = Folding::applyDiacriticsOnly( Folding::trimWhitespace( i ) )
               == Folding::applyDiacriticsOnly( requestedHeadwordFolded );
-          else
+          }
+          else {
             found = Folding::trimWhitespace( i ) == requestedHeadwordFolded;
+          }
 
           if ( found ) {
             // Found it. Now we should make a displayed headword for it.
-            if ( hadFirstHeadword )
+            if ( hadFirstHeadword ) {
               expandTildes( rawHeadword, tildeValueWithUnsorted );
+            }
 
             processUnsortedParts( rawHeadword, false );
 
@@ -651,17 +671,20 @@ void DslDictionary::loadArticle( uint32_t address,
     }
 
 
-    if ( pos == articleData.size() )
+    if ( pos == articleData.size() ) {
       break;
+    }
 
     // Skip \n\r
 
-    if ( articleData[ pos ] == '\r' )
+    if ( articleData[ pos ] == '\r' ) {
       ++pos;
+    }
 
     if ( pos != articleData.size() ) {
-      if ( articleData[ pos ] == '\n' )
+      if ( articleData[ pos ] == '\n' ) {
         ++pos;
+      }
     }
 
     if ( pos == articleData.size() ) {
@@ -673,33 +696,40 @@ void DslDictionary::loadArticle( uint32_t address,
       if ( insidedCard ) {
         // Check for next insided headword
         wstring::size_type hpos = articleData.find_first_of( U"\n\r", pos );
-        if ( hpos == wstring::npos )
+        if ( hpos == wstring::npos ) {
           hpos = articleData.size();
+        }
 
         wstring str = wstring( articleData, pos, hpos - pos );
 
         hpos = str.find( L'@' );
-        if ( hpos == wstring::npos || str[ hpos - 1 ] == L'\\' || !isAtSignFirst( str ) )
+        if ( hpos == wstring::npos || str[ hpos - 1 ] == L'\\' || !isAtSignFirst( str ) ) {
           break;
+        }
       }
-      else
+      else {
         break;
+      }
     }
   }
 
   if ( !foundDisplayedHeadword ) {
     // This is strange. Anyway, use tilde expansion value, it's better
     // than nothing (or requestedHeadwordFolded for insided card.
-    if ( insidedCard )
+    if ( insidedCard ) {
       displayedHeadword = requestedHeadwordFolded;
-    else
+    }
+    else {
       displayedHeadword = tildeValue;
+    }
   }
 
-  if ( pos != articleData.size() )
+  if ( pos != articleData.size() ) {
     articleText = wstring( articleData, pos );
-  else
+  }
+  else {
     articleText.clear();
+  }
 }
 
 string DslDictionary::dslToHtml( wstring const & str, wstring const & headword )
@@ -721,8 +751,9 @@ string DslDictionary::processNodeChildren( ArticleDom::Node const & node )
 {
   string result;
 
-  for ( const auto & i : node )
+  for ( const auto & i : node ) {
     result += nodeToHtml( i );
+  }
 
   return result;
 }
@@ -739,8 +770,9 @@ string DslDictionary::getNodeLink( ArticleDom::Node const & node )
       link           = Html::escape( Filetype::simplifyString( string( target.toUtf8().data() ), false ) );
     }
   }
-  if ( link.empty() )
+  if ( link.empty() ) {
     link = Html::escape( Filetype::simplifyString( Utf8::encode( node.renderAsText() ), false ) );
+  }
 
   return link;
 }
@@ -757,26 +789,31 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
     string::size_type n;
 
     // Strip all '\r'
-    while ( ( n = result.find( '\r' ) ) != string::npos )
+    while ( ( n = result.find( '\r' ) ) != string::npos ) {
       result.erase( n, 1 );
+    }
 
     // Replace all '\n'
-    while ( ( n = result.find( '\n' ) ) != string::npos )
+    while ( ( n = result.find( '\n' ) ) != string::npos ) {
       result.replace( n, 1, "<p></p>" );
+    }
 
     return result;
   }
 
-  if ( node.tagName == U"b" )
+  if ( node.tagName == U"b" ) {
     result += "<b class=\"dsl_b\">" + processNodeChildren( node ) + "</b>";
-  else if ( node.tagName == U"i" )
+  }
+  else if ( node.tagName == U"i" ) {
     result += "<i class=\"dsl_i\">" + processNodeChildren( node ) + "</i>";
+  }
   else if ( node.tagName == U"u" ) {
     string nodeText = processNodeChildren( node );
 
-    if ( nodeText.size() && isDslWs( nodeText[ 0 ] ) )
+    if ( nodeText.size() && isDslWs( nodeText[ 0 ] ) ) {
       result.push_back( ' ' ); // Fix a common problem where in "foo[i] bar[/i]"
-                               // the space before "bar" gets underlined.
+    }
+    // the space before "bar" gets underlined.
 
     result += "<span class=\"dsl_u\">" + nodeText + "</span>";
   }
@@ -794,16 +831,21 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
       + QString::number( optionalPartNom++ ).toStdString();
     result += R"(<span class="dsl_opt" id=")" + id + "\">" + processNodeChildren( node ) + "</span>";
   }
-  else if ( node.tagName == U"m" )
+  else if ( node.tagName == U"m" ) {
     result += "<div class=\"dsl_m\">" + processNodeChildren( node ) + "</div>";
-  else if ( node.tagName.size() == 2 && node.tagName[ 0 ] == L'm' && iswdigit( node.tagName[ 1 ] ) )
+  }
+  else if ( node.tagName.size() == 2 && node.tagName[ 0 ] == L'm' && iswdigit( node.tagName[ 1 ] ) ) {
     result += "<div class=\"dsl_" + Utf8::encode( node.tagName ) + "\">" + processNodeChildren( node ) + "</div>";
-  else if ( node.tagName == U"trn" )
+  }
+  else if ( node.tagName == U"trn" ) {
     result += "<span class=\"dsl_trn\">" + processNodeChildren( node ) + "</span>";
-  else if ( node.tagName == U"ex" )
+  }
+  else if ( node.tagName == U"ex" ) {
     result += "<span class=\"dsl_ex\">" + processNodeChildren( node ) + "</span>";
-  else if ( node.tagName == U"com" )
+  }
+  else if ( node.tagName == U"com" ) {
     result += "<span class=\"dsl_com\">" + processNodeChildren( node ) + "</span>";
+  }
   else if ( node.tagName == U"s" || node.tagName == U"video" ) {
     string filename = Filetype::simplifyString( Utf8::encode( node.renderAsText() ), false );
     string n        = resourceDir1 + filename;
@@ -820,8 +862,9 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
       url.setScheme( "gdau" );
       url.setHost( QString::fromUtf8( search ? "search" : getId().c_str() ) );
       url.setPath( Utils::Url::ensureLeadingSlash( QString::fromUtf8( filename.c_str() ) ) );
-      if ( search && idxHeader.hasSoundDictionaryName )
+      if ( search && idxHeader.hasSoundDictionaryName ) {
         Utils::Url::setFragment( url, QString::fromUtf8( preferredSoundDictionary.c_str() ) );
+      }
 
       string ref = string( "\"" ) + url.toEncoded().data() + "\"";
 
@@ -865,8 +908,9 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
   }
   else if ( node.tagName == U"url" ) {
     string link = getNodeLink( node );
-    if ( QUrl::fromEncoded( link.c_str() ).scheme().isEmpty() )
+    if ( QUrl::fromEncoded( link.c_str() ).scheme().isEmpty() ) {
       link = "http://" + link;
+    }
 
     QUrl url( QString::fromUtf8( link.c_str() ) );
     if ( url.isLocalFile() && url.host().isEmpty() ) {
@@ -920,8 +964,9 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
       int n        = attr.indexOf( "id=" );
       if ( n >= 0 ) {
         int id = attr.mid( n + 3 ).toInt();
-        if ( id )
+        if ( id ) {
           langcode = findCodeForDslId( id );
+        }
       }
       else {
         n = attr.indexOf( "name=\"" );
@@ -933,8 +978,9 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
           }
         }
       }
-      if ( !langcode.empty() )
+      if ( !langcode.empty() ) {
         result += " lang=\"" + langcode + "\"";
+      }
     }
     result += ">" + processNodeChildren( node ) + "</span>";
   }
@@ -994,8 +1040,9 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
                QString::fromStdU32String( currentHeadword ).toUtf8().data() );
 
     result += "<span class=\"dsl_unknown\">[" + string( QString::fromStdU32String( node.tagName ).toUtf8().data() );
-    if ( !node.tagAttrs.empty() )
+    if ( !node.tagAttrs.empty() ) {
       result += " " + string( QString::fromStdU32String( node.tagAttrs ).toUtf8().data() );
+    }
     result += "]" + processNodeChildren( node ) + "</span>";
   }
 
@@ -1004,8 +1051,9 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
 
 QString const & DslDictionary::getDescription()
 {
-  if ( !dictionaryDescription.isEmpty() )
+  if ( !dictionaryDescription.isEmpty() ) {
     return dictionaryDescription;
+  }
 
   QString none = QStringLiteral( "NONE" );
 
@@ -1014,18 +1062,21 @@ QString const & DslDictionary::getDescription()
   QString fileName = QDir::fromNativeSeparators( getDictionaryFilenames()[ 0 ].c_str() );
 
   // Remove the extension
-  if ( fileName.endsWith( ".dsl.dz", Qt::CaseInsensitive ) )
+  if ( fileName.endsWith( ".dsl.dz", Qt::CaseInsensitive ) ) {
     fileName.chop( 6 );
-  else
+  }
+  else {
     fileName.chop( 3 );
+  }
 
   fileName += "ann";
   QFileInfo info( fileName );
 
   if ( info.exists() ) {
     QFile annFile( fileName );
-    if ( !annFile.open( QFile::ReadOnly | QFile::Text ) )
+    if ( !annFile.open( QFile::ReadOnly | QFile::Text ) ) {
       return dictionaryDescription;
+    }
 
     QTextStream annStream( &annFile );
     QString data, str;
@@ -1048,17 +1099,21 @@ QString const & DslDictionary::getDescription()
         annLang = LangCoder::findIdForLanguage( gd::toWString( langStr ) );
         do {
           str = annStream.readLine();
-          if ( str.left( 10 ).compare( "#LANGUAGE " ) == 0 )
+          if ( str.left( 10 ).compare( "#LANGUAGE " ) == 0 ) {
             break;
-          if ( !str.endsWith( '\n' ) )
+          }
+          if ( !str.endsWith( '\n' ) ) {
             str.append( '\n' );
+          }
           data += str;
         } while ( !annStream.atEnd() );
         if ( dictionaryDescription.compare( "NONE " ) == 0 || langStr.compare( "English", Qt::CaseInsensitive ) == 0
-             || gdLang == annLang )
+             || gdLang == annLang ) {
           dictionaryDescription = data.trimmed();
-        if ( gdLang == annLang || annStream.atEnd() )
+        }
+        if ( gdLang == annLang || annStream.atEnd() ) {
           break;
+        }
       }
     }
   }
@@ -1081,11 +1136,13 @@ void DslDictionary::makeFTSIndex( QAtomicInt & isCancelled )
   }
 
 
-  if ( haveFTSIndex() )
+  if ( haveFTSIndex() ) {
     return;
+  }
 
-  if ( !ensureInitDone().empty() )
+  if ( !ensureInitDone().empty() ) {
     return;
+  }
 
 
   gdDebug( "Dsl: Building the full-text index for dictionary: %s\n", getName().c_str() );
@@ -1158,8 +1215,9 @@ void DslDictionary::getArticleText( uint32_t articleAddress, QString & headword,
     size_t begin = pos;
 
     pos = articleData.find_first_of( U"\n\r", begin );
-    if ( pos == wstring::npos )
+    if ( pos == wstring::npos ) {
       pos = articleData.size();
+    }
 
     if ( articleHeadword.empty() ) {
       // Process the headword
@@ -1172,14 +1230,17 @@ void DslDictionary::getArticleText( uint32_t articleAddress, QString & headword,
           wstring head = Folding::trimWhitespace( articleHeadword.substr( hpos + 1 ) );
           hpos         = head.find( L'~' );
           while ( hpos != string::npos ) {
-            if ( hpos == 0 || head[ hpos ] != L'\\' )
+            if ( hpos == 0 || head[ hpos ] != L'\\' ) {
               break;
+            }
             hpos = head.find( L'~', hpos + 1 );
           }
-          if ( hpos == string::npos )
+          if ( hpos == string::npos ) {
             articleHeadword = head;
-          else
+          }
+          else {
             articleHeadword.clear();
+          }
         }
       }
 
@@ -1191,22 +1252,26 @@ void DslDictionary::getArticleText( uint32_t articleAddress, QString & headword,
         processUnsortedParts( articleHeadword, true );
         expandOptionalParts( articleHeadword, &lst );
 
-        if ( lst.size() ) // Should always be
+        if ( lst.size() ) { // Should always be
           articleHeadword = lst.front();
+        }
       }
     }
 
-    if ( pos == articleData.size() )
+    if ( pos == articleData.size() ) {
       break;
+    }
 
     // Skip \n\r
 
-    if ( articleData[ pos ] == '\r' )
+    if ( articleData[ pos ] == '\r' ) {
       ++pos;
+    }
 
     if ( pos < articleData.size() ) {
-      if ( articleData[ pos ] == '\n' )
+      if ( articleData[ pos ] == '\n' ) {
         ++pos;
+      }
     }
 
     if ( pos >= articleData.size() ) {
@@ -1218,17 +1283,20 @@ void DslDictionary::getArticleText( uint32_t articleAddress, QString & headword,
       if ( insidedCard ) {
         // Check for next insided headword
         wstring::size_type hpos = articleData.find_first_of( U"\n\r", pos );
-        if ( hpos == wstring::npos )
+        if ( hpos == wstring::npos ) {
           hpos = articleData.size();
+        }
 
         wstring str = wstring( articleData, pos, hpos - pos );
 
         hpos = str.find( L'@' );
-        if ( hpos == wstring::npos || str[ hpos - 1 ] == L'\\' || !isAtSignFirst( str ) )
+        if ( hpos == wstring::npos || str[ hpos - 1 ] == L'\\' || !isAtSignFirst( str ) ) {
           break;
+        }
       }
-      else
+      else {
         break;
+      }
     }
   }
 
@@ -1240,10 +1308,12 @@ void DslDictionary::getArticleText( uint32_t articleAddress, QString & headword,
 
   wstring articleText;
 
-  if ( pos != articleData.size() )
+  if ( pos != articleData.size() ) {
     articleText = wstring( articleData, pos );
-  else
+  }
+  else {
     articleText.clear();
+  }
 
   if ( !tildeValue.empty() ) {
     list< wstring > lst;
@@ -1251,8 +1321,9 @@ void DslDictionary::getArticleText( uint32_t articleAddress, QString & headword,
     processUnsortedParts( tildeValue, false );
     expandOptionalParts( tildeValue, &lst );
 
-    if ( lst.size() ) // Should always be
+    if ( lst.size() ) { // Should always be
       expandTildes( articleText, lst.front() );
+    }
   }
 
   if ( !articleText.empty() ) {
@@ -1279,8 +1350,9 @@ void DslDictionary::getArticleText( uint32_t articleAddress, QString & headword,
         }
 
         int pos2 = text.indexOf( ']', pos + 1, Qt::CaseInsensitive );
-        if ( pos2 < 0 )
+        if ( pos2 < 0 ) {
           break;
+        }
 
         QString tag = text.mid( pos + 1, pos2 - pos - 1 );
 
@@ -1293,8 +1365,9 @@ void DslDictionary::getArticleText( uint32_t articleAddress, QString & headword,
           }
         }
 
-        if ( n >= stripTagsNumber )
+        if ( n >= stripTagsNumber ) {
           pos += 1;
+        }
       }
     }
 
@@ -1318,8 +1391,9 @@ void DslDictionary::getArticleText( uint32_t articleAddress, QString & headword,
         break;
       }
 
-      if ( pos >= 0 )
+      if ( pos >= 0 ) {
         pos += 1;
+      }
     }
 
     if ( haveInsidedCards ) {
@@ -1333,8 +1407,9 @@ void DslDictionary::getArticleText( uint32_t articleAddress, QString & headword,
       while ( pos >= 0 ) {
         pos = text.indexOf( '\\', pos );
         if ( pos >= 0 ) {
-          if ( text[ pos + 1 ] == '\\' )
+          if ( text[ pos + 1 ] == '\\' ) {
             pos += 1;
+          }
 
           text.remove( pos, 1 );
         }
@@ -1442,24 +1517,29 @@ void DslArticleRequest::run()
                         headwordIndex,
                         articleBody );
 
-      if ( !articlesIncluded.insert( std::make_pair( x.articleOffset, headwordIndex ) ).second )
+      if ( !articlesIncluded.insert( std::make_pair( x.articleOffset, headwordIndex ) ).second ) {
         continue; // We already have this article in the body.
+      }
 
       dict.articleNom += 1;
 
-      if ( displayedHeadword.empty() || isDslWs( displayedHeadword[ 0 ] ) )
+      if ( displayedHeadword.empty() || isDslWs( displayedHeadword[ 0 ] ) ) {
         displayedHeadword = word; // Special case - insided card
+      }
 
       articleText += "<div class=\"dsl_article\">";
       articleText += "<div class=\"dsl_headwords\"";
-      if ( dict.isFromLanguageRTL() )
+      if ( dict.isFromLanguageRTL() ) {
         articleText += " dir=\"rtl\"";
+      }
       articleText += "><p>";
 
-      if ( displayedHeadword.size() == 1 && displayedHeadword[ 0 ] == '<' ) // Fix special case - "<" header
-        articleText += "<";                                                 // dslToHtml can't handle it correctly.
-      else
+      if ( displayedHeadword.size() == 1 && displayedHeadword[ 0 ] == '<' ) { // Fix special case - "<" header
+        articleText += "<";                                                   // dslToHtml can't handle it correctly.
+      }
+      else {
         articleText += dict.dslToHtml( displayedHeadword, displayedHeadword );
+      }
 
       /// After this may be expand button will be inserted
 
@@ -1468,8 +1548,9 @@ void DslArticleRequest::run()
       expandTildes( articleBody, tildeValue );
 
       articleAfter += "<div class=\"dsl_definition\"";
-      if ( dict.isToLanguageRTL() )
+      if ( dict.isToLanguageRTL() ) {
         articleAfter += " dir=\"rtl\"";
+      }
       articleAfter += ">";
 
       articleAfter += dict.dslToHtml( articleBody, displayedHeadword );
@@ -1482,10 +1563,12 @@ void DslArticleRequest::run()
         string id2    = prefix + "_opt_";
         string button = R"( <img src="qrc:///icons/expand_opt.png" class="hidden_expand_opt" id=")" + id1
           + "\" onclick=\"gdExpandOptPart('" + id1 + "','" + id2 + "')\" alt=\"[+]\"/>";
-        if ( articleText.compare( articleText.size() - 4, 4, "</p>" ) == 0 )
+        if ( articleText.compare( articleText.size() - 4, 4, "</p>" ) == 0 ) {
           articleText.insert( articleText.size() - 4, " " + button );
-        else
+        }
+        else {
           articleText += button;
+        }
       }
 
       articleText += articleAfter;
@@ -1596,11 +1679,13 @@ void DslResourceRequest::run()
           if ( dict.resourceZip.isOpen() ) {
             QMutexLocker _( &dataMutex );
 
-            if ( !dict.resourceZip.loadFile( Utf8::decode( resourceName ), data ) )
+            if ( !dict.resourceZip.loadFile( Utf8::decode( resourceName ), data ) ) {
               throw; // Make it fail since we couldn't read the archive
+            }
           }
-          else
+          else {
             throw;
+          }
         }
       }
     }
@@ -1663,8 +1748,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
     // Try .dsl and .dsl.dz suffixes
 
     bool uncompressedDsl = Utils::endsWithIgnoreCase( fileName, ".dsl" );
-    if ( !uncompressedDsl && !Utils::endsWithIgnoreCase( fileName, ".dsl.dz" ) )
+    if ( !uncompressedDsl && !Utils::endsWithIgnoreCase( fileName, ".dsl.dz" ) ) {
       continue;
+    }
 
     // Make sure it's not an abbreviation file
 
@@ -1690,8 +1776,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
            || File::tryPossibleName( baseName + "_abrv.dsl.dz", abrvFileName )
            || File::tryPossibleName( baseName + "_ABRV.DSL", abrvFileName )
            || File::tryPossibleName( baseName + "_ABRV.DSL.DZ", abrvFileName )
-           || File::tryPossibleName( baseName + "_ABRV.DSL.dz", abrvFileName ) )
+           || File::tryPossibleName( baseName + "_ABRV.DSL.dz", abrvFileName ) ) {
         dictFiles.push_back( abrvFileName );
+      }
 
       initializing.loadingDictionary( fileName );
 
@@ -1704,8 +1791,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
       if ( File::tryPossibleZipName( baseName + ".dsl.files.zip", zipFileName )
            || File::tryPossibleZipName( baseName + ".dsl.dz.files.zip", zipFileName )
            || File::tryPossibleZipName( baseName + ".DSL.FILES.ZIP", zipFileName )
-           || File::tryPossibleZipName( baseName + ".DSL.DZ.FILES.ZIP", zipFileName ) )
+           || File::tryPossibleZipName( baseName + ".DSL.DZ.FILES.ZIP", zipFileName ) ) {
         dictFiles.push_back( zipFileName );
+      }
 
       string indexFile = indicesDir + dictId;
 
@@ -1716,8 +1804,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
         try { // Here we intercept any errors during the read to save line at
               // which the incident happened. We need alive scanner for that.
 
-          if ( scanner.getDictionaryName() == U"Abbrev" )
+          if ( scanner.getDictionaryName() == U"Abbrev" ) {
             continue; // For now just skip abbreviations
+          }
 
           // Building the index
           initializing.indexingDictionary( Utf8::encode( scanner.getDictionaryName() ) );
@@ -1767,10 +1856,12 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
               for ( ;; ) {
                 // Skip any whitespace
-                if ( !abrvScanner.readNextLineWithoutComments( curString, curOffset, true ) )
+                if ( !abrvScanner.readNextLineWithoutComments( curString, curOffset, true ) ) {
                   break;
-                if ( curString.empty() || isDslWs( curString[ 0 ] ) )
+                }
+                if ( curString.empty() || isDslWs( curString[ 0 ] ) ) {
                   continue;
+                }
 
                 list< wstring > keys;
 
@@ -1780,8 +1871,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
                 for ( ;; ) {
                   processUnsortedParts( curString, true );
 
-                  if ( keys.size() )
+                  if ( keys.size() ) {
                     expandTildes( curString, keys.front() );
+                  }
 
                   expandOptionalParts( curString, &keys );
 
@@ -1791,17 +1883,20 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
                     break;
                   }
 
-                  if ( isDslWs( curString[ 0 ] ) )
+                  if ( isDslWs( curString[ 0 ] ) ) {
                     break;
+                  }
                 }
 
-                if ( eof )
+                if ( eof ) {
                   break;
+                }
 
                 curString.erase( 0, curString.find_first_not_of( U" \t" ) );
 
-                if ( keys.size() )
+                if ( keys.size() ) {
                   expandTildes( curString, keys.front() );
+                }
 
                 // If the string has any dsl markup, we strip it
                 string value = Utf8::encode( ArticleDom( curString ).root.renderAsText() );
@@ -1846,15 +1941,17 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
           for ( ;; ) {
             // Find the main headword
 
-            if ( !hasString && !scanner.readNextLineWithoutComments( curString, curOffset, true ) )
+            if ( !hasString && !scanner.readNextLineWithoutComments( curString, curOffset, true ) ) {
               break; // Clean end of file
+            }
 
             hasString = false;
 
             // The line read should either consist of pure whitespace, or be a headword
             // skip too long headword,it can never be headword.
-            if ( curString.empty() || curString.size() > 100 )
+            if ( curString.empty() || curString.size() > 100 ) {
               continue;
+            }
 
             if ( isDslWs( curString[ 0 ] ) ) {
               // The first character is blank. Let's make sure that all other
@@ -1888,11 +1985,13 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
               }
 
               // Lingvo skips empty strings between the headwords
-              if ( curString.empty() )
+              if ( curString.empty() ) {
                 continue;
+              }
 
-              if ( isDslWs( curString[ 0 ] ) )
+              if ( isDslWs( curString[ 0 ] ) ) {
                 break; // No more headwords
+              }
 
               qDebug() << "dsl Alt headword" << QString::fromStdU32String( curString );
 
@@ -1901,8 +2000,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
               expandOptionalParts( curString, &allEntryWords );
             }
 
-            if ( !hasString )
+            if ( !hasString ) {
               break;
+            }
 
             // Insert new entry
 
@@ -1941,8 +2041,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
                   gdWarning( "Unclosed tag '@' at line %i", dogLine );
                   insidedCards.append( InsidedCard( offset, curOffset - offset, insidedHeadwords ) );
                 }
-                if ( noSignificantLines )
+                if ( noSignificantLines ) {
                   gdWarning( "Orphan headword at line %i", headwordLine );
+                }
 
                 break;
               }
@@ -1954,19 +2055,22 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
                 continue;
               }
               else {
-                if ( wasEmptyLine && !Folding::applyWhitespaceOnly( curString ).empty() )
+                if ( wasEmptyLine && !Folding::applyWhitespaceOnly( curString ).empty() ) {
                   gdWarning( "Orphan string at line %i", scanner.getLinesRead() - 1 );
+                }
               }
 
-              if ( noSignificantLines )
+              if ( noSignificantLines ) {
                 noSignificantLines = Folding::applyWhitespaceOnly( curString ).empty();
+              }
 
               // Find embedded cards
 
               wstring::size_type n = curString.find( L'@' );
               if ( n == wstring::npos || curString[ n - 1 ] == L'\\' ) {
-                if ( insideInsided )
+                if ( insideInsided ) {
                   linesInsideCard++;
+                }
 
                 continue;
               }
@@ -1975,8 +2079,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
                 if ( !isAtSignFirst( curString ) ) {
                   gdWarning( "Unescaped '@' symbol at line %i", scanner.getLinesRead() - 1 );
 
-                  if ( insideInsided )
+                  if ( insideInsided ) {
                     linesInsideCard++;
+                  }
 
                   continue;
                 }
@@ -2008,8 +2113,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
                 insidedHeadwords.append( headword );
                 insideInsided = true;
               }
-              else
+              else {
                 insideInsided = false;
+              }
             }
 
             // Now that we're having read the first string after the article
@@ -2040,8 +2146,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
               ++articleCount;
             }
 
-            if ( !hasString )
+            if ( !hasString ) {
               break;
+            }
           }
 
           // Finish with the chunks
@@ -2066,8 +2173,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
             IndexedWords zipFileNames;
             IndexedZip zipFile;
-            if ( zipFile.openZipFile( QDir::fromNativeSeparators( zipFileName.c_str() ) ) )
+            if ( zipFile.openZipFile( QDir::fromNativeSeparators( zipFileName.c_str() ) ) ) {
               zipFile.indexFile( zipFileNames );
+            }
 
             if ( !zipFileNames.empty() ) {
               // Build the resulting zip file index
@@ -2084,8 +2192,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
               idxHeader.zipIndexRootOffset       = 0;
             }
           }
-          else
+          else {
             idxHeader.hasZipFile = 0;
+          }
 
           // That concludes it. Update the header.
 

--- a/src/dict/dsl_details.cc
+++ b/src/dict/dsl_details.cc
@@ -52,14 +52,17 @@ bool isAtSignFirst( wstring const & str )
 
 wstring ArticleDom::Node::renderAsText( bool stripTrsTag ) const
 {
-  if ( !isTag )
+  if ( !isTag ) {
     return text;
+  }
 
   wstring result;
 
-  for ( const auto & i : *this )
-    if ( !stripTrsTag || i.tagName != U"!trs" )
+  for ( const auto & i : *this ) {
+    if ( !stripTrsTag || i.tagName != U"!trs" ) {
       result += i.renderAsText( stripTrsTag );
+    }
+  }
 
   return result;
 }
@@ -115,21 +118,25 @@ ArticleDom::ArticleDom( wstring const & str, string const & dictName, wstring co
       if ( ch == L'@' && !escaped ) {
         if ( !atSignFirstInLine() ) {
           // Not insided card
-          if ( dictName.empty() )
+          if ( dictName.empty() ) {
             gdWarning( "Unescaped '@' symbol found" );
-          else
+          }
+          else {
             gdWarning( "Unescaped '@' symbol found in \"%s\"", dictName.c_str() );
+          }
         }
         else {
           // Insided card
           wstring linkTo;
           nextChar();
           for ( ;; nextChar() ) {
-            if ( ch == L'\n' )
+            if ( ch == L'\n' ) {
               break;
+            }
             if ( ch != L'\r' ) {
-              if ( escaped && ( ch == L'(' || ch == ')' ) )
+              if ( escaped && ( ch == L'(' || ch == ')' ) ) {
                 linkTo.push_back( L'\\' );
+              }
               linkTo.push_back( ch );
             }
           }
@@ -166,27 +173,31 @@ ArticleDom::ArticleDom( wstring const & str, string const & dictName, wstring co
               ArticleDom nodeDom( linkText, dictName, headword_ );
 
               Node link( Node::Tag(), U"@", wstring() );
-              for ( auto & n : nodeDom.root )
+              for ( auto & n : nodeDom.root ) {
                 link.push_back( n );
+              }
 
               ++entry;
 
               if ( stack.empty() ) {
                 root.push_back( link );
-                if ( entry != allLinkEntries.end() ) // Add line break before next entry
+                if ( entry != allLinkEntries.end() ) { // Add line break before next entry
                   root.push_back( Node( Node::Tag(), U"br", wstring() ) );
+                }
               }
               else {
                 stack.back()->push_back( link );
-                if ( entry != allLinkEntries.end() )
+                if ( entry != allLinkEntries.end() ) {
                   stack.back()->push_back( Node( Node::Tag(), U"br", wstring() ) );
+                }
               }
             }
 
             // Skip to next '@'
 
-            while ( !( ch == L'@' && !escaped && atSignFirstInLine() ) )
+            while ( !( ch == L'@' && !escaped && atSignFirstInLine() ) ) {
               nextChar();
+            }
 
             stringPos--;
             ch      = L'\n';
@@ -211,8 +222,9 @@ ArticleDom::ArticleDom( wstring const & str, string const & dictName, wstring co
             isClosing = true;
             nextChar();
           }
-          else
+          else {
             isClosing = false;
+          }
 
           // Read tag's name
 
@@ -221,8 +233,9 @@ ArticleDom::ArticleDom( wstring const & str, string const & dictName, wstring co
             nextChar();
           }
 
-          while ( Folding::isWhitespace( ch ) )
+          while ( Folding::isWhitespace( ch ) ) {
             nextChar();
+          }
 
           // Read attrs
 
@@ -232,16 +245,18 @@ ArticleDom::ArticleDom( wstring const & str, string const & dictName, wstring co
           }
         }
         catch ( std::exception & ex ) {
-          if ( !dictionaryName.empty() )
+          if ( !dictionaryName.empty() ) {
             gdWarning( R"(DSL: Unfinished tag "%s" with attributes "%s" found in "%s", article "%s".)",
                        QString::fromStdU32String( name ).toUtf8().data(),
                        QString::fromStdU32String( attrs ).toUtf8().data(),
                        dictionaryName.c_str(),
                        QString::fromStdU32String( headword ).toUtf8().data() );
-          else
+          }
+          else {
             gdWarning( R"(DSL: Unfinished tag "%s" with attributes "%s" found)",
                        QString::fromStdU32String( name ).toUtf8().data(),
                        QString::fromStdU32String( attrs ).toUtf8().data() );
+          }
 
           throw ex;
         }
@@ -257,21 +272,25 @@ ArticleDom::ArticleDom( wstring const & str, string const & dictName, wstring co
         // If the tag is [t], we update the transcriptionCount
         if ( name == U"t" ) {
           if ( isClosing ) {
-            if ( transcriptionCount )
+            if ( transcriptionCount ) {
               --transcriptionCount;
+            }
           }
-          else
+          else {
             ++transcriptionCount;
+          }
         }
 
         // If the tag is [s], we update the mediaCount
         if ( name == U"s" ) {
           if ( isClosing ) {
-            if ( mediaCount )
+            if ( mediaCount ) {
               --mediaCount;
+            }
           }
-          else
+          else {
             ++mediaCount;
+          }
         }
 
         if ( !isClosing ) {
@@ -319,23 +338,26 @@ ArticleDom::ArticleDom( wstring const & str, string const & dictName, wstring co
             if ( ch == L'>' && !escaped ) {
               nextChar();
 
-              if ( ch == L'>' && !escaped )
+              if ( ch == L'>' && !escaped ) {
                 break;
+              }
               else {
                 linkTo.push_back( L'>' );
                 linkTo.push_back( ch );
 
                 linkText.push_back( L'>' );
-                if ( escaped )
+                if ( escaped ) {
                   linkText.push_back( L'\\' );
+                }
                 linkText.push_back( ch );
               }
             }
             else {
               linkTo.push_back( ch );
 
-              if ( escaped )
+              if ( escaped ) {
                 linkText.push_back( L'\\' );
+              }
               linkText.push_back( ch );
             }
           }
@@ -353,13 +375,16 @@ ArticleDom::ArticleDom( wstring const & str, string const & dictName, wstring co
           ArticleDom nodeDom( linkText, dictName, headword_ );
 
           Node link( Node::Tag(), U"ref", wstring() );
-          for ( auto & n : nodeDom.root )
+          for ( auto & n : nodeDom.root ) {
             link.push_back( n );
+          }
 
-          if ( stack.empty() )
+          if ( stack.empty() ) {
             root.push_back( link );
-          else
+          }
+          else {
             stack.back()->push_back( link );
+          }
 
           continue;
         }
@@ -389,8 +414,9 @@ ArticleDom::ArticleDom( wstring const & str, string const & dictName, wstring co
             if ( ch == L'}' && !escaped ) {
               nextChar();
 
-              if ( ch == L'}' && !escaped )
+              if ( ch == L'}' && !escaped ) {
                 break;
+              }
             }
           }
 
@@ -628,8 +654,9 @@ ArticleDom::ArticleDom( wstring const & str, string const & dictName, wstring co
         }
       }
 
-      if ( escaped && ch == L' ' && mediaCount == 0 )
+      if ( escaped && ch == L' ' && mediaCount == 0 ) {
         ch = 0xA0; // Escaped spaces turn into non-breakable ones in Lingvo
+      }
 
       textNode->text.push_back( ch );
     } // for( ; ; )
@@ -637,13 +664,15 @@ ArticleDom::ArticleDom( wstring const & str, string const & dictName, wstring co
   catch ( eot & ) {
   }
 
-  if ( textNode )
+  if ( textNode ) {
     stack.pop_back();
+  }
 
   if ( !stack.empty() ) {
     auto it = std::find_if( stack.begin(), stack.end(), MustTagBeClosed() );
-    if ( it == stack.end() )
+    if ( it == stack.end() ) {
       return; // no unclosed tags that must be closed => nothing to warn about
+    }
     QByteArray const firstTagName = QString::fromStdU32String( ( *it )->tagName ).toUtf8();
     ++it;
     unsigned const unclosedTagCount = 1 + std::count_if( it, stack.end(), MustTagBeClosed() );
@@ -683,8 +712,9 @@ void ArticleDom::openTag( wstring const & name, wstring const & attrs, list< Nod
 
         parent->pop_back();
       }
-      else
+      else {
         stack.pop_back();
+      }
     }
   }
 
@@ -746,35 +776,41 @@ void ArticleDom::closeTag( wstring const & name, list< Node * > & stack, bool wa
 
         parent->pop_back();
       }
-      else
+      else {
         stack.pop_back();
+      }
 
-      if ( found )
+      if ( found ) {
         break;
+      }
     }
   }
   else if ( warn ) {
-    if ( !dictionaryName.empty() )
+    if ( !dictionaryName.empty() ) {
       gdWarning( R"(No corresponding opening tag for closing tag "%s" found in "%s", article "%s".)",
                  QString::fromStdU32String( name ).toUtf8().data(),
                  dictionaryName.c_str(),
                  QString::fromStdU32String( headword ).toUtf8().data() );
-    else
+    }
+    else {
       gdWarning( "No corresponding opening tag for closing tag \"%s\" found.",
                  QString::fromStdU32String( name ).toUtf8().data() );
+    }
   }
 }
 
 void ArticleDom::nextChar()
 {
-  if ( !*stringPos )
+  if ( !*stringPos ) {
     throw eot();
+  }
 
   ch = *stringPos++;
 
   if ( ch == L'\\' ) {
-    if ( !*stringPos )
+    if ( !*stringPos ) {
       throw eot();
+    }
 
     ch = *stringPos++;
 
@@ -788,18 +824,21 @@ void ArticleDom::nextChar()
     ++stringPos;
     escaped = true;
   }
-  else
+  else {
     escaped = false;
+  }
 
-  if ( ch == '\n' || ch == '\r' )
+  if ( ch == '\n' || ch == '\r' ) {
     lineStartPos = stringPos;
+  }
 }
 
 bool ArticleDom::atSignFirstInLine()
 {
   // Check if '@' sign is first after '\n', leading spaces and dsl tags
-  if ( stringPos <= lineStartPos )
+  if ( stringPos <= lineStartPos ) {
     return true;
+  }
 
   return isAtSignFirst( wstring( lineStartPos ) );
 }
@@ -816,8 +855,9 @@ DslScanner::DslScanner( string const & fileName ):
   // read it -- they are much nicer than the dict_data- ones.
 
   f = gd_gzopen( fileName.c_str() );
-  if ( !f )
+  if ( !f ) {
     throw exCantOpen( fileName );
+  }
 
   // Now try guessing the encoding
 
@@ -878,59 +918,74 @@ DslScanner::DslScanner( string const & fileName ):
       throw exMalformedDslFile( fileName );
     }
 
-    if ( str.empty() || str[ 0 ] != L'#' )
+    if ( str.empty() || str[ 0 ] != L'#' ) {
       break;
+    }
 
     bool isName      = false;
     bool isLangFrom  = false;
     bool isLangTo    = false;
     bool isSoundDict = false;
 
-    if ( !str.compare( 0, 5, U"#NAME", 5 ) )
+    if ( !str.compare( 0, 5, U"#NAME", 5 ) ) {
       isName = true;
-    else if ( !str.compare( 0, 15, U"#INDEX_LANGUAGE", 15 ) )
+    }
+    else if ( !str.compare( 0, 15, U"#INDEX_LANGUAGE", 15 ) ) {
       isLangFrom = true;
-    else if ( !str.compare( 0, 18, U"#CONTENTS_LANGUAGE", 18 ) )
+    }
+    else if ( !str.compare( 0, 18, U"#CONTENTS_LANGUAGE", 18 ) ) {
       isLangTo = true;
-    else if ( !str.compare( 0, 17, U"#SOUND_DICTIONARY", 17 ) )
+    }
+    else if ( !str.compare( 0, 17, U"#SOUND_DICTIONARY", 17 ) ) {
       isSoundDict = true;
-    else if ( str.compare( 0, 17, U"#SOURCE_CODE_PAGE", 17 ) )
+    }
+    else if ( str.compare( 0, 17, U"#SOURCE_CODE_PAGE", 17 ) ) {
       continue;
+    }
 
     // Locate the argument
 
     size_t beg = str.find_first_of( L'"' );
 
-    if ( beg == wstring::npos )
+    if ( beg == wstring::npos ) {
       throw exMalformedDslFile( fileName );
+    }
 
     size_t end = str.find_last_of( L'"' );
 
-    if ( end == beg )
+    if ( end == beg ) {
       throw exMalformedDslFile( fileName );
+    }
 
     wstring arg( str, beg + 1, end - beg - 1 );
 
-    if ( isName )
+    if ( isName ) {
       dictionaryName = arg;
-    else if ( isLangFrom )
+    }
+    else if ( isLangFrom ) {
       langFrom = arg;
-    else if ( isLangTo )
+    }
+    else if ( isLangTo ) {
       langTo = arg;
-    else if ( isSoundDict )
+    }
+    else if ( isSoundDict ) {
       soundDictionary = arg;
+    }
     else {
       // The encoding
       if ( !needExactEncoding ) {
         // We don't need that!
         GD_FDPRINTF( stderr, "Warning: encoding was specified in a Unicode file, ignoring.\n" );
       }
-      else if ( !arg.compare( U"Latin" ) )
+      else if ( !arg.compare( U"Latin" ) ) {
         encoding = Utf8::Windows1252;
-      else if ( !arg.compare( U"Cyrillic" ) )
+      }
+      else if ( !arg.compare( U"Cyrillic" ) ) {
         encoding = Utf8::Windows1251;
-      else if ( !arg.compare( U"EasternEuropean" ) )
+      }
+      else if ( !arg.compare( U"EasternEuropean" ) ) {
         encoding = Utf8::Windows1250;
+      }
       else {
         gzclose( f );
         throw exUnknownCodePage();
@@ -942,8 +997,9 @@ DslScanner::DslScanner( string const & fileName ):
   // We need to rewind to that line so readNextLine() would return it again
   // next time it's called. To do that, we just use the slow gzseek() and
   // empty the read buffer.
-  if ( gzdirect( f ) ) // Without this ZLib 1.2.7 gzread() return 0
-    gzrewind( f );     // after gzseek() call on uncompressed files
+  if ( gzdirect( f ) ) { // Without this ZLib 1.2.7 gzread() return 0
+    gzrewind( f );       // after gzseek() call on uncompressed files
+  }
   gzseek( f, offset, SEEK_SET );
   readBufferPtr  = readBuffer;
   readBufferLeft = 0;
@@ -969,19 +1025,22 @@ bool DslScanner::readNextLine( wstring & out, size_t & offset, bool only_head_wo
         // Read some more bytes to readBuffer
         const int result = gzread( f, readBuffer + readBufferLeft, sizeof( readBuffer ) - readBufferLeft );
 
-        if ( result == -1 )
+        if ( result == -1 ) {
           throw exCantReadDslFile();
+        }
 
         readBufferPtr = readBuffer;
         readBufferLeft += (size_t)result;
       }
     }
-    if ( readBufferLeft <= 0 )
+    if ( readBufferLeft <= 0 ) {
       return false;
+    }
 
     int pos = Utf8::findFirstLinePosition( readBufferPtr, readBufferLeft, lineFeed.lineFeed, lineFeed.length );
-    if ( pos == -1 )
+    if ( pos == -1 ) {
       return false;
+    }
     QString line = codec->toUnicode( readBufferPtr, pos );
     line         = Utils::rstrip( line );
 
@@ -991,8 +1050,9 @@ bool DslScanner::readNextLine( wstring & out, size_t & offset, bool only_head_wo
     readBufferLeft -= pos;
     readBufferPtr += pos;
     linesRead++;
-    if ( only_head_word && ( line.isEmpty() || line.at( 0 ).isSpace() ) )
+    if ( only_head_word && ( line.isEmpty() || line.at( 0 ).isSpace() ) ) {
       continue;
+    }
     out = line.toStdU32String();
     return true;
   }
@@ -1010,11 +1070,13 @@ bool DslScanner::readNextLineWithoutComments( wstring & out, size_t & offset, bo
   do {
     bool b = readNextLine( str, currentOffset, only_headword );
 
-    if ( offset == 0 )
+    if ( offset == 0 ) {
       offset = currentOffset;
+    }
 
-    if ( !b )
+    if ( !b ) {
       return false;
+    }
 
     stripComments( str, commentToNextLine );
 
@@ -1119,8 +1181,9 @@ void expandOptionalParts( wstring & str, list< wstring > * result, size_t x, boo
             // Escape code
             ++y;
           }
-          else if ( ch == L'(' )
+          else if ( ch == L'(' ) {
             ++refCount;
+          }
           else if ( ch == L')' ) {
             if ( !--refCount ) {
               // Now that the closing parenthesis is found,
@@ -1145,8 +1208,9 @@ void expandOptionalParts( wstring & str, list< wstring > * result, size_t x, boo
           wstring removed( str, 0, x );
 
           // Limit the amount of results to avoid excessive resource consumption
-          if ( headwords->size() < 32 )
+          if ( headwords->size() < 32 ) {
             headwords->push_back( removed );
+          }
           else {
             if ( !inside_recurse ) {
               result->splice( result->end(), expanded );
@@ -1165,13 +1229,15 @@ void expandOptionalParts( wstring & str, list< wstring > * result, size_t x, boo
       // Closing paren doesn't mean much -- just erase it
       str.erase( x, 1 );
     }
-    else
+    else {
       ++x;
+    }
   }
 
   // Limit the amount of results to avoid excessive resource consumption
-  if ( headwords->size() < 32 )
+  if ( headwords->size() < 32 ) {
     headwords->push_back( str );
+  }
   if ( !inside_recurse ) {
     result->splice( result->end(), expanded );
   }
@@ -1196,8 +1262,9 @@ void stripComments( wstring & str, bool & nextLine )
     }
 
     n = str.find( openBraces, n2 );
-    if ( n == string::npos )
+    if ( n == string::npos ) {
       return;
+    }
     nextLine = true;
     n2       = n;
   }
@@ -1206,9 +1273,10 @@ void stripComments( wstring & str, bool & nextLine )
 void expandTildes( wstring & str, wstring const & tildeReplacement )
 {
   wstring tildeValue = Folding::trimWhitespace( tildeReplacement );
-  for ( size_t x = 0; x < str.size(); )
-    if ( str[ x ] == L'\\' )
+  for ( size_t x = 0; x < str.size(); ) {
+    if ( str[ x ] == L'\\' ) {
       x += 2;
+    }
     else if ( str[ x ] == L'~' ) {
       if ( x > 0 && str[ x - 1 ] == '^' && ( x < 2 || str[ x - 2 ] != '\\' ) ) {
         str.replace( x - 1, 2, tildeValue );
@@ -1221,15 +1289,19 @@ void expandTildes( wstring & str, wstring const & tildeReplacement )
         x += tildeValue.size();
       }
     }
-    else
+    else {
       ++x;
+    }
+  }
 }
 
 void unescapeDsl( wstring & str )
 {
-  for ( size_t x = 0; x < str.size(); ++x )
-    if ( str[ x ] == L'\\' )
+  for ( size_t x = 0; x < str.size(); ++x ) {
+    if ( str[ x ] == L'\\' ) {
       str.erase( x, 1 ); // ++x would skip the next char without processing it
+    }
+  }
 }
 
 void normalizeHeadword( wstring & str )
@@ -1238,8 +1310,9 @@ void normalizeHeadword( wstring & str )
   {
     if ( str[ x ] == L' ' ) {
       size_t y;
-      for ( y = x; y && ( str[ y - 1 ] == L' ' ); --y )
+      for ( y = x; y && ( str[ y - 1 ] == L' ' ); --y ) {
         ;
+      }
 
       if ( y != x ) {
         // Remove extra spaces
@@ -1250,17 +1323,20 @@ void normalizeHeadword( wstring & str )
       }
     }
   }
-  if ( !str.empty() && str[ str.size() - 1 ] == L' ' )
+  if ( !str.empty() && str[ str.size() - 1 ] == L' ' ) {
     str.erase( str.size() - 1, 1 );
-  if ( !str.empty() && str[ 0 ] == L' ' )
+  }
+  if ( !str.empty() && str[ 0 ] == L' ' ) {
     str.erase( 0, 1 );
+  }
 }
 
 namespace {
 void cutEnding( wstring & where, wstring const & ending )
 {
-  if ( where.size() > ending.size() && where.compare( where.size() - ending.size(), ending.size(), ending ) == 0 )
+  if ( where.size() > ending.size() && where.compare( where.size() - ending.size(), ending.size(), ending ) == 0 ) {
     where.erase( where.size() - ending.size() );
+  }
 }
 } // namespace
 

--- a/src/dict/epwing.cc
+++ b/src/dict/epwing.cc
@@ -41,7 +41,7 @@ using gd::wstring;
 
 namespace {
 
-#pragma pack( push, 1 )
+  #pragma pack( push, 1 )
 
 enum {
   Signature            = 0x58575045, // EPWX on little-endian, XWPE on big-endian
@@ -247,7 +247,6 @@ EpwingDictionary::EpwingDictionary( string const & id,
   // Full-text search parameters
 
   ftsIdxName = indexFile + Dictionary::getFtsSuffix();
-
 }
 
 EpwingDictionary::~EpwingDictionary()

--- a/src/dict/epwing_book.cc
+++ b/src/dict/epwing_book.cc
@@ -43,7 +43,8 @@ void finalize()
 
 namespace Book {
 
-#define HookFunc( name ) EB_Error_Code name( EB_Book *, EB_Appendix *, void *, EB_Hook_Code, int, const unsigned int * )
+  #define HookFunc( name ) \
+    EB_Error_Code name( EB_Book *, EB_Appendix *, void *, EB_Hook_Code, int, const unsigned int * )
 
 HookFunc( hook_newline );
 HookFunc( hook_iso8859_1 );
@@ -96,8 +97,8 @@ const EB_Hook hooks[] = { { EB_HOOK_NEWLINE, hook_newline },
 const EB_Hook refHooks[] = {
   { EB_HOOK_BEGIN_REFERENCE, hook_reference }, { EB_HOOK_END_REFERENCE, hook_reference }, { EB_HOOK_NULL, NULL } };
 
-#define EUC_TO_ASCII_TABLE_START 0xa0
-#define EUC_TO_ASCII_TABLE_END   0xff
+  #define EUC_TO_ASCII_TABLE_START 0xa0
+  #define EUC_TO_ASCII_TABLE_END   0xff
 
 // Tables from EB library
 
@@ -540,11 +541,11 @@ bool EpwingBook::setSubBook( int book_nom )
   QFile f( fileName );
   if ( f.open( QFile::ReadOnly | QFile::Text ) ) {
     QTextStream ts( &f );
-#if ( QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 ) )
+  #if ( QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 ) )
     ts.setCodec( "UTF-8" );
-#else
+  #else
     ts.setEncoding( QStringConverter::Utf8 );
-#endif
+  #endif
 
     QString line = ts.readLine();
     while ( !line.isEmpty() ) {

--- a/src/dict/forvo.cc
+++ b/src/dict/forvo.cc
@@ -133,8 +133,9 @@ ForvoDictionary::getArticle( wstring const & word, vector< wstring > const & alt
 
 void ForvoDictionary::loadIcon() noexcept
 {
-  if ( dictionaryIconLoaded )
+  if ( dictionaryIconLoaded ) {
     return;
+  }
 
   dictionaryIcon       = QIcon( ":/icons/forvo.png" );
   dictionaryIconLoaded = true;
@@ -161,8 +162,9 @@ ForvoArticleRequest::ForvoArticleRequest( wstring const & str,
 
   addQuery( mgr, str );
 
-  for ( const auto & alt : alts )
+  for ( const auto & alt : alts ) {
     addQuery( mgr, alt );
+  }
 }
 
 void ForvoArticleRequest::addQuery( QNetworkAccessManager & mgr, wstring const & str )
@@ -193,8 +195,9 @@ void ForvoArticleRequest::requestFinished( QNetworkReply * r )
 {
   GD_DPRINTF( "Finished.\n" );
 
-  if ( isFinished() ) // Was cancelled
+  if ( isFinished() ) { // Was cancelled
     return;
+  }
 
   // Find this reply
 
@@ -203,7 +206,7 @@ void ForvoArticleRequest::requestFinished( QNetworkReply * r )
   for ( auto & netReplie : netReplies ) {
     if ( netReplie.reply.get() == r ) {
       netReplie.finished = true; // Mark as finished
-      found       = true;
+      found              = true;
       break;
     }
   }
@@ -283,8 +286,9 @@ void ForvoArticleRequest::requestFinished( QNetworkReply * r )
                   }
 
                   if ( negativeVotes ) {
-                    if ( positiveVotes )
+                    if ( positiveVotes ) {
                       votes += " ";
+                    }
 
                     votes += "<span class='forvo_negative_votes'>-";
                     votes += QByteArray::number( negativeVotes ).data();
@@ -333,14 +337,17 @@ void ForvoArticleRequest::requestFinished( QNetworkReply * r )
       }
       GD_DPRINTF( "done.\n" );
     }
-    else
+    else {
       setErrorString( netReply->errorString() );
+    }
   }
 
-  if ( netReplies.empty() )
+  if ( netReplies.empty() ) {
     finish();
-  else if ( updated )
+  }
+  else if ( updated ) {
     update();
+  }
 }
 
 vector< sptr< Dictionary::Class > >
@@ -367,8 +374,9 @@ makeDictionaries( Dictionary::Initializing &, Config::Forvo const & forvo, QNetw
 
         QString displayedCode( code.toLower() );
 
-        if ( displayedCode.size() )
+        if ( displayedCode.size() ) {
           displayedCode[ 0 ] = displayedCode[ 0 ].toUpper();
+        }
 
         result.push_back(
           std::make_shared< ForvoDictionary >( hash.result().toHex().data(),

--- a/src/dict/hunspell.cc
+++ b/src/dict/hunspell.cc
@@ -139,17 +139,20 @@ bool containsWhitespace( wstring const & str )
 {
   wchar const * next = str.c_str();
 
-  for ( ; *next; ++next )
-    if ( Folding::isWhitespace( *next ) )
+  for ( ; *next; ++next ) {
+    if ( Folding::isWhitespace( *next ) ) {
       return true;
+    }
+  }
 
   return false;
 }
 
 void HunspellDictionary::loadIcon() noexcept
 {
-  if ( dictionaryIconLoaded )
+  if ( dictionaryIconLoaded ) {
     return;
+  }
 
   QString fileName = QDir::fromNativeSeparators( getDictionaryFilenames()[ 0 ].c_str() );
 
@@ -268,8 +271,9 @@ void HunspellArticleRequest::run()
         result += Html::escape( suggestionUtf8 ) + "\">";
         result += Html::escape( suggestionUtf8 ) + "</a>";
 
-        if ( x != suggestions.size() - 1 )
+        if ( x != suggestions.size() - 1 ) {
           result += ", ";
+        }
       }
 
       result += "</div>";
@@ -358,8 +362,9 @@ void HunspellHeadwordsRequest::run()
     getSuggestionsForExpression( trimmedWord, results, hunspellMutex, hunspell );
 
     QMutexLocker _( &dataMutex );
-    for ( const auto & result : results )
+    for ( const auto & result : results ) {
       matches.push_back( result );
+    }
   }
   else {
     QList< wstring > suggestions = suggest( trimmedWord, hunspellMutex, hunspell );
@@ -367,8 +372,9 @@ void HunspellHeadwordsRequest::run()
     if ( !suggestions.empty() ) {
       QMutexLocker _( &dataMutex );
 
-      for ( const auto & suggestion : suggestions )
+      for ( const auto & suggestion : suggestions ) {
         matches.push_back( suggestion );
+      }
     }
   }
 
@@ -399,8 +405,9 @@ QList< wstring > suggest( wstring & word, QMutex & hunspellMutex, Hunspell & hun
 
         // Strip comments
         int n = suggestion.indexOf( '#' );
-        if ( n >= 0 )
+        if ( n >= 0 ) {
           suggestion.chop( suggestion.length() - n );
+        }
 
         GD_DPRINTF( ">>>Sugg: %s\n", suggestion.toLocal8Bit().data() );
 
@@ -534,19 +541,22 @@ void getSuggestionsForExpression( wstring const & expression,
         words.push_back( word );
         word.clear();
       }
-      if ( *c )
+      if ( *c ) {
         punct.push_back( *c );
+      }
     }
     else {
       if ( punct.size() ) {
         words.push_back( punct );
         punct.clear();
       }
-      if ( *c )
+      if ( *c ) {
         word.push_back( *c );
+      }
     }
-    if ( !*c )
+    if ( !*c ) {
       break;
+    }
   }
 
   if ( words.size() > 21 ) {
@@ -561,38 +571,45 @@ void getSuggestionsForExpression( wstring const & expression,
   for ( const auto & i : words ) {
     word = i;
     if ( Folding::isPunct( word[ 0 ] ) || Folding::isWhitespace( word[ 0 ] ) ) {
-      for ( auto & result : results )
+      for ( auto & result : results ) {
         result.append( word );
+      }
     }
     else {
-      QList< wstring > sugg   = suggest( word, hunspellMutex, hunspell );
-      int suggNum             = sugg.size() + 1;
-      if ( suggNum > 3 )
+      QList< wstring > sugg = suggest( word, hunspellMutex, hunspell );
+      int suggNum           = sugg.size() + 1;
+      if ( suggNum > 3 ) {
         suggNum = 3;
+      }
       int resNum = results.size();
       wstring resultStr;
 
       if ( resNum == 0 ) {
-        for ( int k = 0; k < suggNum; k++ )
+        for ( int k = 0; k < suggNum; k++ ) {
           results.push_back( k == 0 ? word : sugg.at( k - 1 ) );
+        }
       }
       else {
         for ( int j = 0; j < resNum; j++ ) {
           resultStr = results.at( j );
           for ( int k = 0; k < suggNum; k++ ) {
-            if ( k == 0 )
+            if ( k == 0 ) {
               results[ j ].append( word );
-            else
+            }
+            else {
               results.push_back( resultStr + sugg.at( k - 1 ) );
+            }
           }
         }
       }
     }
   }
 
-  for ( const auto & result : results )
-    if ( result != trimmedWord )
+  for ( const auto & result : results ) {
+    if ( result != trimmedWord ) {
       suggestions.push_back( result );
+    }
+  }
 }
 
 string encodeToHunspell( Hunspell & hunspell, wstring const & str )
@@ -662,8 +679,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( Config::Hunspell const & c
 vector< DataFiles > findDataFiles( QString const & path )
 {
   // Empty path means unconfigured directory
-  if ( path.isEmpty() )
+  if ( path.isEmpty() ) {
     return vector< DataFiles >();
+  }
 
   QDir dir( path );
 
@@ -686,8 +704,9 @@ vector< DataFiles > findDataFiles( QString const & path )
 
     if ( !QFile( dicFileName ).exists() ) {
       dicFileName = dicFileNameBase + "DIC";
-      if ( !QFile( dicFileName ).exists() )
+      if ( !QFile( dicFileName ).exists() ) {
         continue; // No dic file
+      }
     }
 
     QString dictId = i->fileName();
@@ -702,8 +721,9 @@ vector< DataFiles > findDataFiles( QString const & path )
 
     QString localizedName;
 
-    if ( dictBaseId.size() == 2 )
+    if ( dictBaseId.size() == 2 ) {
       localizedName = Language::localizedNameForId( LangCoder::code2toInt( dictBaseId.toLatin1().data() ) );
+    }
 
     QString dictName = dictId;
 
@@ -711,8 +731,9 @@ vector< DataFiles > findDataFiles( QString const & path )
       dictName = localizedName;
 
       if ( dictId.size() > 2 && ( dictId[ 2 ] == '-' || dictId[ 2 ] == '_' )
-           && dictId.mid( 3 ).toLower() != dictBaseId )
+           && dictId.mid( 3 ).toLower() != dictBaseId ) {
         dictName += " (" + dictId.mid( 3 ) + ")";
+      }
     }
 
     dictName = QCoreApplication::translate( "Hunspell", "%1 Morphology" ).arg( dictName );

--- a/src/dict/lingualibre.cc
+++ b/src/dict/lingualibre.cc
@@ -208,8 +208,9 @@ WHERE {
 protected:
   void loadIcon() noexcept override
   {
-    if ( dictionaryIconLoaded )
+    if ( dictionaryIconLoaded ) {
       return;
+    }
 
     dictionaryIcon       = QIcon( ":/icons/lingualibre.svg" );
     dictionaryIconLoaded = true;

--- a/src/dict/loaddictionaries.cc
+++ b/src/dict/loaddictionaries.cc
@@ -115,8 +115,9 @@ void LoadDictionaries::run()
     //handle the custom dictionary name&fts option
     for ( const auto & dict : dictionaries ) {
       auto baseDir = dict->getContainingFolder();
-      if ( baseDir.isEmpty() )
+      if ( baseDir.isEmpty() ) {
         continue;
+      }
 
       auto filePath = Utils::Path::combine( baseDir, "metadata.toml" );
 
@@ -155,12 +156,14 @@ void LoadDictionaries::handlePath( Config::Path const & path )
     if ( path.recursive && i->isDir() ) {
       // Make sure the path doesn't look like with dsl resources
       if ( !fullName.endsWith( ".dsl.files", Qt::CaseInsensitive )
-           && !fullName.endsWith( ".dsl.dz.files", Qt::CaseInsensitive ) )
+           && !fullName.endsWith( ".dsl.dz.files", Qt::CaseInsensitive ) ) {
         handlePath( Config::Path( fullName, true ) );
+      }
     }
 
-    if ( !i->isDir() )
+    if ( !i->isDir() ) {
       allFiles.push_back( QDir::toNativeSeparators( fullName ).toStdString() );
+    }
   }
 
   addDicts( Bgl::makeDictionaries( allFiles, Config::getIndexDir().toStdString(), *this ) );
@@ -248,16 +251,19 @@ void loadDictionaries( QWidget * parent,
   addDicts( CustomTranslit::makeDictionaries( cfg.transliteration.customTrans ) );
 
   // Make Russian transliteration
-  if ( cfg.transliteration.enableRussianTransliteration )
+  if ( cfg.transliteration.enableRussianTransliteration ) {
     dictionaries.push_back( RussianTranslit::makeDictionary() );
+  }
 
   // Make German transliteration
-  if ( cfg.transliteration.enableGermanTransliteration )
+  if ( cfg.transliteration.enableGermanTransliteration ) {
     dictionaries.push_back( GermanTranslit::makeDictionary() );
+  }
 
   // Make Greek transliteration
-  if ( cfg.transliteration.enableGreekTransliteration )
+  if ( cfg.transliteration.enableGreekTransliteration ) {
     dictionaries.push_back( GreekTranslit::makeDictionary() );
+  }
 
   // Make Belarusian transliteration
   if ( cfg.transliteration.enableBelarusianTransliteration ) {
@@ -296,12 +302,14 @@ void loadDictionaries( QWidget * parent,
 
   // Run deferred inits
 
-  if ( doDeferredInit_ )
+  if ( doDeferredInit_ ) {
     doDeferredInit( dictionaries );
+  }
 }
 
 void doDeferredInit( std::vector< sptr< Dictionary::Class > > & dictionaries )
 {
-  for ( const auto & dictionarie : dictionaries )
+  for ( const auto & dictionarie : dictionaries ) {
     dictionarie->deferredInit();
+  }
 }

--- a/src/dict/lsa.cc
+++ b/src/dict/lsa.cc
@@ -75,10 +75,12 @@ bool indexIsOldOrBad( string const & indexFile )
 
 string stripExtension( string const & str )
 {
-  if ( Utils::endsWithIgnoreCase( str, ".wav" ) )
+  if ( Utils::endsWithIgnoreCase( str, ".wav" ) ) {
     return string( str, 0, str.size() - 4 );
-  else
+  }
+  else {
     return str;
+  }
 }
 
 struct Entry
@@ -103,14 +105,16 @@ Entry::Entry( File::Index & f )
   vector< uint16_t > filenameBuffer( 64 );
 
   for ( ;; ++read ) {
-    if ( filenameBuffer.size() <= read )
+    if ( filenameBuffer.size() <= read ) {
       filenameBuffer.resize( read + 64 );
+    }
 
     f.read( &filenameBuffer[ read ], 2 );
 
     if ( filenameBuffer[ read ] == 0xD ) {
-      if ( f.read< uint16_t >() != 0xA )
+      if ( f.read< uint16_t >() != 0xA ) {
         throw exInvalidData();
+      }
 
       // Filename ending marker
       break;
@@ -120,11 +124,13 @@ Entry::Entry( File::Index & f )
   // Skip zero or ff, or just ff.
 
   if ( auto x = f.read< uint8_t >() ) {
-    if ( x != 0xFF )
+    if ( x != 0xFF ) {
       throw exInvalidData();
+    }
   }
-  else if ( f.read< uint8_t >() != 0xFF )
+  else if ( f.read< uint8_t >() != 0xFF ) {
     throw exInvalidData();
+  }
 
 
   if ( !firstEntry ) {
@@ -132,11 +138,13 @@ Entry::Entry( File::Index & f )
     // samples.
     samplesOffset = f.read< uint32_t >();
 
-    if ( f.read< uint8_t >() != 0xFF )
+    if ( f.read< uint8_t >() != 0xFF ) {
       throw exInvalidData();
+    }
   }
-  else
+  else {
     samplesOffset = 0;
+  }
 
   // Read the size of the recording, in samples
   samplesLength = f.read< uint32_t >();
@@ -224,12 +232,14 @@ sptr< Dictionary::DataRequest > LsaDictionary::getArticle( wstring const & word,
                                     // by only allowing them to appear once.
 
   wstring wordCaseFolded = Folding::applySimpleCaseOnly( word );
-  if ( ignoreDiacritics )
+  if ( ignoreDiacritics ) {
     wordCaseFolded = Folding::applyDiacriticsOnly( wordCaseFolded );
+  }
 
   for ( auto & x : chain ) {
-    if ( articlesIncluded.find( x.articleOffset ) != articlesIncluded.end() )
+    if ( articlesIncluded.find( x.articleOffset ) != articlesIncluded.end() ) {
       continue; // We already have this article in the body.
+    }
 
     // Ok. Now, does it go to main articles, or to alternate ones? We list
     // main ones first, and alternates after.
@@ -237,8 +247,9 @@ sptr< Dictionary::DataRequest > LsaDictionary::getArticle( wstring const & word,
     // We do the case-folded comparison here.
 
     wstring headwordStripped = Folding::applySimpleCaseOnly( x.word );
-    if ( ignoreDiacritics )
+    if ( ignoreDiacritics ) {
       headwordStripped = Folding::applyDiacriticsOnly( headwordStripped );
+    }
 
     multimap< wstring, string > & mapToUse = ( wordCaseFolded == headwordStripped ) ? mainArticles : alternateArticles;
 
@@ -247,8 +258,9 @@ sptr< Dictionary::DataRequest > LsaDictionary::getArticle( wstring const & word,
     articlesIncluded.insert( x.articleOffset );
   }
 
-  if ( mainArticles.empty() && alternateArticles.empty() )
+  if ( mainArticles.empty() && alternateArticles.empty() ) {
     return std::make_shared< Dictionary::DataRequestInstant >( false ); // No such word
+  }
 
   string result;
 
@@ -330,25 +342,29 @@ int ShiftedVorbis::seek( void * datasource, ogg_int64_t offset, int whence )
 {
   auto * sv = (ShiftedVorbis *)datasource;
 
-  if ( whence == SEEK_SET )
+  if ( whence == SEEK_SET ) {
     offset += sv->shift;
+  }
 
-  if ( whence == SEEK_CUR )
+  if ( whence == SEEK_CUR ) {
     offset += sv->f.pos();
+  }
 
-  if ( whence == SEEK_END )
+  if ( whence == SEEK_END ) {
     offset += sv->f.size();
+  }
 
   return sv->f.seek( offset );
 }
 
 long ShiftedVorbis::tell( void * datasource )
 {
-  auto * sv = (ShiftedVorbis *)datasource;
-  long result        = sv->f.pos();
+  auto * sv   = (ShiftedVorbis *)datasource;
+  long result = sv->f.pos();
 
-  if ( result != -1 )
+  if ( result != -1 ) {
     result -= sv->shift;
+  }
 
   return result;
 }
@@ -381,14 +397,13 @@ sptr< Dictionary::DataRequest > LsaDictionary::getResource( string const & name 
 {
   // See if the name ends in .wav. Remove that extension then
 
-  string strippedName = Utils::endsWithIgnoreCase( name,  ".wav" )  ?
-    string( name, 0, name.size() - 4 ) :
-    name;
+  string strippedName = Utils::endsWithIgnoreCase( name, ".wav" ) ? string( name, 0, name.size() - 4 ) : name;
 
   vector< WordArticleLink > chain = findArticles( Utf8::decode( strippedName ) );
 
-  if ( chain.empty() )
+  if ( chain.empty() ) {
     return std::make_shared< Dictionary::DataRequestInstant >( false ); // No such resource
+  }
 
   File::Index f( getDictionaryFilenames()[ 0 ], "rb" );
 
@@ -403,11 +418,13 @@ sptr< Dictionary::DataRequest > LsaDictionary::getResource( string const & name 
 
   int result = ov_open_callbacks( &sv, &vf, 0, 0, ShiftedVorbis::callbacks );
 
-  if ( result )
+  if ( result ) {
     throw exFailedToOpenVorbisData();
+  }
 
-  if ( ov_pcm_seek( &vf, e.samplesOffset ) )
+  if ( ov_pcm_seek( &vf, e.samplesOffset ) ) {
     throw exFailedToSeekInVorbisData();
+  }
 
   vorbis_info * vi = ov_info( &vf, -1 );
 
@@ -473,8 +490,9 @@ sptr< Dictionary::DataRequest > LsaDictionary::getResource( string const & name 
 
 void LsaDictionary::loadIcon() noexcept
 {
-  if ( dictionaryIconLoaded )
+  if ( dictionaryIconLoaded ) {
     return;
+  }
 
   QString fileName = QDir::fromNativeSeparators( getDictionaryFilenames()[ 0 ].c_str() );
 
@@ -499,8 +517,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
   for ( auto i = fileNames.begin(); i != fileNames.end(); ++i ) {
     /// Only allow .dat and .lsa extensions to save scanning time
-    if ( !Utils::endsWithIgnoreCase( *i, ".dat" ) && !Utils::endsWithIgnoreCase( *i, ".lsa" ) )
+    if ( !Utils::endsWithIgnoreCase( *i, ".dat" ) && !Utils::endsWithIgnoreCase( *i, ".lsa" ) ) {
       continue;
+    }
 
     try {
       File::Index f( *i, "rb" );
@@ -574,8 +593,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         f.read( buf, sizeof( buf ) );
 
-        if ( strncmp( buf, "OggS", 4 ) != 0 )
+        if ( strncmp( buf, "OggS", 4 ) != 0 ) {
           throw exInvalidData();
+        }
 
         // Build the index
 

--- a/src/dict/mdictparser.cc
+++ b/src/dict/mdictparser.cc
@@ -54,8 +54,9 @@ static inline int u16StrSize( const ushort * unicode )
 {
   int size = 0;
   if ( unicode ) {
-    while ( unicode[ size ] != 0 )
+    while ( unicode[ size ] != 0 ) {
       size++;
+    }
   }
   return size;
 }
@@ -75,8 +76,9 @@ static QDomNamedNodeMap parseHeaderAttributes( const QString & headerText )
 
 size_t MdictParser::RecordIndex::bsearch( const vector< MdictParser::RecordIndex > & offsets, qint64 val )
 {
-  if ( offsets.size() == 0 )
+  if ( offsets.size() == 0 ) {
     return (size_t)( -1 );
+  }
 
   size_t lo = 0;
   size_t hi = offsets.size() - 1;
@@ -84,12 +86,15 @@ size_t MdictParser::RecordIndex::bsearch( const vector< MdictParser::RecordIndex
   while ( lo <= hi ) {
     size_t mid            = ( lo + hi ) >> 1;
     RecordIndex const & p = offsets[ mid ];
-    if ( p == val )
+    if ( p == val ) {
       return mid;
-    else if ( p < val )
+    }
+    else if ( p < val ) {
       lo = mid + 1;
-    else
+    }
+    else {
       hi = mid - 1;
+    }
   }
 
   return (size_t)( -1 );
@@ -118,46 +123,55 @@ bool MdictParser::open( const char * filename )
 
   gdDebug( "MdictParser: open %s", filename );
 
-  if ( file_.isNull() || !file_->exists() )
+  if ( file_.isNull() || !file_->exists() ) {
     return false;
+  }
 
-  if ( !file_->open( QIODevice::ReadOnly ) )
+  if ( !file_->open( QIODevice::ReadOnly ) ) {
     return false;
+  }
 
   QDataStream in( file_ );
   in.setByteOrder( QDataStream::BigEndian );
 
-  if ( !readHeader( in ) )
+  if ( !readHeader( in ) ) {
     return false;
+  }
 
-  if ( !readHeadWordBlockInfos( in ) )
+  if ( !readHeadWordBlockInfos( in ) ) {
     return false;
+  }
 
-  if ( !readRecordBlockInfos() )
+  if ( !readRecordBlockInfos() ) {
     return false;
+  }
 
   return true;
 }
 
 bool MdictParser::readNextHeadWordIndex( MdictParser::HeadWordIndex & headWordIndex )
 {
-  if ( headWordBlockInfosIter_ == headWordBlockInfos_.end() )
+  if ( headWordBlockInfosIter_ == headWordBlockInfos_.end() ) {
     return false;
+  }
 
   qint64 compressedSize   = headWordBlockInfosIter_->first;
   qint64 decompressedSize = headWordBlockInfosIter_->second;
 
-  if ( compressedSize < 8 )
+  if ( compressedSize < 8 ) {
     return false;
+  }
 
   ScopedMemMap compressed( *file_, headWordPos_, compressedSize );
-  if ( !compressed.startAddress() )
+  if ( !compressed.startAddress() ) {
     return false;
+  }
 
   headWordPos_ += compressedSize;
   QByteArray decompressed;
-  if ( !parseCompressedBlock( compressedSize, (char *)compressed.startAddress(), decompressedSize, decompressed ) )
+  if ( !parseCompressedBlock( compressedSize, (char *)compressed.startAddress(), decompressedSize, decompressed ) ) {
     return false;
+  }
 
   headWordIndex = splitHeadWordBlock( decompressed );
   ++headWordBlockInfosIter_;
@@ -173,8 +187,9 @@ bool MdictParser::checkAdler32( const char * buffer, unsigned int len, quint32 c
 
 QString MdictParser::toUtf16( const char * fromCode, const char * from, size_t fromSize )
 {
-  if ( !fromCode || !from )
+  if ( !fromCode || !from ) {
     return QString();
+  }
 
   QTextCodec * codec = QTextCodec::codecForName( fromCode );
   return codec->toUnicode( from, fromSize );
@@ -207,8 +222,9 @@ bool MdictParser::parseCompressedBlock( qint64 compressedBlockSize,
                                         qint64 decompressedBlockSize,
                                         QByteArray & decompressedBlock )
 {
-  if ( compressedBlockSize <= 8 )
+  if ( compressedBlockSize <= 8 ) {
     return false;
+  }
 
   // compression type
   quint32 type     = qFromBigEndian< quint32 >( (const uchar *)compressedBlockPtr );
@@ -298,8 +314,9 @@ bool MdictParser::readHeader( QDataStream & in )
   in >> headerTextSize;
 
   QByteArray headerTextUtf16 = file_->read( headerTextSize );
-  if ( headerTextUtf16.size() != headerTextSize )
+  if ( headerTextUtf16.size() != headerTextSize ) {
     return false;
+  }
 
   QString headerText = toUtf16( "UTF-16LE", headerTextUtf16.constData(), headerTextUtf16.size() );
 
@@ -334,8 +351,9 @@ bool MdictParser::readHeader( QDataStream & in )
 
   QDomNamedNodeMap headerAttributes = parseHeaderAttributes( headerText );
 
-  if ( headerAttributes.isEmpty() )
+  if ( headerAttributes.isEmpty() ) {
     return false;
+  }
 
   encoding_ = headerAttributes.namedItem( "Encoding" ).toAttr().value();
   if ( encoding_ == "GBK" || encoding_ == "GB2312" ) {
@@ -361,10 +379,12 @@ bool MdictParser::readHeader( QDataStream & in )
   // before version 2.0, number is 4 bytes integer
   // version 2.0 and above uses 8 bytes
   version_ = headerAttributes.namedItem( "GeneratedByEngineVersion" ).toAttr().value().toDouble();
-  if ( version_ < 2.0 )
+  if ( version_ < 2.0 ) {
     numberTypeSize_ = 4;
-  else
+  }
+  else {
     numberTypeSize_ = 8;
+  }
 
   // Encrypted ?
   encrypted_ = headerAttributes.namedItem( "Encrypted" ).toAttr().value().toInt();
@@ -378,10 +398,12 @@ bool MdictParser::readHeader( QDataStream & in )
     title_ = fi.baseName();
   }
   else {
-    if ( title.contains( '<' ) || title.contains( '>' ) )
+    if ( title.contains( '<' ) || title.contains( '>' ) ) {
       title_ = QTextDocumentFragment::fromHtml( title ).toPlainText();
-    else
+    }
+    else {
       title_ = title;
+    }
   }
   QString description = headerAttributes.namedItem( "Description" ).toAttr().value();
   description_        = description; //QTextDocumentFragment::fromHtml( description ).toPlainText();
@@ -400,8 +422,9 @@ bool MdictParser::readHeadWordBlockInfos( QDataStream & in )
 
   // number of bytes of a headword block info after decompression
   qint64 decompressedSize;
-  if ( version_ >= 2.0 )
+  if ( version_ >= 2.0 ) {
     stream >> decompressedSize;
+  }
 
   // number of bytes of a headword block info before decompression
   headWordBlockInfoSize_ = readNumber( stream );
@@ -413,27 +436,31 @@ bool MdictParser::readHeadWordBlockInfos( QDataStream & in )
   if ( version_ >= 2.0 ) {
     quint32 checksum;
     in >> checksum;
-    if ( !checkAdler32( header.constData(), numberTypeSize_ * 5, checksum ) )
+    if ( !checkAdler32( header.constData(), numberTypeSize_ * 5, checksum ) ) {
       return false;
+    }
   }
 
   headWordBlockInfoPos_ = file_->pos();
 
   // read headword block info
   QByteArray headWordBlockInfo = file_->read( headWordBlockInfoSize_ );
-  if ( headWordBlockInfo.size() != headWordBlockInfoSize_ )
+  if ( headWordBlockInfo.size() != headWordBlockInfoSize_ ) {
     return false;
+  }
 
   if ( version_ >= 2.0 ) {
     // decrypt
     if ( encrypted_ & EcryptedHeadWordIndex ) {
-      if ( !decryptHeadWordIndex( headWordBlockInfo.data(), headWordBlockInfo.size() ) )
+      if ( !decryptHeadWordIndex( headWordBlockInfo.data(), headWordBlockInfo.size() ) ) {
         return false;
+      }
     }
 
     QByteArray decompressed;
-    if ( !parseCompressedBlock( headWordBlockInfo.size(), headWordBlockInfo.data(), decompressedSize, decompressed ) )
+    if ( !parseCompressedBlock( headWordBlockInfo.size(), headWordBlockInfo.data(), decompressedSize, decompressed ) ) {
       return false;
+    }
 
     headWordBlockInfos_ = decodeHeadWordBlockInfo( decompressed );
   }
@@ -501,17 +528,21 @@ MdictParser::BlockInfoVector MdictParser::decodeHeadWordBlockInfo( QByteArray co
     // Size of the first headword in the block
     quint32 textHeadSize = readU8OrU16( s, isU16 );
     // The first headword
-    if ( encoding_ != "UTF-16LE" )
+    if ( encoding_ != "UTF-16LE" ) {
       s.skipRawData( textHeadSize + textTermSize );
-    else
+    }
+    else {
       s.skipRawData( ( textHeadSize + textTermSize ) * 2 );
+    }
     // Size of the last headword in the block
     quint32 textTailSize = readU8OrU16( s, isU16 );
     // The last headword
-    if ( encoding_ != "UTF-16LE" )
+    if ( encoding_ != "UTF-16LE" ) {
       s.skipRawData( textTailSize + textTermSize );
-    else
+    }
+    else {
       s.skipRawData( ( textTailSize + textTermSize ) * 2 );
+    }
 
     // headword block compressed size
     qint64 compressedSize = readNumber( s );
@@ -559,19 +590,23 @@ bool MdictParser::readRecordBlock( MdictParser::HeadWordIndex & headWordIndex,
   size_t idx = 0;
 
   for ( HeadWordIndex::const_iterator i = headWordIndex.begin(); i != headWordIndex.end(); ++i ) {
-    if ( recordBlockInfos_[ idx ].shadowEndPos <= i->first )
+    if ( recordBlockInfos_[ idx ].shadowEndPos <= i->first ) {
       idx = RecordIndex::bsearch( recordBlockInfos_, i->first );
+    }
 
-    if ( idx == (size_t)( -1 ) )
+    if ( idx == (size_t)( -1 ) ) {
       return false;
+    }
 
     RecordIndex const & recordIndex     = recordBlockInfos_[ idx ];
     HeadWordIndex::const_iterator iNext = i + 1;
     qint64 recordSize;
-    if ( iNext == headWordIndex.end() )
+    if ( iNext == headWordIndex.end() ) {
       recordSize = recordIndex.shadowEndPos - i->first;
-    else
+    }
+    else {
       recordSize = iNext->first - i->first;
+    }
 
     RecordInfo recordInfo;
     recordInfo.compressedBlockPos    = recordPos_ + recordIndex.startPos;

--- a/src/dict/mediawiki.cc
+++ b/src/dict/mediawiki.cc
@@ -47,8 +47,9 @@ public:
     langId( 0 )
   {
     int n = url.indexOf( "." );
-    if ( n == 2 || ( n > 3 && url[ n - 3 ] == '/' ) )
+    if ( n == 2 || ( n > 3 && url[ n - 3 ] == '/' ) ) {
       langId = LangCoder::code2toInt( url.mid( n - 2, 2 ).toLatin1().data() );
+    }
   }
 
   string getName() noexcept override
@@ -110,19 +111,23 @@ protected slots:
 
 void MediaWikiDictionary::loadIcon() noexcept
 {
-  if ( dictionaryIconLoaded )
+  if ( dictionaryIconLoaded ) {
     return;
+  }
 
   if ( !icon.isEmpty() ) {
     QFileInfo fInfo( QDir( Config::getConfigDir() ), icon );
-    if ( fInfo.isFile() )
+    if ( fInfo.isFile() ) {
       loadIconFromFile( fInfo.absoluteFilePath(), true );
+    }
   }
   if ( dictionaryIcon.isNull() ) {
-    if ( url.contains( "tionary" ) )
+    if ( url.contains( "tionary" ) ) {
       dictionaryIcon = QIcon( ":/icons/wiktionary.png" );
-    else
+    }
+    else {
       dictionaryIcon = QIcon( ":/icons/icon32_wiki.png" );
+    }
   }
   dictionaryIconLoaded = true;
 }
@@ -183,8 +188,9 @@ void MediaWikiWordSearchRequest::cancel()
   // We either finish it in place, or in the timer handler
   isCancelling = true;
 
-  if ( netReply.get() )
+  if ( netReply.get() ) {
     netReply.reset();
+  }
 
   finish();
 
@@ -193,8 +199,9 @@ void MediaWikiWordSearchRequest::cancel()
 
 void MediaWikiWordSearchRequest::downloadFinished()
 {
-  if ( isCancelling || isFinished() ) // Was cancelled
+  if ( isCancelling || isFinished() ) { // Was cancelled
     return;
+  }
 
   if ( netReply->error() == QNetworkReply::NoError ) {
     QDomDocument dd;
@@ -215,14 +222,16 @@ void MediaWikiWordSearchRequest::downloadFinished()
         QMutexLocker _( &dataMutex );
 
         qDebug() << "matches" << matches.size();
-        for ( int x = 0; x < nl.length(); ++x )
+        for ( int x = 0; x < nl.length(); ++x ) {
           matches.emplace_back( gd::toWString( nl.item( x ).toElement().attribute( "title" ) ) );
+        }
       }
     }
     GD_DPRINTF( "done.\n" );
   }
-  else
+  else {
     setErrorString( netReply->errorString() );
+  }
 
   finish();
 }
@@ -243,8 +252,9 @@ public:
   {
     QString const emptyTocIndicator = "<meta property=\"mw:PageProp/toc\" />";
     int const emptyTocPos           = articleString.indexOf( emptyTocIndicator );
-    if ( emptyTocPos == -1 )
+    if ( emptyTocPos == -1 ) {
       return; // The ToC must be absent or nonempty => nothing to do.
+    }
 
     QDomElement const sectionsElement = parseNode.firstChildElement( "sections" );
     if ( sectionsElement.isNull() ) {
@@ -283,8 +293,9 @@ void MediaWikiSectionsParser::generateTableOfContents( QDomElement const & secti
 
   QString const elTagName = "s";
   QDomElement el          = sectionsElement.firstChildElement( elTagName );
-  if ( el.isNull() )
+  if ( el.isNull() ) {
     return;
+  }
 
   // Omit invisible and useless toctogglecheckbox, toctogglespan and toctogglelabel elements.
   // The values of lang (e.g. 'en') and dir (e.g. 'ltr') attributes of the toctitle element depend on
@@ -351,8 +362,9 @@ bool MediaWikiSectionsParser::addListLevel( QString const & levelString )
     tableOfContents += "\n<ul>\n";
     previousLevel = level;
   }
-  else
+  else {
     closeListTags( level );
+  }
   Q_ASSERT( level == previousLevel );
 
   // Open this list item tag.
@@ -407,8 +419,9 @@ private:
   public:
     bool insert( T x )
     {
-      if ( std::find( elements.begin(), elements.end(), x ) != elements.end() )
+      if ( std::find( elements.begin(), elements.end(), x ) != elements.end() ) {
         return false;
+      }
       elements.push_back( x );
       return true;
     }
@@ -446,8 +459,9 @@ MediaWikiArticleRequest::MediaWikiArticleRequest( wstring const & str,
 
   addQuery( mgr, str );
 
-  for ( const auto & alt : alts )
+  for ( const auto & alt : alts ) {
     addQuery( mgr, alt );
+  }
 }
 
 void MediaWikiArticleRequest::addQuery( QNetworkAccessManager & mgr, wstring const & str )
@@ -478,8 +492,9 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
 {
   GD_DPRINTF( "Finished.\n" );
 
-  if ( isFinished() ) // Was cancelled
+  if ( isFinished() ) { // Was cancelled
     return;
+  }
 
   // Find this reply
 
@@ -488,7 +503,7 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
   for ( auto & netReplie : netReplies ) {
     if ( netReplie.first == r ) {
       netReplie.second = true; // Mark as finished
-      found     = true;
+      found            = true;
       break;
     }
   }
@@ -544,8 +559,9 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
                 continue;
               }
 
-              if ( link.indexOf( ':' ) >= 0 )
+              if ( link.indexOf( ':' ) >= 0 ) {
                 link.replace( ':', "%3A" );
+              }
 
               int n = link.indexOf( '#', 1 );
               if ( n > 0 ) {
@@ -587,7 +603,7 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
               QString tag                    = match.captured();
               QRegularExpressionMatch match2 = reg2.match( tag );
               if ( match2.hasMatch() ) {
-                QString ref       = match2.captured( 1 );
+                QString ref = match2.captured( 1 );
                 // audio url may like this <a href="//upload.wikimedia.org/wikipedia/a.ogg"
                 if ( ref.startsWith( "//" ) ) {
                   ref = wikiUrl.scheme() + ":" + ref;
@@ -597,8 +613,9 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
                   + R"("><img src="qrc:///icons/playsound.png" border="0" align="absmiddle" alt="Play"/></a>)";
                 articleNewString += audio_url;
               }
-              else
+              else {
                 articleNewString += match.captured();
+              }
             }
             if ( pos ) {
               articleNewString += articleString.mid( pos );
@@ -620,9 +637,11 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
             it = rxLink.globalMatch( articleString );
             while ( it.hasNext() ) {
               QRegularExpressionMatch match = it.next();
-              for ( int i = match.capturedStart() + 9; i < match.capturedEnd(); i++ )
-                if ( articleString.at( i ) == QChar( '_' ) )
+              for ( int i = match.capturedStart() + 9; i < match.capturedEnd(); i++ ) {
+                if ( articleString.at( i ) == QChar( '_' ) ) {
                   articleString[ i ] = ' ';
+                }
+              }
             }
 
             //fix file: url
@@ -676,17 +695,20 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
       }
       GD_DPRINTF( "done.\n" );
     }
-    else
+    else {
       setErrorString( netReply->errorString() );
+    }
 
     disconnect( netReply, 0, 0, 0 );
     netReply->deleteLater();
   }
 
-  if ( netReplies.empty() )
+  if ( netReplies.empty() ) {
     finish();
-  else if ( updated )
+  }
+  else if ( updated ) {
     update();
+  }
 }
 
 sptr< WordSearchRequest > MediaWikiDictionary::prefixMatch( wstring const & word, unsigned long maxResults )
@@ -698,8 +720,9 @@ sptr< WordSearchRequest > MediaWikiDictionary::prefixMatch( wstring const & word
 
     return std::make_shared< WordSearchRequestInstant >();
   }
-  else
+  else {
     return std::make_shared< MediaWikiWordSearchRequest >( word, url, lang, netMgr );
+  }
 }
 
 sptr< DataRequest >
@@ -711,8 +734,9 @@ MediaWikiDictionary::getArticle( wstring const & word, vector< wstring > const &
 
     return std::make_shared< DataRequestInstant >( false );
   }
-  else
+  else {
     return std::make_shared< MediaWikiArticleRequest >( word, alts, url, lang, netMgr, this );
+  }
 }
 
 } // namespace
@@ -724,13 +748,14 @@ makeDictionaries( Dictionary::Initializing &, Config::MediaWikis const & wikis, 
   vector< sptr< Dictionary::Class > > result;
 
   for ( const auto & wiki : wikis ) {
-    if ( wiki.enabled )
+    if ( wiki.enabled ) {
       result.push_back( std::make_shared< MediaWikiDictionary >( wiki.id.toStdString(),
                                                                  wiki.name.toUtf8().data(),
                                                                  wiki.url,
                                                                  wiki.icon,
                                                                  wiki.lang,
                                                                  mgr ) );
+    }
   }
 
   return result;

--- a/src/dict/programs.cc
+++ b/src/dict/programs.cc
@@ -63,8 +63,9 @@ protected:
 sptr< WordSearchRequest > ProgramsDictionary::prefixMatch( wstring const & word, unsigned long /*maxResults*/ )
 
 {
-  if ( prg.type == Config::Program::PrefixMatch )
+  if ( prg.type == Config::Program::PrefixMatch ) {
     return std::make_shared< ProgramWordSearchRequest >( QString::fromStdU32String( word ), prg );
+  }
   else {
     sptr< WordSearchRequestInstant > sr = std::make_shared< WordSearchRequestInstant >();
 
@@ -116,16 +117,19 @@ ProgramsDictionary::getArticle( wstring const & word, vector< wstring > const &,
 
 void ProgramsDictionary::loadIcon() noexcept
 {
-  if ( dictionaryIconLoaded )
+  if ( dictionaryIconLoaded ) {
     return;
+  }
 
   if ( !prg.iconFilename.isEmpty() ) {
     QFileInfo fInfo( QDir( Config::getConfigDir() ), prg.iconFilename );
-    if ( fInfo.isFile() )
+    if ( fInfo.isFile() ) {
       loadIconFromFile( fInfo.absoluteFilePath(), true );
+    }
   }
-  if ( dictionaryIcon.isNull() )
+  if ( dictionaryIcon.isNull() ) {
     dictionaryIcon = QIcon( ":/icons/programdict.svg" );
+  }
   dictionaryIconLoaded = true;
 }
 
@@ -185,16 +189,19 @@ void RunInstance::handleProcessFinished()
   QByteArray output = process.readAllStandardOutput();
 
   QString error;
-  if ( process.exitStatus() != QProcess::NormalExit )
+  if ( process.exitStatus() != QProcess::NormalExit ) {
     error = tr( "The program has crashed." );
-  else if ( int code = process.exitCode() )
+  }
+  else if ( int code = process.exitCode() ) {
     error = tr( "The program has returned exit code %1." ).arg( code );
+  }
 
   if ( !error.isEmpty() ) {
     QByteArray err = process.readAllStandardError();
 
-    if ( !err.isEmpty() )
+    if ( !err.isEmpty() ) {
       error += "\n\n" + QString::fromLocal8Bit( err );
+    }
   }
 
   emit finished( output, error );
@@ -227,15 +234,17 @@ void ProgramDataRequest::instanceFinished( QByteArray output, QString error )
             unsigned char * uchars = reinterpret_cast< unsigned char * >( output.data() );
             if ( output.length() >= 2 && uchars[ 0 ] == 0xFF && uchars[ 1 ] == 0xFE ) {
               int size = output.length() - 2;
-              if ( size & 1 )
+              if ( size & 1 ) {
                 size -= 1;
+              }
               string res  = Iconv::toUtf8( "UTF-16LE", output.data() + 2, size );
               prog_output = QString::fromUtf8( res.c_str(), res.size() );
             }
             else if ( output.length() >= 2 && uchars[ 0 ] == 0xFE && uchars[ 1 ] == 0xFF ) {
               int size = output.length() - 2;
-              if ( size & 1 )
+              if ( size & 1 ) {
                 size -= 1;
+              }
               string res  = Iconv::toUtf8( "UTF-16BE", output.data() + 2, size );
               prog_output = QString::fromUtf8( res.c_str(), res.size() );
             }
@@ -259,14 +268,16 @@ void ProgramDataRequest::instanceFinished( QByteArray output, QString error )
             unsigned char * uchars = reinterpret_cast< unsigned char * >( output.data() );
             if ( output.length() >= 2 && uchars[ 0 ] == 0xFF && uchars[ 1 ] == 0xFE ) {
               int size = output.length() - 2;
-              if ( size & 1 )
+              if ( size & 1 ) {
                 size -= 1;
+              }
               result += Iconv::toUtf8( "UTF-16LE", output.data() + 2, size );
             }
             else if ( output.length() >= 2 && uchars[ 0 ] == 0xFE && uchars[ 1 ] == 0xFF ) {
               int size = output.length() - 2;
-              if ( size & 1 )
+              if ( size & 1 ) {
                 size -= 1;
+              }
               result += Iconv::toUtf8( "UTF-16BE", output.data() + 2, size );
             }
             else if ( output.length() >= 3 && uchars[ 0 ] == 0xEF && uchars[ 1 ] == 0xBB && uchars[ 2 ] == 0xBF ) {
@@ -290,8 +301,9 @@ void ProgramDataRequest::instanceFinished( QByteArray output, QString error )
       hasAnyData = true;
     }
 
-    if ( !error.isEmpty() )
+    if ( !error.isEmpty() ) {
       setErrorString( error );
+    }
 
     finish();
   }
@@ -321,11 +333,13 @@ void ProgramWordSearchRequest::instanceFinished( QByteArray output, QString erro
     output.replace( "\r\n", "\n" );
     QStringList result = QString::fromUtf8( output ).split( "\n", Qt::SkipEmptyParts );
 
-    for ( const auto & x : result )
+    for ( const auto & x : result ) {
       matches.push_back( Dictionary::WordMatch( gd::toWString( x ) ) );
+    }
 
-    if ( !error.isEmpty() )
+    if ( !error.isEmpty() ) {
       setErrorString( error );
+    }
 
     finish();
   }
@@ -341,9 +355,11 @@ vector< sptr< Dictionary::Class > > makeDictionaries( Config::Programs const & p
 {
   vector< sptr< Dictionary::Class > > result;
 
-  for ( const auto & program : programs )
-    if ( program.enabled )
+  for ( const auto & program : programs ) {
+    if ( program.enabled ) {
       result.push_back( std::make_shared< ProgramsDictionary >( program ) );
+    }
+  }
 
   return result;
 }

--- a/src/dict/sounddir.cc
+++ b/src/dict/sounddir.cc
@@ -147,12 +147,14 @@ sptr< Dictionary::DataRequest > SoundDirDictionary::getArticle( wstring const & 
                                     // by only allowing them to appear once.
 
   wstring wordCaseFolded = Folding::applySimpleCaseOnly( word );
-  if ( ignoreDiacritics )
+  if ( ignoreDiacritics ) {
     wordCaseFolded = Folding::applyDiacriticsOnly( wordCaseFolded );
+  }
 
   for ( unsigned x = 0; x < chain.size(); ++x ) {
-    if ( articlesIncluded.find( chain[ x ].articleOffset ) != articlesIncluded.end() )
+    if ( articlesIncluded.find( chain[ x ].articleOffset ) != articlesIncluded.end() ) {
       continue; // We already have this article in the body.
+    }
 
     // Ok. Now, does it go to main articles, or to alternate ones? We list
     // main ones first, and alternates after.
@@ -160,8 +162,9 @@ sptr< Dictionary::DataRequest > SoundDirDictionary::getArticle( wstring const & 
     // We do the case-folded comparison here.
 
     wstring headwordStripped = Folding::applySimpleCaseOnly( chain[ x ].word );
-    if ( ignoreDiacritics )
+    if ( ignoreDiacritics ) {
       headwordStripped = Folding::applyDiacriticsOnly( headwordStripped );
+    }
 
     multimap< wstring, unsigned > & mapToUse =
       ( wordCaseFolded == headwordStripped ) ? mainArticles : alternateArticles;
@@ -171,8 +174,9 @@ sptr< Dictionary::DataRequest > SoundDirDictionary::getArticle( wstring const & 
     articlesIncluded.insert( chain[ x ].articleOffset );
   }
 
-  if ( mainArticles.empty() && alternateArticles.empty() )
+  if ( mainArticles.empty() && alternateArticles.empty() ) {
     return std::make_shared< Dictionary::DataRequestInstant >( false ); // No such word
+  }
 
   string result;
 
@@ -187,8 +191,9 @@ sptr< Dictionary::DataRequest > SoundDirDictionary::getArticle( wstring const & 
   for ( i = mainArticles.begin(); i != mainArticles.end(); ++i ) {
     uint32_t address = chain[ i->second ].articleOffset;
 
-    if ( mainArticles.size() + alternateArticles.size() <= 1 )
+    if ( mainArticles.size() + alternateArticles.size() <= 1 ) {
       displayedName = chain[ i->second ].word;
+    }
     else {
       try {
         QMutexLocker _( &idxMutex );
@@ -234,8 +239,9 @@ sptr< Dictionary::DataRequest > SoundDirDictionary::getArticle( wstring const & 
   for ( i = alternateArticles.begin(); i != alternateArticles.end(); ++i ) {
     uint32_t address = chain[ i->second ].articleOffset;
 
-    if ( mainArticles.size() + alternateArticles.size() <= 1 )
+    if ( mainArticles.size() + alternateArticles.size() <= 1 ) {
       displayedName = chain[ i->second ].word;
+    }
     else {
       try {
         QMutexLocker _( &idxMutex );
@@ -289,16 +295,19 @@ sptr< Dictionary::DataRequest > SoundDirDictionary::getArticle( wstring const & 
 
 void SoundDirDictionary::loadIcon() noexcept
 {
-  if ( dictionaryIconLoaded )
+  if ( dictionaryIconLoaded ) {
     return;
+  }
 
   if ( !iconFilename.isEmpty() ) {
     const QFileInfo fInfo( QDir( Config::getConfigDir() ), iconFilename );
-    if ( fInfo.isFile() )
+    if ( fInfo.isFile() ) {
       loadIconFromFile( fInfo.absoluteFilePath(), true );
+    }
   }
-  if ( dictionaryIcon.isNull() )
+  if ( dictionaryIcon.isNull() ) {
     dictionaryIcon = QIcon( ":/icons/sounddir.svg" );
+  }
   dictionaryIconLoaded = true;
 }
 
@@ -344,8 +353,9 @@ sptr< Dictionary::DataRequest > SoundDirDictionary::getResource( string const & 
   }
 
 
-  if ( !isNumber )
+  if ( !isNumber ) {
     return std::make_shared< Dictionary::DataRequestInstant >( false ); // No such resource
+  }
 
   QString file_name;
   if ( !get_file_name( articleOffset, file_name ) ) {
@@ -389,8 +399,9 @@ void addDir( QDir const & baseDir,
   const QFileInfoList entries = dir.entryInfoList( QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot );
 
   for ( QFileInfoList::const_iterator i = entries.constBegin(); i != entries.constEnd(); ++i ) {
-    if ( i->isDir() )
+    if ( i->isDir() ) {
       addDir( baseDir, QDir( i->absoluteFilePath() ), indexedWords, soundsCount, chunks );
+    }
     else if ( Filetype::isNameOfSound( i->fileName().toUtf8().data() ) ) {
       // Add this sound to index
       string fileName = baseDir.relativeFilePath( i->filePath() ).toUtf8().data();
@@ -402,8 +413,9 @@ void addDir( QDir const & baseDir,
 
       const wstring::size_type pos = name.rfind( L'.' );
 
-      if ( pos != wstring::npos )
+      if ( pos != wstring::npos ) {
         name.erase( pos );
+      }
 
       indexedWords.addWord( name, articleOffset );
 
@@ -424,8 +436,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( Config::SoundDirs const & 
   for ( const auto & soundDir : soundDirs ) {
     QDir dir( soundDir.path );
 
-    if ( !dir.exists() )
+    if ( !dir.exists() ) {
       continue; // No such dir, no dictionary then
+    }
 
     vector< string > dictFiles( 1, QDir::toNativeSeparators( dir.canonicalPath() ).toStdString() );
 

--- a/src/dict/sources.cc
+++ b/src/dict/sources.cc
@@ -240,8 +240,9 @@ void Sources::on_removeMediaWiki_clicked()
             tr( "Remove site <b>%1</b> from the list?" ).arg( mediawikisModel.getCurrentWikis()[ current.row() ].name ),
             QMessageBox::Ok,
             QMessageBox::Cancel )
-         == QMessageBox::Ok )
+         == QMessageBox::Ok ) {
     mediawikisModel.removeWiki( current.row() );
+  }
 }
 
 void Sources::on_addWebSite_clicked()
@@ -265,8 +266,9 @@ void Sources::on_removeWebSite_clicked()
                                    .arg( webSitesModel.getCurrentWebSites()[ current.row() ].name ),
                                  QMessageBox::Ok,
                                  QMessageBox::Cancel )
-         == QMessageBox::Ok )
+         == QMessageBox::Ok ) {
     webSitesModel.removeSite( current.row() );
+  }
 }
 
 void Sources::on_addDictServer_clicked()
@@ -290,8 +292,9 @@ void Sources::on_removeDictServer_clicked()
                                    .arg( dictServersModel.getCurrentDictServers()[ current.row() ].name ),
                                  QMessageBox::Ok,
                                  QMessageBox::Cancel )
-         == QMessageBox::Ok )
+         == QMessageBox::Ok ) {
     dictServersModel.removeServer( current.row() );
+  }
 }
 
 void Sources::on_addProgram_clicked()
@@ -315,8 +318,9 @@ void Sources::on_removeProgram_clicked()
                                    .arg( programsModel.getCurrentPrograms()[ current.row() ].name ),
                                  QMessageBox::Ok,
                                  QMessageBox::Cancel )
-         == QMessageBox::Ok )
+         == QMessageBox::Ok ) {
     programsModel.removeProgram( current.row() );
+  }
 }
 
 #ifndef NO_TTS_SUPPORT
@@ -430,10 +434,12 @@ Qt::ItemFlags MediaWikisModel::flags( QModelIndex const & index ) const
   Qt::ItemFlags result = QAbstractItemModel::flags( index );
 
   if ( index.isValid() ) {
-    if ( !index.column() )
+    if ( !index.column() ) {
       result |= Qt::ItemIsUserCheckable;
-    else
+    }
+    else {
       result |= Qt::ItemIsEditable;
+    }
   }
 
   return result;
@@ -441,23 +447,27 @@ Qt::ItemFlags MediaWikisModel::flags( QModelIndex const & index ) const
 
 int MediaWikisModel::rowCount( QModelIndex const & parent ) const
 {
-  if ( parent.isValid() )
+  if ( parent.isValid() ) {
     return 0;
-  else
+  }
+  else {
     return mediawikis.size();
+  }
 }
 
 int MediaWikisModel::columnCount( QModelIndex const & parent ) const
 {
-  if ( parent.isValid() )
+  if ( parent.isValid() ) {
     return 0;
-  else
+  }
+  else {
     return 5;
+  }
 }
 
 QVariant MediaWikisModel::headerData( int section, Qt::Orientation /*orientation*/, int role ) const
 {
-  if ( role == Qt::DisplayRole )
+  if ( role == Qt::DisplayRole ) {
     switch ( section ) {
       case 0:
         return tr( "Enabled" );
@@ -472,14 +482,16 @@ QVariant MediaWikisModel::headerData( int section, Qt::Orientation /*orientation
       default:
         return QVariant();
     }
+  }
 
   return QVariant();
 }
 
 QVariant MediaWikisModel::data( QModelIndex const & index, int role ) const
 {
-  if ( index.row() >= mediawikis.size() )
+  if ( index.row() >= mediawikis.size() ) {
     return QVariant();
+  }
 
   if ( role == Qt::DisplayRole || role == Qt::EditRole ) {
     switch ( index.column() ) {
@@ -496,16 +508,18 @@ QVariant MediaWikisModel::data( QModelIndex const & index, int role ) const
     }
   }
 
-  if ( role == Qt::CheckStateRole && !index.column() )
+  if ( role == Qt::CheckStateRole && !index.column() ) {
     return mediawikis[ index.row() ].enabled ? Qt::Checked : Qt::Unchecked;
+  }
 
   return QVariant();
 }
 
 bool MediaWikisModel::setData( QModelIndex const & index, const QVariant & value, int role )
 {
-  if ( index.row() >= mediawikis.size() )
+  if ( index.row() >= mediawikis.size() ) {
     return false;
+  }
 
   if ( role == Qt::CheckStateRole && !index.column() ) {
     //GD_DPRINTF( "type = %d\n", (int)value.type() );
@@ -518,7 +532,7 @@ bool MediaWikisModel::setData( QModelIndex const & index, const QVariant & value
     return true;
   }
 
-  if ( role == Qt::DisplayRole || role == Qt::EditRole )
+  if ( role == Qt::DisplayRole || role == Qt::EditRole ) {
     switch ( index.column() ) {
       case 1:
         mediawikis[ index.row() ].name = value.toString();
@@ -539,6 +553,7 @@ bool MediaWikisModel::setData( QModelIndex const & index, const QVariant & value
       default:
         return false;
     }
+  }
 
   return false;
 }
@@ -590,10 +605,12 @@ Qt::ItemFlags WebSitesModel::flags( QModelIndex const & index ) const
   Qt::ItemFlags result = QAbstractItemModel::flags( index );
 
   if ( index.isValid() ) {
-    if ( index.column() <= 1 )
+    if ( index.column() <= 1 ) {
       result |= Qt::ItemIsUserCheckable;
-    else
+    }
+    else {
       result |= Qt::ItemIsEditable;
+    }
   }
 
   return result;
@@ -601,30 +618,35 @@ Qt::ItemFlags WebSitesModel::flags( QModelIndex const & index ) const
 
 int WebSitesModel::rowCount( QModelIndex const & parent ) const
 {
-  if ( parent.isValid() )
+  if ( parent.isValid() ) {
     return 0;
-  else
+  }
+  else {
     return webSites.size();
+  }
 }
 
 int WebSitesModel::columnCount( QModelIndex const & parent ) const
 {
-  if ( parent.isValid() )
+  if ( parent.isValid() ) {
     return 0;
-  else
+  }
+  else {
     return 5;
+  }
 }
 
 QVariant WebSitesModel::headerData( int section, Qt::Orientation /*orientation*/, int role ) const
 {
   if ( role == Qt::ToolTipRole ) {
-    if ( section == 1 )
+    if ( section == 1 ) {
       return tr( "Insert article as link inside <iframe> tag" );
+    }
 
     return QVariant();
   }
 
-  if ( role == Qt::DisplayRole )
+  if ( role == Qt::DisplayRole ) {
     switch ( section ) {
       case 0:
         return tr( "Enabled" );
@@ -639,18 +661,21 @@ QVariant WebSitesModel::headerData( int section, Qt::Orientation /*orientation*/
       default:
         return QVariant();
     }
+  }
 
   return QVariant();
 }
 
 QVariant WebSitesModel::data( QModelIndex const & index, int role ) const
 {
-  if ( index.row() >= webSites.size() )
+  if ( index.row() >= webSites.size() ) {
     return QVariant();
+  }
 
   if ( role == Qt::ToolTipRole ) {
-    if ( index.column() == 1 )
+    if ( index.column() == 1 ) {
       return tr( "Insert article as link inside <iframe> tag" );
+    }
 
     return QVariant();
   }
@@ -668,19 +693,22 @@ QVariant WebSitesModel::data( QModelIndex const & index, int role ) const
     }
   }
 
-  if ( role == Qt::CheckStateRole && !index.column() )
+  if ( role == Qt::CheckStateRole && !index.column() ) {
     return webSites[ index.row() ].enabled ? Qt::Checked : Qt::Unchecked;
+  }
 
-  if ( role == Qt::CheckStateRole && index.column() == 1 )
+  if ( role == Qt::CheckStateRole && index.column() == 1 ) {
     return webSites[ index.row() ].inside_iframe ? Qt::Checked : Qt::Unchecked;
+  }
 
   return QVariant();
 }
 
 bool WebSitesModel::setData( QModelIndex const & index, const QVariant & value, int role )
 {
-  if ( index.row() >= webSites.size() )
+  if ( index.row() >= webSites.size() ) {
     return false;
+  }
 
   if ( role == Qt::CheckStateRole && !index.column() ) {
     //GD_DPRINTF( "type = %d\n", (int)value.type() );
@@ -700,7 +728,7 @@ bool WebSitesModel::setData( QModelIndex const & index, const QVariant & value, 
     return true;
   }
 
-  if ( role == Qt::DisplayRole || role == Qt::EditRole )
+  if ( role == Qt::DisplayRole || role == Qt::EditRole ) {
     switch ( index.column() ) {
       case 2:
         webSites[ index.row() ].name = value.toString();
@@ -717,6 +745,7 @@ bool WebSitesModel::setData( QModelIndex const & index, const QVariant & value, 
       default:
         return false;
     }
+  }
 
   return false;
 }
@@ -765,10 +794,12 @@ Qt::ItemFlags DictServersModel::flags( QModelIndex const & index ) const
   Qt::ItemFlags result = QAbstractItemModel::flags( index );
 
   if ( index.isValid() ) {
-    if ( !index.column() )
+    if ( !index.column() ) {
       result |= Qt::ItemIsUserCheckable;
-    else
+    }
+    else {
       result |= Qt::ItemIsEditable;
+    }
   }
 
   return result;
@@ -776,23 +807,27 @@ Qt::ItemFlags DictServersModel::flags( QModelIndex const & index ) const
 
 int DictServersModel::rowCount( QModelIndex const & parent ) const
 {
-  if ( parent.isValid() )
+  if ( parent.isValid() ) {
     return 0;
-  else
+  }
+  else {
     return dictServers.size();
+  }
 }
 
 int DictServersModel::columnCount( QModelIndex const & parent ) const
 {
-  if ( parent.isValid() )
+  if ( parent.isValid() ) {
     return 0;
-  else
+  }
+  else {
     return 6;
+  }
 }
 
 QVariant DictServersModel::headerData( int section, Qt::Orientation /*orientation*/, int role ) const
 {
-  if ( role == Qt::DisplayRole )
+  if ( role == Qt::DisplayRole ) {
     switch ( section ) {
       case 0:
         return tr( "Enabled" );
@@ -809,14 +844,16 @@ QVariant DictServersModel::headerData( int section, Qt::Orientation /*orientatio
       default:
         return QVariant();
     }
+  }
 
   return QVariant();
 }
 
 QVariant DictServersModel::data( QModelIndex const & index, int role ) const
 {
-  if ( index.row() >= dictServers.size() )
+  if ( index.row() >= dictServers.size() ) {
     return QVariant();
+  }
 
   if ( role == Qt::DisplayRole || role == Qt::EditRole ) {
     switch ( index.column() ) {
@@ -835,22 +872,26 @@ QVariant DictServersModel::data( QModelIndex const & index, int role ) const
     }
   }
 
-  if ( role == Qt::ToolTipRole && index.column() == 3 )
+  if ( role == Qt::ToolTipRole && index.column() == 3 ) {
     return tr( "Comma-delimited list of databases\n(empty string or \"*\" matches all databases)" );
+  }
 
-  if ( role == Qt::ToolTipRole && index.column() == 4 )
+  if ( role == Qt::ToolTipRole && index.column() == 4 ) {
     return tr( "Comma-delimited list of search strategies\n(empty string mean \"prefix\" strategy)" );
+  }
 
-  if ( role == Qt::CheckStateRole && !index.column() )
+  if ( role == Qt::CheckStateRole && !index.column() ) {
     return dictServers[ index.row() ].enabled ? Qt::Checked : Qt::Unchecked;
+  }
 
   return QVariant();
 }
 
 bool DictServersModel::setData( QModelIndex const & index, const QVariant & value, int role )
 {
-  if ( index.row() >= dictServers.size() )
+  if ( index.row() >= dictServers.size() ) {
     return false;
+  }
 
   if ( role == Qt::CheckStateRole && !index.column() ) {
     // XXX it seems to be always passing Int( 2 ) as a value, so we just toggle
@@ -860,7 +901,7 @@ bool DictServersModel::setData( QModelIndex const & index, const QVariant & valu
     return true;
   }
 
-  if ( role == Qt::DisplayRole || role == Qt::EditRole )
+  if ( role == Qt::DisplayRole || role == Qt::EditRole ) {
     switch ( index.column() ) {
       case 1:
         dictServers[ index.row() ].name = value.toString();
@@ -885,6 +926,7 @@ bool DictServersModel::setData( QModelIndex const & index, const QVariant & valu
       default:
         return false;
     }
+  }
 
   return false;
 }
@@ -934,10 +976,12 @@ Qt::ItemFlags ProgramsModel::flags( QModelIndex const & index ) const
   Qt::ItemFlags result = QAbstractItemModel::flags( index );
 
   if ( index.isValid() ) {
-    if ( !index.column() )
+    if ( !index.column() ) {
       result |= Qt::ItemIsUserCheckable;
-    else
+    }
+    else {
       result |= Qt::ItemIsEditable;
+    }
   }
 
   return result;
@@ -945,23 +989,27 @@ Qt::ItemFlags ProgramsModel::flags( QModelIndex const & index ) const
 
 int ProgramsModel::rowCount( QModelIndex const & parent ) const
 {
-  if ( parent.isValid() )
+  if ( parent.isValid() ) {
     return 0;
-  else
+  }
+  else {
     return programs.size();
+  }
 }
 
 int ProgramsModel::columnCount( QModelIndex const & parent ) const
 {
-  if ( parent.isValid() )
+  if ( parent.isValid() ) {
     return 0;
-  else
+  }
+  else {
     return 5;
+  }
 }
 
 QVariant ProgramsModel::headerData( int section, Qt::Orientation /*orientation*/, int role ) const
 {
-  if ( role == Qt::DisplayRole )
+  if ( role == Qt::DisplayRole ) {
     switch ( section ) {
       case 0:
         return tr( "Enabled" );
@@ -976,22 +1024,26 @@ QVariant ProgramsModel::headerData( int section, Qt::Orientation /*orientation*/
       default:
         return QVariant();
     }
+  }
 
   return QVariant();
 }
 
 QVariant ProgramsModel::data( QModelIndex const & index, int role ) const
 {
-  if ( index.row() >= programs.size() )
+  if ( index.row() >= programs.size() ) {
     return QVariant();
+  }
 
   if ( role == Qt::DisplayRole || role == Qt::EditRole ) {
     switch ( index.column() ) {
       case 1:
-        if ( role == Qt::DisplayRole )
+        if ( role == Qt::DisplayRole ) {
           return ProgramTypeEditor::getNameForType( programs[ index.row() ].type );
-        else
+        }
+        else {
           return QVariant( (int)programs[ index.row() ].type );
+        }
       case 2:
         return programs[ index.row() ].name;
       case 3:
@@ -1003,16 +1055,18 @@ QVariant ProgramsModel::data( QModelIndex const & index, int role ) const
     }
   }
 
-  if ( role == Qt::CheckStateRole && !index.column() )
+  if ( role == Qt::CheckStateRole && !index.column() ) {
     return programs[ index.row() ].enabled ? Qt::Checked : Qt::Unchecked;
+  }
 
   return QVariant();
 }
 
 bool ProgramsModel::setData( QModelIndex const & index, const QVariant & value, int role )
 {
-  if ( index.row() >= programs.size() )
+  if ( index.row() >= programs.size() ) {
     return false;
+  }
 
   if ( role == Qt::CheckStateRole && !index.column() ) {
     programs[ index.row() ].enabled = !programs[ index.row() ].enabled;
@@ -1021,7 +1075,7 @@ bool ProgramsModel::setData( QModelIndex const & index, const QVariant & value, 
     return true;
   }
 
-  if ( role == Qt::DisplayRole || role == Qt::EditRole )
+  if ( role == Qt::DisplayRole || role == Qt::EditRole ) {
     switch ( index.column() ) {
       case 1:
         programs[ index.row() ].type = Config::Program::Type( value.toInt() );
@@ -1042,6 +1096,7 @@ bool ProgramsModel::setData( QModelIndex const & index, const QVariant & value, 
       default:
         return false;
     }
+  }
 
   return false;
 }
@@ -1065,8 +1120,9 @@ QString ProgramTypeEditor::getNameForType( int v )
 ProgramTypeEditor::ProgramTypeEditor( QWidget * widget ):
   QComboBox( widget )
 {
-  for ( int x = 0; x < Config::Program::MaxTypeValue; ++x )
+  for ( int x = 0; x < Config::Program::MaxTypeValue; ++x ) {
     addItem( getNameForType( x ) );
+  }
 }
 
 int ProgramTypeEditor::getType() const
@@ -1115,31 +1171,36 @@ Qt::ItemFlags PathsModel::flags( QModelIndex const & index ) const
 {
   Qt::ItemFlags result = QAbstractItemModel::flags( index );
 
-  if ( index.isValid() && index.column() == 1 )
+  if ( index.isValid() && index.column() == 1 ) {
     result |= Qt::ItemIsUserCheckable;
+  }
 
   return result;
 }
 
 int PathsModel::rowCount( QModelIndex const & parent ) const
 {
-  if ( parent.isValid() )
+  if ( parent.isValid() ) {
     return 0;
-  else
+  }
+  else {
     return paths.size();
+  }
 }
 
 int PathsModel::columnCount( QModelIndex const & parent ) const
 {
-  if ( parent.isValid() )
+  if ( parent.isValid() ) {
     return 0;
-  else
+  }
+  else {
     return 2;
+  }
 }
 
 QVariant PathsModel::headerData( int section, Qt::Orientation /*orientation*/, int role ) const
 {
-  if ( role == Qt::DisplayRole )
+  if ( role == Qt::DisplayRole ) {
     switch ( section ) {
       case 0:
         return tr( "Path" );
@@ -1148,28 +1209,33 @@ QVariant PathsModel::headerData( int section, Qt::Orientation /*orientation*/, i
       default:
         return QVariant();
     }
+  }
 
   return QVariant();
 }
 
 QVariant PathsModel::data( QModelIndex const & index, int role ) const
 {
-  if ( index.row() >= paths.size() )
+  if ( index.row() >= paths.size() ) {
     return QVariant();
+  }
 
-  if ( ( role == Qt::DisplayRole || role == Qt::EditRole ) && !index.column() )
+  if ( ( role == Qt::DisplayRole || role == Qt::EditRole ) && !index.column() ) {
     return paths[ index.row() ].path;
+  }
 
-  if ( role == Qt::CheckStateRole && index.column() == 1 )
+  if ( role == Qt::CheckStateRole && index.column() == 1 ) {
     return paths[ index.row() ].recursive ? Qt::Checked : Qt::Unchecked;
+  }
 
   return QVariant();
 }
 
 bool PathsModel::setData( QModelIndex const & index, const QVariant & /*value*/, int role )
 {
-  if ( index.row() >= paths.size() )
+  if ( index.row() >= paths.size() ) {
     return false;
+  }
 
   if ( role == Qt::CheckStateRole && index.column() == 1 ) {
     paths[ index.row() ].recursive = !paths[ index.row() ].recursive;
@@ -1218,31 +1284,36 @@ Qt::ItemFlags SoundDirsModel::flags( QModelIndex const & index ) const
 {
   Qt::ItemFlags result = QAbstractItemModel::flags( index );
 
-  if ( index.isValid() && index.column() < 3 )
+  if ( index.isValid() && index.column() < 3 ) {
     result |= Qt::ItemIsEditable;
+  }
 
   return result;
 }
 
 int SoundDirsModel::rowCount( QModelIndex const & parent ) const
 {
-  if ( parent.isValid() )
+  if ( parent.isValid() ) {
     return 0;
-  else
+  }
+  else {
     return soundDirs.size();
+  }
 }
 
 int SoundDirsModel::columnCount( QModelIndex const & parent ) const
 {
-  if ( parent.isValid() )
+  if ( parent.isValid() ) {
     return 0;
-  else
+  }
+  else {
     return 3;
+  }
 }
 
 QVariant SoundDirsModel::headerData( int section, Qt::Orientation /*orientation*/, int role ) const
 {
-  if ( role == Qt::DisplayRole )
+  if ( role == Qt::DisplayRole ) {
     switch ( section ) {
       case 0:
         return tr( "Path" );
@@ -1253,39 +1324,48 @@ QVariant SoundDirsModel::headerData( int section, Qt::Orientation /*orientation*
       default:
         return QVariant();
     }
+  }
 
   return QVariant();
 }
 
 QVariant SoundDirsModel::data( QModelIndex const & index, int role ) const
 {
-  if ( index.row() >= soundDirs.size() )
+  if ( index.row() >= soundDirs.size() ) {
     return QVariant();
+  }
 
-  if ( ( role == Qt::DisplayRole || role == Qt::EditRole ) && !index.column() )
+  if ( ( role == Qt::DisplayRole || role == Qt::EditRole ) && !index.column() ) {
     return soundDirs[ index.row() ].path;
+  }
 
-  if ( ( role == Qt::DisplayRole || role == Qt::EditRole ) && index.column() == 1 )
+  if ( ( role == Qt::DisplayRole || role == Qt::EditRole ) && index.column() == 1 ) {
     return soundDirs[ index.row() ].name;
+  }
 
-  if ( ( role == Qt::DisplayRole || role == Qt::EditRole ) && index.column() == 2 )
+  if ( ( role == Qt::DisplayRole || role == Qt::EditRole ) && index.column() == 2 ) {
     return soundDirs[ index.row() ].iconFilename;
+  }
 
   return QVariant();
 }
 
 bool SoundDirsModel::setData( QModelIndex const & index, const QVariant & value, int role )
 {
-  if ( index.row() >= soundDirs.size() )
+  if ( index.row() >= soundDirs.size() ) {
     return false;
+  }
 
   if ( ( role == Qt::DisplayRole || role == Qt::EditRole ) && index.column() < 3 ) {
-    if ( !index.column() )
+    if ( !index.column() ) {
       soundDirs[ index.row() ].path = value.toString();
-    else if ( index.column() == 1 )
+    }
+    else if ( index.column() == 1 ) {
       soundDirs[ index.row() ].name = value.toString();
-    else
+    }
+    else {
       soundDirs[ index.row() ].iconFilename = value.toString();
+    }
 
     dataChanged( index, index );
     return true;
@@ -1326,8 +1406,9 @@ Qt::ItemFlags HunspellDictsModel::flags( QModelIndex const & index ) const
   Qt::ItemFlags result = QAbstractItemModel::flags( index );
 
   if ( index.isValid() ) {
-    if ( !index.column() )
+    if ( !index.column() ) {
       result |= Qt::ItemIsUserCheckable;
+    }
   }
 
   return result;
@@ -1335,23 +1416,27 @@ Qt::ItemFlags HunspellDictsModel::flags( QModelIndex const & index ) const
 
 int HunspellDictsModel::rowCount( QModelIndex const & parent ) const
 {
-  if ( parent.isValid() )
+  if ( parent.isValid() ) {
     return 0;
-  else
+  }
+  else {
     return dataFiles.size();
+  }
 }
 
 int HunspellDictsModel::columnCount( QModelIndex const & parent ) const
 {
-  if ( parent.isValid() )
+  if ( parent.isValid() ) {
     return 0;
-  else
+  }
+  else {
     return 2;
+  }
 }
 
 QVariant HunspellDictsModel::headerData( int section, Qt::Orientation /*orientation*/, int role ) const
 {
-  if ( role == Qt::DisplayRole )
+  if ( role == Qt::DisplayRole ) {
     switch ( section ) {
       case 0:
         return tr( "Enabled" );
@@ -1360,22 +1445,26 @@ QVariant HunspellDictsModel::headerData( int section, Qt::Orientation /*orientat
       default:
         return QVariant();
     }
+  }
 
   return QVariant();
 }
 
 QVariant HunspellDictsModel::data( QModelIndex const & index, int role ) const
 {
-  if ( (unsigned)index.row() >= dataFiles.size() )
+  if ( (unsigned)index.row() >= dataFiles.size() ) {
     return QVariant();
+  }
 
-  if ( role == Qt::DisplayRole && index.column() == 1 )
+  if ( role == Qt::DisplayRole && index.column() == 1 ) {
     return dataFiles[ index.row() ].dictName;
+  }
 
   if ( role == Qt::CheckStateRole && !index.column() ) {
     for ( unsigned x = enabledDictionaries.size(); x--; ) {
-      if ( enabledDictionaries[ x ] == dataFiles[ index.row() ].dictId )
+      if ( enabledDictionaries[ x ] == dataFiles[ index.row() ].dictId ) {
         return Qt::Checked;
+      }
     }
 
     return Qt::Unchecked;
@@ -1386,8 +1475,9 @@ QVariant HunspellDictsModel::data( QModelIndex const & index, int role ) const
 
 bool HunspellDictsModel::setData( QModelIndex const & index, const QVariant & /*value*/, int role )
 {
-  if ( (unsigned)index.row() >= dataFiles.size() )
+  if ( (unsigned)index.row() >= dataFiles.size() ) {
     return false;
+  }
 
   if ( role == Qt::CheckStateRole && !index.column() ) {
     for ( unsigned x = enabledDictionaries.size(); x--; ) {

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -204,9 +204,10 @@ public:
     if ( metadata_enable_fts.has_value() ) {
       can_FTS = fts.enabled && metadata_enable_fts.value();
     }
-    else
+    else {
       can_FTS = fts.enabled && !fts.disabledTypes.contains( "STARDICT", Qt::CaseInsensitive )
         && ( fts.maxDictionarySize == 0 || getArticleCount() <= fts.maxDictionarySize );
+    }
   }
 
 protected:
@@ -248,8 +249,9 @@ StardictDictionary::StardictDictionary( string const & id,
   DZ_ERRORS error;
   dz = dict_data_open( dictionaryFiles[ 2 ].c_str(), &error, 0 );
 
-  if ( !dz )
+  if ( !dz ) {
     throw exDictzipError( string( dz_error_str( error ) ) + "(" + dictionaryFiles[ 2 ] + ")" );
+  }
 
   // Initialize the index
 
@@ -264,8 +266,9 @@ StardictDictionary::StardictDictionary( string const & id,
 
     QString zipName = QDir::fromNativeSeparators( getDictionaryFilenames().back().c_str() );
 
-    if ( zipName.endsWith( ".zip", Qt::CaseInsensitive ) ) // Sanity check
+    if ( zipName.endsWith( ".zip", Qt::CaseInsensitive ) ) { // Sanity check
       resourceZip.openZipFile( zipName );
+    }
   }
 
   // Full-text search parameters
@@ -275,14 +278,16 @@ StardictDictionary::StardictDictionary( string const & id,
 
 StardictDictionary::~StardictDictionary()
 {
-  if ( dz )
+  if ( dz ) {
     dict_data_close( dz );
+  }
 }
 
 void StardictDictionary::loadIcon() noexcept
 {
-  if ( dictionaryIconLoaded )
+  if ( dictionaryIconLoaded ) {
     return;
+  }
 
   QString fileName = QDir::fromNativeSeparators( getDictionaryFilenames()[ 0 ].c_str() );
 
@@ -299,8 +304,9 @@ void StardictDictionary::loadIcon() noexcept
 
 string StardictDictionary::loadString( size_t size )
 {
-  if ( size == 0 )
+  if ( size == 0 ) {
     return string();
+  }
 
   vector< char > data( size );
 
@@ -487,8 +493,9 @@ string StardictDictionary::handleResource( char type, char const * resource, siz
           }
 
           QString newLink;
-          if ( link.indexOf( '#' ) < 0 )
+          if ( link.indexOf( '#' ) < 0 ) {
             newLink = QString( "<a" ) + match.captured( 1 ) + "href=\"bword:" + link + "\"";
+          }
 
 
           // Anchors
@@ -501,11 +508,13 @@ string StardictDictionary::handleResource( char type, char const * resource, siz
           if ( !newLink.isEmpty() ) {
             articleNewText += newLink;
           }
-          else
+          else {
             articleNewText += match.captured();
+          }
         }
-        else
+        else {
           articleNewText += match.captured();
+        }
       }
       if ( pos ) {
         articleNewText += articleText.mid( pos );
@@ -609,8 +618,9 @@ string StardictDictionary::handleResource( char type, char const * resource, siz
     return string( "<b>Unknown textual entry type " ) + string( 1, type ) + ":</b> "
       + Html::escape( string( resource, size ) ) + "<br>";
   }
-  else
+  else {
     return string( "<b>Unknown blob entry type " ) + string( 1, type ) + "</b><br>";
+  }
 }
 
 void StardictDictionary::pangoToHtml( QString & text )
@@ -661,8 +671,9 @@ void StardictDictionary::pangoToHtml( QString & text )
               if ( str.compare( "normal", Qt::CaseInsensitive ) == 0
                    || str.compare( "oblique", Qt::CaseInsensitive ) == 0
                    || str.compare( "italic", Qt::CaseInsensitive ) == 0 ) {
-                if ( !stylesStr.contains( "font-style:" ) )
+                if ( !stylesStr.contains( "font-style:" ) ) {
                   stylesStr += QString( "font-style:" ) + str + ";";
+                }
                 continue;
               }
 
@@ -739,8 +750,9 @@ void StardictDictionary::pangoToHtml( QString & text )
             if ( n >= 0 ) {
               familiesStr = QString( "font-family:" );
               for ( int i = 0; i <= n; i++ ) {
-                if ( i > 0 && !familiesStr.endsWith( ',' ) )
+                if ( i > 0 && !familiesStr.endsWith( ',' ) ) {
                   familiesStr += ",";
+                }
                 familiesStr += list.at( i );
               }
               familiesStr += ";";
@@ -749,111 +761,143 @@ void StardictDictionary::pangoToHtml( QString & text )
             newSpan += familiesStr + stylesStr + sizeStr;
           }
           else if ( style.compare( "font_family", Qt::CaseInsensitive ) == 0
-                    || style.compare( "face", Qt::CaseInsensitive ) == 0 )
+                    || style.compare( "face", Qt::CaseInsensitive ) == 0 ) {
             newSpan += QString( "font-family:" ) + cap2 + ";";
+          }
           else if ( style.compare( "font_size", Qt::CaseInsensitive ) == 0
                     || style.compare( "size", Qt::CaseInsensitive ) == 0 ) {
             if ( cap2[ 0 ].isLetter() || cap2.endsWith( "px", Qt::CaseInsensitive )
                  || cap2.endsWith( "pt", Qt::CaseInsensitive ) || cap2.endsWith( "em", Qt::CaseInsensitive )
-                 || cap2.endsWith( "%" ) )
+                 || cap2.endsWith( "%" ) ) {
               newSpan += QString( "font-size:" ) + cap2 + ";";
+            }
             else {
               int size = cap2.toInt();
-              if ( size )
+              if ( size ) {
                 newSpan += QString( "font-size:%1pt;" ).arg( size / 1024.0, 0, 'f', 3 );
+              }
             }
           }
           else if ( style.compare( "font_style", Qt::CaseInsensitive ) == 0
-                    || style.compare( "style", Qt::CaseInsensitive ) == 0 )
+                    || style.compare( "style", Qt::CaseInsensitive ) == 0 ) {
             newSpan += QString( "font-style:" ) + cap2 + ";";
+          }
           else if ( style.compare( "font_weight", Qt::CaseInsensitive ) == 0
                     || style.compare( "weight", Qt::CaseInsensitive ) == 0 ) {
             QString str = cap2;
-            if ( str.compare( "ultralight", Qt::CaseInsensitive ) == 0 )
+            if ( str.compare( "ultralight", Qt::CaseInsensitive ) == 0 ) {
               newSpan += QString( "font-weight:100;" );
-            else if ( str.compare( "light", Qt::CaseInsensitive ) == 0 )
+            }
+            else if ( str.compare( "light", Qt::CaseInsensitive ) == 0 ) {
               newSpan += QString( "font-weight:200;" );
-            else if ( str.compare( "ultrabold", Qt::CaseInsensitive ) == 0 )
+            }
+            else if ( str.compare( "ultrabold", Qt::CaseInsensitive ) == 0 ) {
               newSpan += QString( "font-weight:800;" );
-            else if ( str.compare( "heavy", Qt::CaseInsensitive ) == 0 )
+            }
+            else if ( str.compare( "heavy", Qt::CaseInsensitive ) == 0 ) {
               newSpan += QString( "font-weight:900" );
-            else
+            }
+            else {
               newSpan += QString( "font-weight:" ) + str + ";";
+            }
           }
           else if ( style.compare( "font_variant", Qt::CaseInsensitive ) == 0
                     || style.compare( "variant", Qt::CaseInsensitive ) == 0 ) {
-            if ( cap2.compare( "smallcaps", Qt::CaseInsensitive ) == 0 )
+            if ( cap2.compare( "smallcaps", Qt::CaseInsensitive ) == 0 ) {
               newSpan += QString( "font-variant:small-caps" );
-            else
+            }
+            else {
               newSpan += QString( "font-variant:" ) + cap2 + ";";
+            }
           }
           else if ( style.compare( "font_stretch", Qt::CaseInsensitive ) == 0
                     || style.compare( "stretch", Qt::CaseInsensitive ) == 0 ) {
             QString str = cap2;
-            if ( str.compare( "ultracondensed", Qt::CaseInsensitive ) == 0 )
+            if ( str.compare( "ultracondensed", Qt::CaseInsensitive ) == 0 ) {
               newSpan += QString( "font-stretch:ultra-condensed;" );
-            else if ( str.compare( "extracondensed", Qt::CaseInsensitive ) == 0 )
+            }
+            else if ( str.compare( "extracondensed", Qt::CaseInsensitive ) == 0 ) {
               newSpan += QString( "font-stretch:extra-condensed;" );
-            else if ( str.compare( "semicondensed", Qt::CaseInsensitive ) == 0 )
+            }
+            else if ( str.compare( "semicondensed", Qt::CaseInsensitive ) == 0 ) {
               newSpan += QString( "font-stretch:semi-condensed;" );
-            else if ( str.compare( "semiexpanded", Qt::CaseInsensitive ) == 0 )
+            }
+            else if ( str.compare( "semiexpanded", Qt::CaseInsensitive ) == 0 ) {
               newSpan += QString( "font-stretch:semi-expanded;" );
-            else if ( str.compare( "extraexpanded", Qt::CaseInsensitive ) == 0 )
+            }
+            else if ( str.compare( "extraexpanded", Qt::CaseInsensitive ) == 0 ) {
               newSpan += QString( "font-stretch:extra-expanded;" );
-            else if ( str.compare( "ultraexpanded", Qt::CaseInsensitive ) == 0 )
+            }
+            else if ( str.compare( "ultraexpanded", Qt::CaseInsensitive ) == 0 ) {
               newSpan += QString( "font-stretch:ultra-expanded;" );
-            else
+            }
+            else {
               newSpan += QString( "font-stretch:" ) + str + ";";
+            }
           }
           else if ( style.compare( "foreground", Qt::CaseInsensitive ) == 0
                     || style.compare( "fgcolor", Qt::CaseInsensitive ) == 0
-                    || style.compare( "color", Qt::CaseInsensitive ) == 0 )
+                    || style.compare( "color", Qt::CaseInsensitive ) == 0 ) {
             newSpan += QString( "color:" ) + cap2 + ";";
+          }
           else if ( style.compare( "background", Qt::CaseInsensitive ) == 0
-                    || style.compare( "bgcolor", Qt::CaseInsensitive ) == 0 )
+                    || style.compare( "bgcolor", Qt::CaseInsensitive ) == 0 ) {
             newSpan += QString( "background-color:" ) + cap2 + ";";
+          }
           else if ( style.compare( "underline_color", Qt::CaseInsensitive ) == 0
-                    || style.compare( "strikethrough_color", Qt::CaseInsensitive ) == 0 )
+                    || style.compare( "strikethrough_color", Qt::CaseInsensitive ) == 0 ) {
             newSpan += QString( "text-decoration-color:" ) + cap2 + ";";
+          }
           else if ( style.compare( "underline", Qt::CaseInsensitive ) == 0 ) {
-            if ( cap2.compare( "none", Qt::CaseInsensitive ) )
+            if ( cap2.compare( "none", Qt::CaseInsensitive ) ) {
               newSpan += QString( "text-decoration-line:none;" );
+            }
             else {
               newSpan += QString( "text-decoration-line:underline; " );
-              if ( cap2.compare( "low", Qt::CaseInsensitive ) )
+              if ( cap2.compare( "low", Qt::CaseInsensitive ) ) {
                 newSpan += QString( "text-decoration-style:dotted;" );
-              else if ( cap2.compare( "single", Qt::CaseInsensitive ) )
+              }
+              else if ( cap2.compare( "single", Qt::CaseInsensitive ) ) {
                 newSpan += QString( "text-decoration-style:solid;" );
-              else if ( cap2.compare( "error", Qt::CaseInsensitive ) )
+              }
+              else if ( cap2.compare( "error", Qt::CaseInsensitive ) ) {
                 newSpan += QString( "text-decoration-style:wavy;" );
-              else
+              }
+              else {
                 newSpan += QString( "text-decoration-style:" ) + cap2 + ";";
+              }
             }
           }
           else if ( style.compare( "strikethrough", Qt::CaseInsensitive ) == 0 ) {
-            if ( cap2.compare( "true", Qt::CaseInsensitive ) )
+            if ( cap2.compare( "true", Qt::CaseInsensitive ) ) {
               newSpan += QString( "text-decoration-line:line-through;" );
-            else
+            }
+            else {
               newSpan += QString( "text-decoration-line:none;" );
+            }
           }
           else if ( style.compare( "rise", Qt::CaseInsensitive ) == 0 ) {
             if ( cap2.endsWith( "px", Qt::CaseInsensitive ) || cap2.endsWith( "pt", Qt::CaseInsensitive )
-                 || cap2.endsWith( "em", Qt::CaseInsensitive ) || cap2.endsWith( "%" ) )
+                 || cap2.endsWith( "em", Qt::CaseInsensitive ) || cap2.endsWith( "%" ) ) {
               newSpan += QString( "vertical-align:" ) + cap2 + ";";
+            }
             else {
               int riseValue = cap2.toInt();
-              if ( riseValue )
+              if ( riseValue ) {
                 newSpan += QString( "vertical-align:%1pt;" ).arg( riseValue / 1024.0, 0, 'f', 3 );
+              }
             }
           }
           else if ( style.compare( "letter_spacing", Qt::CaseInsensitive ) == 0 ) {
             if ( cap2.endsWith( "px", Qt::CaseInsensitive ) || cap2.endsWith( "pt", Qt::CaseInsensitive )
-                 || cap2.endsWith( "em", Qt::CaseInsensitive ) || cap2.endsWith( "%" ) )
+                 || cap2.endsWith( "em", Qt::CaseInsensitive ) || cap2.endsWith( "%" ) ) {
               newSpan += QString( "letter-spacing:" ) + cap2 + ";";
+            }
             else {
               int spacing = cap2.toInt();
-              if ( spacing )
+              if ( spacing ) {
                 newSpan += QString( "letter-spacing:%1pt;" ).arg( spacing / 1024.0, 0, 'f', 3 );
+              }
             }
           }
 
@@ -904,8 +948,9 @@ void StardictDictionary::loadArticle( uint32_t address, string & headword, strin
 
       uint32_t entrySize = 0;
 
-      if ( entrySizeKnown )
+      if ( entrySizeKnown ) {
         entrySize = size;
+      }
       else if ( !size ) {
         gdWarning( "Stardict: short entry for the word %s encountered in \"%s\".\n",
                    headword.c_str(),
@@ -917,8 +962,9 @@ void StardictDictionary::loadArticle( uint32_t address, string & headword, strin
 
       if ( islower( type ) ) {
         // Zero-terminated entry, unless it's the last one
-        if ( !entrySizeKnown )
+        if ( !entrySizeKnown ) {
           entrySize = strlen( ptr );
+        }
 
         if ( size < entrySize ) {
           gdWarning( "Stardict: malformed entry for the word %s encountered in \"%s\".\n",
@@ -929,8 +975,9 @@ void StardictDictionary::loadArticle( uint32_t address, string & headword, strin
 
         articleText += handleResource( type, ptr, entrySize );
 
-        if ( !entrySizeKnown )
+        if ( !entrySizeKnown ) {
           ++entrySize; // Need to skip the zero byte
+        }
 
         ptr += entrySize;
         size -= entrySize;
@@ -1036,8 +1083,9 @@ void StardictDictionary::loadArticle( uint32_t address, string & headword, strin
 
 QString const & StardictDictionary::getDescription()
 {
-  if ( !dictionaryDescription.isEmpty() )
+  if ( !dictionaryDescription.isEmpty() ) {
     return dictionaryDescription;
+  }
 
   File::Index ifoFile( getDictionaryFilenames()[ 0 ], "r" );
   Ifo ifo( ifoFile );
@@ -1075,8 +1123,9 @@ QString const & StardictDictionary::getDescription()
     dictionaryDescription += Html::unescape( desc, Html::HtmlOption::Keep );
   }
 
-  if ( dictionaryDescription.isEmpty() )
+  if ( dictionaryDescription.isEmpty() ) {
     dictionaryDescription = "NONE";
+  }
 
   return dictionaryDescription;
 }
@@ -1089,14 +1138,17 @@ QString StardictDictionary::getMainFilename()
 void StardictDictionary::makeFTSIndex( QAtomicInt & isCancelled )
 {
   if ( !( Dictionary::needToRebuildIndex( getDictionaryFilenames(), ftsIdxName )
-          || FtsHelpers::ftsIndexIsOldOrBad( this ) ) )
+          || FtsHelpers::ftsIndexIsOldOrBad( this ) ) ) {
     FTS_index_completed.ref();
+  }
 
-  if ( haveFTSIndex() )
+  if ( haveFTSIndex() ) {
     return;
+  }
 
-  if ( ensureInitDone().size() )
+  if ( ensureInitDone().size() ) {
     return;
+  }
 
 
   gdDebug( "Stardict: Building the full-text index for dictionary: %s\n", getName().c_str() );
@@ -1300,8 +1352,9 @@ void StardictArticleRequest::run()
                                       // by only allowing them to appear once.
 
     wstring wordCaseFolded = Folding::applySimpleCaseOnly( word );
-    if ( ignoreDiacritics )
+    if ( ignoreDiacritics ) {
       wordCaseFolded = Folding::applyDiacriticsOnly( wordCaseFolded );
+    }
 
     //if the chain is too large, it is more likely has some dictionary making or parsing issue.
     for ( unsigned x = 0; x < qMin( 10, (int)chain.size() ); ++x ) {
@@ -1310,8 +1363,9 @@ void StardictArticleRequest::run()
         return;
       }
 
-      if ( articlesIncluded.find( chain[ x ].articleOffset ) != articlesIncluded.end() )
+      if ( articlesIncluded.find( chain[ x ].articleOffset ) != articlesIncluded.end() ) {
         continue; // We already have this article in the body.
+      }
 
       // Now grab that article
 
@@ -1325,8 +1379,9 @@ void StardictArticleRequest::run()
       // We do the case-folded comparison here.
 
       wstring headwordStripped = Folding::applySimpleCaseOnly( headword );
-      if ( ignoreDiacritics )
+      if ( ignoreDiacritics ) {
         headwordStripped = Folding::applyDiacriticsOnly( headwordStripped );
+      }
 
       multimap< wstring, pair< string, string > > & mapToUse =
         ( wordCaseFolded == headwordStripped ) ? mainArticles : alternateArticles;
@@ -1352,24 +1407,28 @@ void StardictArticleRequest::run()
       result += dict.isFromLanguageRTL() ? R"(<h3 class="sdct_headwords" dir="rtl">)" : "<h3 class=\"sdct_headwords\">";
       result += i->second.first;
       result += "</h3>";
-      if ( dict.isToLanguageRTL() )
+      if ( dict.isToLanguageRTL() ) {
         result += R"(<div style="display:inline;" dir="rtl">)";
+      }
       result += i->second.second;
       result += cleaner;
-      if ( dict.isToLanguageRTL() )
+      if ( dict.isToLanguageRTL() ) {
         result += "</div>";
+      }
     }
 
     for ( i = alternateArticles.begin(); i != alternateArticles.end(); ++i ) {
       result += dict.isFromLanguageRTL() ? R"(<h3 class="sdct_headwords" dir="rtl">)" : "<h3 class=\"sdct_headwords\">";
       result += i->second.first;
       result += "</h3>";
-      if ( dict.isToLanguageRTL() )
+      if ( dict.isToLanguageRTL() ) {
         result += R"(<div style="display:inline;" dir="rtl">)";
+      }
       result += i->second.second;
       result += cleaner;
-      if ( dict.isToLanguageRTL() )
+      if ( dict.isToLanguageRTL() ) {
         result += "</div>";
+      }
     }
 
     appendString( result );
@@ -1414,8 +1473,9 @@ Ifo::Ifo( File::Index & f ):
   //GD_DPRINTF( "%s<\n", f.gets().c_str() );
 
   if ( QString::fromUtf8( f.gets().c_str() ) != "StarDict's dict ifo file"
-       || f.gets().compare( 0, versionEq.size(), versionEq ) )
+       || f.gets().compare( 0, versionEq.size(), versionEq ) ) {
     throw exNotAnIfoFile();
+  }
 
   /// Now go through the file and parse options
 
@@ -1423,43 +1483,57 @@ Ifo::Ifo( File::Index & f ):
     char option[ 16384 ];
 
     for ( ;; ) {
-      if ( !f.gets( option, sizeof( option ), true ) )
+      if ( !f.gets( option, sizeof( option ), true ) ) {
         break;
+      }
 
-      if ( char const * val = beginsWith( "bookname=", option ) )
+      if ( char const * val = beginsWith( "bookname=", option ) ) {
         bookname = val;
+      }
       else if ( char const * val = beginsWith( "wordcount=", option ) ) {
-        if ( sscanf( val, "%u", &wordcount ) != 1 )
+        if ( sscanf( val, "%u", &wordcount ) != 1 ) {
           throw exBadFieldInIfo( option );
+        }
       }
       else if ( char const * val = beginsWith( "synwordcount=", option ) ) {
-        if ( sscanf( val, "%u", &synwordcount ) != 1 )
+        if ( sscanf( val, "%u", &synwordcount ) != 1 ) {
           throw exBadFieldInIfo( option );
+        }
       }
       else if ( char const * val = beginsWith( "idxfilesize=", option ) ) {
-        if ( sscanf( val, "%u", &idxfilesize ) != 1 )
+        if ( sscanf( val, "%u", &idxfilesize ) != 1 ) {
           throw exBadFieldInIfo( option );
+        }
       }
       else if ( char const * val = beginsWith( "idxoffsetbits=", option ) ) {
-        if ( sscanf( val, "%u", &idxoffsetbits ) != 1 || ( idxoffsetbits != 32 && idxoffsetbits != 64 ) )
+        if ( sscanf( val, "%u", &idxoffsetbits ) != 1 || ( idxoffsetbits != 32 && idxoffsetbits != 64 ) ) {
           throw exBadFieldInIfo( option );
+        }
       }
-      else if ( char const * val = beginsWith( "sametypesequence=", option ) )
+      else if ( char const * val = beginsWith( "sametypesequence=", option ) ) {
         sametypesequence = val;
-      else if ( char const * val = beginsWith( "dicttype=", option ) )
+      }
+      else if ( char const * val = beginsWith( "dicttype=", option ) ) {
         dicttype = val;
-      else if ( char const * val = beginsWith( "description=", option ) )
+      }
+      else if ( char const * val = beginsWith( "description=", option ) ) {
         description = val;
-      else if ( char const * val = beginsWith( "copyright=", option ) )
+      }
+      else if ( char const * val = beginsWith( "copyright=", option ) ) {
         copyright = val;
-      else if ( char const * val = beginsWith( "author=", option ) )
+      }
+      else if ( char const * val = beginsWith( "author=", option ) ) {
         author = val;
-      else if ( char const * val = beginsWith( "email=", option ) )
+      }
+      else if ( char const * val = beginsWith( "email=", option ) ) {
         email = val;
-      else if ( char const * val = beginsWith( "website=", option ) )
+      }
+      else if ( char const * val = beginsWith( "website=", option ) ) {
         website = val;
-      else if ( char const * val = beginsWith( "date=", option ) )
+      }
+      else if ( char const * val = beginsWith( "date=", option ) ) {
         date = val;
+      }
     }
   }
   catch ( File::exReadError & ) {
@@ -1513,10 +1587,12 @@ void StardictResourceRequest::run()
   }
 
   try {
-    if ( resourceName.at( 0 ) == '\x1E' )
+    if ( resourceName.at( 0 ) == '\x1E' ) {
       resourceName = resourceName.erase( 0, 1 );
-    if ( resourceName.at( resourceName.length() - 1 ) == '\x1F' )
+    }
+    if ( resourceName.at( resourceName.length() - 1 ) == '\x1F' ) {
       resourceName.erase( resourceName.length() - 1, 1 );
+    }
 
     string n =
       dict.getContainingFolder().toStdString() + Utils::Fs::separator() + "res" + Utils::Fs::separator() + resourceName;
@@ -1534,11 +1610,13 @@ void StardictResourceRequest::run()
       if ( dict.resourceZip.isOpen() ) {
         QMutexLocker _( &dataMutex );
 
-        if ( !dict.resourceZip.loadFile( Utf8::decode( resourceName ), data ) )
+        if ( !dict.resourceZip.loadFile( Utf8::decode( resourceName ), data ) ) {
           throw; // Make it fail since we couldn't read the archive
+        }
       }
-      else
+      else {
         throw;
+      }
     }
 
     if ( Filetype::isNameOfTiff( resourceName ) ) {
@@ -1622,17 +1700,20 @@ static void findCorrespondingFiles( string const & ifo, string & idx, string & d
 
   if ( !( File::tryPossibleName( base + "idx", idx ) || File::tryPossibleName( base + "idx.gz", idx )
           || File::tryPossibleName( base + "idx.dz", idx ) || File::tryPossibleName( base + "IDX", idx )
-          || File::tryPossibleName( base + "IDX.GZ", idx ) || File::tryPossibleName( base + "IDX.DZ", idx ) ) )
+          || File::tryPossibleName( base + "IDX.GZ", idx ) || File::tryPossibleName( base + "IDX.DZ", idx ) ) ) {
     throw exNoIdxFile( ifo );
+  }
 
   if ( !( File::tryPossibleName( base + "dict", dict ) || File::tryPossibleName( base + "dict.dz", dict )
-          || File::tryPossibleName( base + "DICT", dict ) || File::tryPossibleName( base + "dict.DZ", dict ) ) )
+          || File::tryPossibleName( base + "DICT", dict ) || File::tryPossibleName( base + "dict.DZ", dict ) ) ) {
     throw exNoDictFile( ifo );
+  }
 
   if ( !( File::tryPossibleName( base + "syn", syn ) || File::tryPossibleName( base + "syn.gz", syn )
           || File::tryPossibleName( base + "syn.dz", syn ) || File::tryPossibleName( base + "SYN", syn )
-          || File::tryPossibleName( base + "SYN.GZ", syn ) || File::tryPossibleName( base + "SYN.DZ", syn ) ) )
+          || File::tryPossibleName( base + "SYN.GZ", syn ) || File::tryPossibleName( base + "SYN.DZ", syn ) ) ) {
     syn.clear();
+  }
 }
 
 static void handleIdxSynFile( string const & fileName,
@@ -1643,8 +1724,9 @@ static void handleIdxSynFile( string const & fileName,
                               bool parseHeadwords )
 {
   gzFile stardictIdx = gd_gzopen( fileName.c_str() );
-  if ( !stardictIdx )
+  if ( !stardictIdx ) {
     throw exCantReadFile( fileName );
+  }
 
   vector< char > image;
 
@@ -1710,8 +1792,9 @@ static void handleIdxSynFile( string const & fileName,
 
       offset = chunks.startNewBlock();
 
-      if ( articleOffsets )
+      if ( articleOffsets ) {
         articleOffsets->push_back( offset );
+      }
 
       chunks.addToBlock( &articleOffset, sizeof( uint32_t ) );
       chunks.addToBlock( &articleSize, sizeof( uint32_t ) );
@@ -1726,8 +1809,9 @@ static void handleIdxSynFile( string const & fileName,
 
       offsetInIndex = ntohl( offsetInIndex );
 
-      if ( offsetInIndex >= articleOffsets->size() )
+      if ( offsetInIndex >= articleOffsets->size() ) {
         throw exIncorrectOffset( fileName );
+      }
 
       offset = ( *articleOffsets )[ offsetInIndex ];
 
@@ -1739,12 +1823,14 @@ static void handleIdxSynFile( string const & fileName,
       // synonyms which really start from slash and contain dollar signs, or
       // end with dollar and contain slashes.
       if ( *word == '/' ) {
-        if ( strchr( word, '$' ) )
+        if ( strchr( word, '$' ) ) {
           continue; // Skip this entry
+        }
       }
       else if ( wordLen && word[ wordLen - 1 ] == '$' ) {
-        if ( strchr( word, '/' ) )
+        if ( strchr( word, '/' ) ) {
           continue; // Skip this entry
+        }
       }
 
       // if the entry is hypen, skip
@@ -1755,10 +1841,12 @@ static void handleIdxSynFile( string const & fileName,
 
     // Insert new entry into an index
 
-    if ( parseHeadwords )
+    if ( parseHeadwords ) {
       indexedWords.addWord( Utf8::decode( word ), offset );
-    else
+    }
+    else {
       indexedWords.addSingleWord( Utf8::decode( word ), offset );
+    }
   }
 
   GD_DPRINTF( "%u entires made\n", (unsigned)indexedWords.size() );
@@ -1774,8 +1862,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
   vector< sptr< Dictionary::Class > > dictionaries;
 
   for ( const auto & fileName : fileNames ) {
-    if ( !Utils::endsWithIgnoreCase( fileName, ".ifo" ) )
+    if ( !Utils::endsWithIgnoreCase( fileName, ".ifo" ) ) {
       continue;
+    }
 
     try {
       vector< string > dictFiles( 1, fileName );
@@ -1787,8 +1876,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
       dictFiles.push_back( idxFileName );
       dictFiles.push_back( dictFileName );
 
-      if ( synFileName.size() )
+      if ( synFileName.size() ) {
         dictFiles.push_back( synFileName );
+      }
 
       // See if there's a zip file with resources present. If so, include it.
 
@@ -1798,8 +1888,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
       if ( File::tryPossibleZipName( baseName + "res.zip", zipFileName )
            || File::tryPossibleZipName( baseName + "RES.ZIP", zipFileName )
-           || File::tryPossibleZipName( baseName + "res" + Utils::Fs::separator() + "res.zip", zipFileName ) )
+           || File::tryPossibleZipName( baseName + "res" + Utils::Fs::separator() + "res.zip", zipFileName ) ) {
         dictFiles.push_back( zipFileName );
+      }
 
       string dictId = Dictionary::makeDictionaryId( dictFiles );
 
@@ -1814,11 +1905,13 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         gdDebug( "Stardict: Building the index for dictionary: %s\n", ifo.bookname.c_str() );
 
-        if ( ifo.idxoffsetbits == 64 )
+        if ( ifo.idxoffsetbits == 64 ) {
           throw ex64BitsNotSupported();
+        }
 
-        if ( ifo.dicttype.size() )
+        if ( ifo.dicttype.size() ) {
           throw exDicttypeNotSupported();
+        }
 
         if ( synFileName.empty() ) {
           if ( ifo.synwordcount ) {
@@ -1858,13 +1951,14 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
         ChunkedStorage::Writer chunks( idx );
 
         // Load indices
-        if ( !ifo.synwordcount )
+        if ( !ifo.synwordcount ) {
           handleIdxSynFile( idxFileName,
                             indexedWords,
                             chunks,
                             0,
                             false,
                             !maxHeadwordsToExpand || ifo.wordcount < maxHeadwordsToExpand );
+        }
         else {
           vector< uint32_t > articleOffsets;
 
@@ -1925,8 +2019,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
           IndexedWords zipFileNames;
           IndexedZip zipFile;
-          if ( zipFile.openZipFile( QDir::fromNativeSeparators( zipFileName.c_str() ) ) )
+          if ( zipFile.openZipFile( QDir::fromNativeSeparators( zipFileName.c_str() ) ) ) {
             zipFile.indexFile( zipFileNames );
+          }
 
           if ( !zipFileNames.empty() ) {
             // Build the resulting zip file index
@@ -1943,8 +2038,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
             idxHeader.zipIndexRootOffset       = 0;
           }
         }
-        else
+        else {
           idxHeader.hasZipFile = 0;
+        }
 
         // That concludes it. Update the header.
 

--- a/src/dict/transliteration.cc
+++ b/src/dict/transliteration.cc
@@ -63,8 +63,9 @@ sptr< Dictionary::WordSearchRequest > BaseTransliterationDictionary::findHeadwor
 
   GD_DPRINTF( "alts = %u\n", (unsigned)alts.size() );
 
-  for ( const auto & alt : alts )
+  for ( const auto & alt : alts ) {
     result->getMatches().push_back( alt );
+  }
 
   return result;
 }
@@ -74,8 +75,9 @@ void Table::ins( char const * from, char const * to )
 {
   wstring fr = Utf8::decode( std::string( from ) );
 
-  if ( fr.size() > maxEntrySize )
+  if ( fr.size() > maxEntrySize ) {
     maxEntrySize = fr.size();
+  }
 
   insert( std::pair< wstring, wstring >( fr, Utf8::decode( std::string( to ) ) ) );
 }
@@ -132,8 +134,9 @@ vector< wstring > TransliterationDictionary::getAlternateWritings( wstring const
     }
   }
 
-  if ( result != *target )
+  if ( result != *target ) {
     results.push_back( result );
+  }
 
   return results;
 }

--- a/src/dict/utils/decompress.cc
+++ b/src/dict/utils/decompress.cc
@@ -22,14 +22,16 @@ QByteArray zlibDecompress( const char * bufptr, unsigned length )
       zs.avail_out = CHUNK_SIZE;
       res          = inflate( &zs, Z_SYNC_FLUSH );
       str.append( buf, CHUNK_SIZE - zs.avail_out );
-      if ( res != Z_OK && res != Z_STREAM_END )
+      if ( res != Z_OK && res != Z_STREAM_END ) {
         break;
+      }
     }
   }
 
   inflateEnd( &zs );
-  if ( res != Z_STREAM_END )
+  if ( res != Z_STREAM_END ) {
     str.clear();
+  }
   return str;
 }
 
@@ -57,13 +59,15 @@ string decompressBzip2( const char * bufptr, unsigned length )
       zs.total_out_lo32 = length;
       res               = BZ2_bzDecompress( &zs );
       str.append( buf, CHUNK_SIZE - zs.avail_out );
-      if ( res != BZ_OK && res != BZ_STREAM_END )
+      if ( res != BZ_OK && res != BZ_STREAM_END ) {
         break;
+      }
     }
   }
   BZ2_bzDecompressEnd( &zs );
-  if ( res != BZ_STREAM_END )
+  if ( res != BZ_STREAM_END ) {
     str.clear();
+  }
   return str;
 }
 
@@ -89,10 +93,12 @@ string decompressLzma2( const char * bufptr, unsigned length, bool raw_decoder )
   }
 
 
-  if ( raw_decoder )
+  if ( raw_decoder ) {
     res = lzma_raw_decoder( &strm, filters );
-  else
+  }
+  else {
     res = lzma_stream_decoder( &strm, UINT64_MAX, 0 );
+  }
 
   if ( res == LZMA_OK ) {
 
@@ -101,12 +107,14 @@ string decompressLzma2( const char * bufptr, unsigned length, bool raw_decoder )
       strm.avail_out = CHUNK_SIZE;
       res            = lzma_code( &strm, LZMA_RUN );
       str.append( buf, CHUNK_SIZE - strm.avail_out );
-      if ( res != LZMA_OK && res != LZMA_STREAM_END )
+      if ( res != LZMA_OK && res != LZMA_STREAM_END ) {
         break;
+      }
     }
     lzma_end( &strm );
-    if ( res != LZMA_STREAM_END )
+    if ( res != LZMA_STREAM_END ) {
       str.clear();
+    }
   }
 
   return str;

--- a/src/dict/utils/dictfile.cc
+++ b/src/dict/utils/dictfile.cc
@@ -19,8 +19,9 @@ bool tryPossibleName( std::string const & name, std::string & copyTo )
     copyTo = name;
     return true;
   }
-  else
+  else {
     return false;
+  }
 }
 
 bool tryPossibleZipName( std::string const & name, std::string & copyTo )
@@ -29,8 +30,9 @@ bool tryPossibleZipName( std::string const & name, std::string & copyTo )
     copyTo = name;
     return true;
   }
-  else
+  else {
     return false;
+  }
 }
 
 void loadFromFile( std::string const & filename, std::vector< char > & data )
@@ -70,8 +72,9 @@ void Index::open( char const * mode )
     ++pch;
   }
 
-  if ( !f.open( openMode ) )
+  if ( !f.open( openMode ) ) {
     throw exCantOpen( f.fileName().toStdString() + ": " + f.errorString().toUtf8().data() );
+  }
 }
 
 Index::Index( std::string_view filename, char const * mode )
@@ -124,10 +127,12 @@ char * Index::gets( char * s, int size, bool stripNl )
     while ( len-- ) {
       --last;
 
-      if ( *last == '\n' || *last == '\r' )
+      if ( *last == '\n' || *last == '\r' ) {
         *last = 0;
-      else
+      }
+      else {
         break;
+      }
     }
   }
 
@@ -138,8 +143,9 @@ std::string Index::gets( bool stripNl )
 {
   char buf[ 1024 ];
 
-  if ( !gets( buf, sizeof( buf ), stripNl ) )
+  if ( !gets( buf, sizeof( buf ), stripNl ) ) {
     throw exReadError();
+  }
 
   return { buf };
 }
@@ -152,8 +158,9 @@ QByteArray Index::readall()
 
 void Index::seek( qint64 offset )
 {
-  if ( !f.seek( offset ) )
+  if ( !f.seek( offset ) ) {
     throw exSeekError();
+  }
 }
 
 uchar * Index::map( qint64 offset, qint64 size )
@@ -169,8 +176,9 @@ bool Index::unmap( uchar * address )
 
 void Index::seekEnd()
 {
-  if ( !f.seek( f.size() ) )
+  if ( !f.seek( f.size() ) ) {
     throw exSeekError();
+  }
 }
 
 void Index::rewind()

--- a/src/dict/utils/dictzip.c
+++ b/src/dict/utils/dictzip.c
@@ -158,14 +158,16 @@ static void err_fatal( const char * routine, const char * format, ... )
 
   fflush( stdout );
   if ( _err_programName ) {
-    if ( routine )
+    if ( routine ) {
       fprintf( stderr, "%s (%s): ", _err_programName, routine );
-    else
+    } else {
       fprintf( stderr, "%s: ", _err_programName );
+}
   }
   else {
-    if ( routine )
+    if ( routine ) {
       fprintf( stderr, "%s: ", routine );
+}
   }
 
   va_start( ap, format );
@@ -190,14 +192,16 @@ static void err_fatal_errno( const char * routine, const char * format, ... )
 
   fflush( stdout );
   if ( _err_programName ) {
-    if ( routine )
+    if ( routine ) {
       fprintf( stderr, "%s (%s): ", _err_programName, routine );
-    else
+    } else {
       fprintf( stderr, "%s: ", _err_programName );
+}
   }
   else {
-    if ( routine )
+    if ( routine ) {
       fprintf( stderr, "%s: ", routine );
+}
   }
 
   va_start( ap, format );
@@ -229,16 +233,18 @@ static void err_internal( const char * routine, const char * format, ... )
 
   fflush( stdout );
   if ( _err_programName ) {
-    if ( routine )
+    if ( routine ) {
       fprintf( stderr, "%s (%s): Internal error\n     ", _err_programName, routine );
-    else
+    } else {
       fprintf( stderr, "%s: Internal error\n     ", _err_programName );
+}
   }
   else {
-    if ( routine )
+    if ( routine ) {
       fprintf( stderr, "%s: Internal error\n     ", routine );
-    else
+    } else {
       fprintf( stderr, "Internal error\n     " );
+}
   }
 
   va_start( ap, format );
@@ -246,10 +252,11 @@ static void err_internal( const char * routine, const char * format, ... )
   log_error( routine, format, ap );
   va_end( ap );
 
-  if ( _err_programName )
+  if ( _err_programName ) {
     fprintf( stderr, "Aborting %s...\n", _err_programName );
-  else
+  } else {
     fprintf( stderr, "Aborting...\n" );
+}
   fflush( stderr );
   fflush( stdout );
   //  abort();
@@ -544,30 +551,36 @@ void dict_data_close( dictData * header )
 {
   int i;
 
-  if ( !header )
+  if ( !header ) {
     return;
+}
 
 #ifdef __WIN32
   if ( header->fd != INVALID_HANDLE_VALUE )
     CloseHandle( header->fd );
 #else
-  if ( header->fd )
+  if ( header->fd ) {
     fclose( header->fd );
+}
 #endif
 
-  if ( header->chunks )
+  if ( header->chunks ) {
     xfree( header->chunks );
-  if ( header->offsets )
+}
+  if ( header->offsets ) {
     xfree( header->offsets );
+}
 
   if ( header->initialized ) {
-    if ( inflateEnd( &header->zStream ) )
+    if ( inflateEnd( &header->zStream ) ) {
       err_internal( __func__, "Cannot shut down inflation engine: %s\n", header->zStream.msg );
+}
   }
 
   for ( i = 0; i < DICT_CACHE_SIZE; ++i ) {
-    if ( header->cache[ i ].inBuffer )
+    if ( header->cache[ i ].inBuffer ) {
       xfree( header->cache[ i ].inBuffer );
+}
   }
 
   xfree( header );
@@ -695,8 +708,9 @@ char * dict_data_read_(
         h->cache[ target ].stamp = ++h->stamp;
         if ( h->stamp < 0 ) {
           h->stamp = 0;
-          for ( j = 0; j < DICT_CACHE_SIZE; j++ )
+          for ( j = 0; j < DICT_CACHE_SIZE; j++ ) {
             h->cache[ j ].stamp = -1;
+}
         }
         if ( found ) {
           count    = h->cache[ target ].count;
@@ -708,8 +722,9 @@ char * dict_data_read_(
           DWORD readed;
 #endif
           h->cache[ target ].chunk = -1;
-          if ( !h->cache[ target ].inBuffer )
+          if ( !h->cache[ target ].inBuffer ) {
             h->cache[ target ].inBuffer = xmalloc( h->chunkLength );
+}
           inBuffer = h->cache[ target ].inBuffer;
           if ( !inBuffer ) {
             strcpy( h->errorString, dz_error_str( DZ_ERR_NOMEMORY ) );

--- a/src/dict/utils/indexedzip.cc
+++ b/src/dict/utils/indexedzip.cc
@@ -29,8 +29,9 @@ bool IndexedZip::openZipFile( QString const & name )
 
 bool IndexedZip::hasFile( gd::wstring const & name )
 {
-  if ( !zipIsOpen )
+  if ( !zipIsOpen ) {
     return false;
+  }
 
   vector< WordArticleLink > links = findArticles( name );
 
@@ -39,26 +40,30 @@ bool IndexedZip::hasFile( gd::wstring const & name )
 
 bool IndexedZip::loadFile( gd::wstring const & name, vector< char > & data )
 {
-  if ( !zipIsOpen )
+  if ( !zipIsOpen ) {
     return false;
+  }
 
   vector< WordArticleLink > links = findArticles( name );
 
-  if ( links.empty() )
+  if ( links.empty() ) {
     return false;
+  }
 
   return loadFile( links[ 0 ].articleOffset, data );
 }
 
 bool IndexedZip::loadFile( uint32_t offset, vector< char > & data )
 {
-  if ( !zipIsOpen )
+  if ( !zipIsOpen ) {
     return false;
+  }
 
   QMutexLocker _( &mutex );
   // Now seek into the zip file and read its header
-  if ( !zip.seek( offset ) )
+  if ( !zip.seek( offset ) ) {
     return false;
+  }
 
   ZipFile::LocalFileHeader header;
 
@@ -88,8 +93,9 @@ bool IndexedZip::loadFile( uint32_t offset, vector< char > & data )
 
       QByteArray compressedData = zip.read( header.compressedSize );
 
-      if ( compressedData.size() != (int)header.compressedSize )
+      if ( compressedData.size() != (int)header.compressedSize ) {
         return false;
+      }
 
       data.resize( header.uncompressedSize );
 
@@ -130,12 +136,14 @@ bool IndexedZip::loadFile( uint32_t offset, vector< char > & data )
 
 bool IndexedZip::indexFile( BtreeIndexing::IndexedWords & zipFileNames, quint32 * filesCount )
 {
-  if ( !zipIsOpen )
+  if ( !zipIsOpen ) {
     return false;
+  }
 
   QMutexLocker _( &mutex );
-  if ( !ZipFile::positionAtCentralDir( zip ) )
+  if ( !ZipFile::positionAtCentralDir( zip ) ) {
     return false;
+  }
 
   // File seems to be a valid zip file
 
@@ -145,8 +153,9 @@ bool IndexedZip::indexFile( BtreeIndexing::IndexedWords & zipFileNames, quint32 
   ZipFile::CentralDirEntry entry;
 
   bool alreadyCounted;
-  if ( filesCount )
+  if ( filesCount ) {
     *filesCount = 0;
+  }
 
   while ( ZipFile::readNextEntry( zip, entry ) ) {
     if ( entry.compressionMethod == ZipFile::Unsupported ) {
@@ -165,8 +174,9 @@ bool IndexedZip::indexFile( BtreeIndexing::IndexedWords & zipFileNames, quint32 
         hasNonAscii = true;
         break;
       }
-      else if ( !*ptr++ )
+      else if ( !*ptr++ ) {
         break;
+      }
     }
 
     alreadyCounted = false;
@@ -175,8 +185,9 @@ bool IndexedZip::indexFile( BtreeIndexing::IndexedWords & zipFileNames, quint32 
       // Add entry as is
 
       zipFileNames.addSingleWord( Utf8::decode( entry.fileName.data() ), entry.localHeaderOffset );
-      if ( filesCount )
+      if ( filesCount ) {
         *filesCount += 1;
+      }
     }
     else {
       // Try assuming different encodings. Those are UTF8, system locale and two

--- a/src/dict/utils/ripemd.cc
+++ b/src/dict/utils/ripemd.cc
@@ -116,8 +116,9 @@ void RIPEMD128::transform( const uchar buffer[ 64 ] )
   c = g = state[ 2 ];
   d = h = state[ 3 ];
 
-  for ( n = 0; n < 16; n++ )
+  for ( n = 0; n < 16; n++ ) {
     block[ n ] = qFromLittleEndian< quint32 >( buffer + 4 * n );
+  }
   n = 0;
 
   R128_0;
@@ -156,8 +157,9 @@ void RIPEMD128::update( const uchar * data, size_t len )
   if ( ( j + len ) > 63 ) {
     memcpy( &buffer[ j ], data, ( i = 64 - j ) );
     transform( buffer );
-    for ( ; i + 63 < len; i += 64 )
+    for ( ; i + 63 < len; i += 64 ) {
       transform( &data[ i ] );
+    }
     j = 0;
   }
   else {
@@ -170,9 +172,11 @@ void RIPEMD128::digest( uchar * digest )
 {
   quint64 finalcount = qFromLittleEndian( count << 3 );
   update( (const uchar *)"\200", 1 );
-  while ( ( count & 63 ) != 56 )
+  while ( ( count & 63 ) != 56 ) {
     update( (const uchar *)"", 1 );
+  }
   update( (uchar *)&finalcount, 8 ); /* Should cause a transform() */
-  for ( int i = 0; i < 4; i++ )
+  for ( int i = 0; i < 4; i++ ) {
     qToLittleEndian( state[ i ], digest + i * 4 );
+  }
 }

--- a/src/dict/utils/splitfile.cc
+++ b/src/dict/utils/splitfile.cc
@@ -18,10 +18,12 @@ SplitFile::~SplitFile()
 
 void SplitFile::appendFile( const QString & name )
 {
-  if ( offsets.isEmpty() )
+  if ( offsets.isEmpty() ) {
     offsets.append( 0 );
-  else
+  }
+  else {
     offsets.append( offsets.last() + files.last()->size() );
+  }
   files.append( new QFile( name ) );
 }
 
@@ -40,8 +42,9 @@ void SplitFile::close()
 
 void SplitFile::getFilenames( vector< string > & names ) const
 {
-  for ( QList< QFile * >::const_iterator i = files.begin(); i != files.end(); ++i )
+  for ( QList< QFile * >::const_iterator i = files.begin(); i != files.end(); ++i ) {
     names.push_back( ( *i )->fileName().toStdString() );
+  }
 }
 
 int SplitFile::getCurrentFile() const
@@ -51,25 +54,29 @@ int SplitFile::getCurrentFile() const
 
 bool SplitFile::open( QFile::OpenMode mode )
 {
-  for ( QList< QFile * >::iterator i = files.begin(); i != files.end(); ++i )
+  for ( QList< QFile * >::iterator i = files.begin(); i != files.end(); ++i ) {
     if ( !( *i )->open( mode ) ) {
       close();
       return false;
     }
+  }
 
   return true;
 }
 
 bool SplitFile::seek( quint64 pos )
 {
-  if ( offsets.isEmpty() )
+  if ( offsets.isEmpty() ) {
     return false;
+  }
 
   int fileNom;
 
-  for ( fileNom = 0; fileNom < offsets.size() - 1; fileNom++ )
-    if ( pos < offsets.at( fileNom + 1 ) )
+  for ( fileNom = 0; fileNom < offsets.size() - 1; fileNom++ ) {
+    if ( pos < offsets.at( fileNom + 1 ) ) {
       break;
+    }
+  }
 
   pos -= offsets.at( fileNom );
 
@@ -79,8 +86,9 @@ bool SplitFile::seek( quint64 pos )
 
 qint64 SplitFile::read( char * data, qint64 maxSize )
 {
-  if ( offsets.isEmpty() )
+  if ( offsets.isEmpty() ) {
     return 0;
+  }
 
   quint64 bytesReaded = 0;
   for ( int i = currentFile; i < files.size(); i++ ) {
@@ -90,14 +98,16 @@ qint64 SplitFile::read( char * data, qint64 maxSize )
     }
 
     qint64 ret = files.at( i )->read( data + bytesReaded, maxSize );
-    if ( ret < 0 )
+    if ( ret < 0 ) {
       break;
+    }
 
     bytesReaded += ret;
     maxSize -= ret;
 
-    if ( maxSize <= 0 )
+    if ( maxSize <= 0 ) {
       break;
+    }
   }
   return bytesReaded;
 }
@@ -109,8 +119,9 @@ QByteArray SplitFile::read( qint64 maxSize )
 
   qint64 ret = read( data.data(), maxSize );
 
-  if ( ret != maxSize )
+  if ( ret != maxSize ) {
     data.resize( ret );
+  }
 
   return data;
 }
@@ -123,8 +134,9 @@ bool SplitFile::getChar( char * c )
 
 qint64 SplitFile::pos() const
 {
-  if ( offsets.isEmpty() )
+  if ( offsets.isEmpty() ) {
     return 0;
+  }
 
   return offsets.at( currentFile ) + files.at( currentFile )->pos();
 }

--- a/src/dict/website.cc
+++ b/src/dict/website.cc
@@ -163,8 +163,9 @@ QTextCodec * WebSiteArticleRequest::codecForHtml( QByteArray const & ba )
 
 void WebSiteArticleRequest::requestFinished( QNetworkReply * r )
 {
-  if ( isFinished() ) // Was cancelled
+  if ( isFinished() ) { // Was cancelled
     return;
+  }
 
   if ( r != netReply ) {
     // Well, that's not our reply, don't do anything
@@ -192,17 +193,20 @@ void WebSiteArticleRequest::requestFinished( QNetworkReply * r )
     QString articleString;
 
     QTextCodec * codec = WebSiteArticleRequest::codecForHtml( replyData );
-    if ( codec )
+    if ( codec ) {
       articleString = codec->toUnicode( replyData );
-    else
+    }
+    else {
       articleString = QString::fromUtf8( replyData );
+    }
 
     // Change links from relative to absolute
 
     QString root = netReply->url().scheme() + "://" + netReply->url().host();
     QString base = root + netReply->url().path();
-    while ( !base.isEmpty() && !base.endsWith( "/" ) )
+    while ( !base.isEmpty() && !base.endsWith( "/" ) ) {
       base.chop( 1 );
+    }
 
     QRegularExpression tags( R"(<\s*(a|link|img|script)\s+[^>]*(src|href)\s*=\s*['"][^>]+>)",
                              QRegularExpression::CaseInsensitiveOption );
@@ -233,12 +237,15 @@ void WebSiteArticleRequest::requestFinished( QNetworkReply * r )
       }
 
       QString newUrl = match_links.captured( 1 ) + "=" + match_links.captured( 2 );
-      if ( url.startsWith( "//" ) )
+      if ( url.startsWith( "//" ) ) {
         newUrl += netReply->url().scheme() + ":";
-      else if ( url.startsWith( "/" ) )
+      }
+      else if ( url.startsWith( "/" ) ) {
         newUrl += root;
-      else
+      }
+      else {
         newUrl += base;
+      }
       newUrl += match_links.captured( 3 );
 
       tag.replace( match_links.capturedStart(), match_links.capturedLength(), newUrl );
@@ -313,8 +320,9 @@ WebSiteDictionary::getArticle( wstring const & str, vector< wstring > const &, w
   QByteArray urlString;
 
   // Context contains the right url to go to
-  if ( context.size() )
+  if ( context.size() ) {
     urlString = Utf8::encode( context ).c_str();
+  }
   else {
     urlString = urlTemplate;
 
@@ -323,35 +331,42 @@ WebSiteDictionary::getArticle( wstring const & str, vector< wstring > const &, w
     urlString.replace( "%25GDWORD%25", inputWord.toUtf8().toPercentEncoding() );
 
     QTextCodec * codec = QTextCodec::codecForName( "Windows-1251" );
-    if ( codec )
+    if ( codec ) {
       urlString.replace( "%25GD1251%25", codec->fromUnicode( inputWord ).toPercentEncoding() );
+    }
 
     codec = QTextCodec::codecForName( "Big-5" );
-    if ( codec )
+    if ( codec ) {
       urlString.replace( "%25GDBIG5%25", codec->fromUnicode( inputWord ).toPercentEncoding() );
+    }
 
     codec = QTextCodec::codecForName( "Big5-HKSCS" );
-    if ( codec )
+    if ( codec ) {
       urlString.replace( "%25GDBIG5HKSCS%25", codec->fromUnicode( inputWord ).toPercentEncoding() );
+    }
 
     codec = QTextCodec::codecForName( "Shift-JIS" );
-    if ( codec )
+    if ( codec ) {
       urlString.replace( "%25GDSHIFTJIS%25", codec->fromUnicode( inputWord ).toPercentEncoding() );
+    }
 
     codec = QTextCodec::codecForName( "GB18030" );
-    if ( codec )
+    if ( codec ) {
       urlString.replace( "%25GDGBK%25", codec->fromUnicode( inputWord ).toPercentEncoding() );
+    }
 
 
     // Handle all ISO-8859 encodings
     for ( int x = 1; x <= 16; ++x ) {
       codec = QTextCodec::codecForName( QString( "ISO 8859-%1" ).arg( x ).toLatin1() );
-      if ( codec )
+      if ( codec ) {
         urlString.replace( QString( "%25GDISO%1%25" ).arg( x ).toUtf8(),
                            codec->fromUnicode( inputWord ).toPercentEncoding() );
+      }
 
-      if ( x == 10 )
+      if ( x == 10 ) {
         x = 12; // Skip encodings 11..12, they don't exist
+      }
     }
   }
 
@@ -439,8 +454,9 @@ void WebSiteResourceRequest::cancel()
 
 void WebSiteResourceRequest::requestFinished( QNetworkReply * r )
 {
-  if ( isFinished() ) // Was cancelled
+  if ( isFinished() ) { // Was cancelled
     return;
+  }
 
   if ( r != netReply ) {
     // Well, that's not our reply, don't do anything
@@ -473,8 +489,9 @@ void WebSiteResourceRequest::requestFinished( QNetworkReply * r )
 
     hasAnyData = true;
   }
-  else
+  else {
     setErrorString( netReply->errorString() );
+  }
 
   disconnect( netReply, 0, 0, 0 );
   netReply->deleteLater();
@@ -486,23 +503,27 @@ sptr< Dictionary::DataRequest > WebSiteDictionary::getResource( string const & n
 {
   QString link = QString::fromUtf8( name.c_str() );
   int pos      = link.indexOf( '/' );
-  if ( pos > 0 )
+  if ( pos > 0 ) {
     link.replace( pos, 1, "://" );
+  }
   return std::make_shared< WebSiteResourceRequest >( link, netMgr, this );
 }
 
 void WebSiteDictionary::loadIcon() noexcept
 {
-  if ( dictionaryIconLoaded )
+  if ( dictionaryIconLoaded ) {
     return;
+  }
 
   if ( !iconFilename.isEmpty() ) {
     QFileInfo fInfo( QDir( Config::getConfigDir() ), iconFilename );
-    if ( fInfo.isFile() )
+    if ( fInfo.isFile() ) {
       loadIconFromFile( fInfo.absoluteFilePath(), true );
+    }
   }
-  if ( dictionaryIcon.isNull() && !loadIconFromText( ":/icons/webdict.svg", QString::fromStdString( name ) ) )
+  if ( dictionaryIcon.isNull() && !loadIconFromText( ":/icons/webdict.svg", QString::fromStdString( name ) ) ) {
     dictionaryIcon = QIcon( ":/icons/webdict.svg" );
+  }
   dictionaryIconLoaded = true;
 }
 
@@ -514,13 +535,14 @@ vector< sptr< Dictionary::Class > > makeDictionaries( Config::WebSites const & w
   vector< sptr< Dictionary::Class > > result;
 
   for ( const auto & w : ws ) {
-    if ( w.enabled )
+    if ( w.enabled ) {
       result.push_back( std::make_shared< WebSiteDictionary >( w.id.toUtf8().data(),
                                                                w.name.toUtf8().data(),
                                                                w.url,
                                                                w.iconFilename,
                                                                w.inside_iframe,
                                                                mgr ) );
+    }
   }
 
   return result;

--- a/src/dict/xdxf.cc
+++ b/src/dict/xdxf.cc
@@ -63,8 +63,9 @@ quint32 getLanguageId( const QString & lang )
 {
   QString lstr = lang.left( 3 );
 
-  if ( lstr.endsWith( QChar( '-' ) ) )
+  if ( lstr.endsWith( QChar( '-' ) ) ) {
     lstr.chop( 1 );
+  }
 
   switch ( lstr.size() ) {
     case 2:
@@ -202,9 +203,10 @@ public:
     if ( metadata_enable_fts.has_value() ) {
       can_FTS = fts.enabled && metadata_enable_fts.value();
     }
-    else
+    else {
       can_FTS = fts.enabled && !fts.disabledTypes.contains( "XDXF", Qt::CaseInsensitive )
         && ( fts.maxDictionarySize == 0 || getArticleCount() <= fts.maxDictionarySize );
+    }
   }
 
   uint32_t getFtsIndexVersion() override
@@ -245,8 +247,9 @@ XdxfDictionary::XdxfDictionary( string const & id, string const & indexFile, vec
   DZ_ERRORS error;
   dz = dict_data_open( dictionaryFiles[ 0 ].c_str(), &error, 0 );
 
-  if ( !dz )
+  if ( !dz ) {
     throw exDictzipError( string( dz_error_str( error ) ) + "(" + dictionaryFiles[ 0 ] + ")" );
+  }
 
   // Read the abrv, if any
 
@@ -286,8 +289,9 @@ XdxfDictionary::XdxfDictionary( string const & id, string const & indexFile, vec
 
       QString zipName = QDir::fromNativeSeparators( getDictionaryFilenames().back().c_str() );
 
-      if ( zipName.endsWith( ".zip", Qt::CaseInsensitive ) ) // Sanity check
+      if ( zipName.endsWith( ".zip", Qt::CaseInsensitive ) ) { // Sanity check
         resourceZip.openZipFile( zipName );
+      }
     }
   }
 
@@ -302,14 +306,16 @@ XdxfDictionary::XdxfDictionary( string const & id, string const & indexFile, vec
 
 XdxfDictionary::~XdxfDictionary()
 {
-  if ( dz )
+  if ( dz ) {
     dict_data_close( dz );
+  }
 }
 
 void XdxfDictionary::loadIcon() noexcept
 {
-  if ( dictionaryIconLoaded )
+  if ( dictionaryIconLoaded ) {
     return;
+  }
 
   QString fileName = QDir::fromNativeSeparators( getDictionaryFilenames()[ 0 ].c_str() );
 
@@ -328,8 +334,9 @@ void XdxfDictionary::loadIcon() noexcept
     info     = QFileInfo( fileName );
   }
 
-  if ( info.isFile() )
+  if ( info.isFile() ) {
     loadIconFromFile( fileName, true );
+  }
 
   if ( dictionaryIcon.isNull() ) {
     // Load failed -- use default icons
@@ -342,11 +349,13 @@ void XdxfDictionary::loadIcon() noexcept
 
 QString const & XdxfDictionary::getDescription()
 {
-  if ( !dictionaryDescription.isEmpty() )
+  if ( !dictionaryDescription.isEmpty() ) {
     return dictionaryDescription;
+  }
 
-  if ( idxHeader.descriptionAddress == 0 )
+  if ( idxHeader.descriptionAddress == 0 ) {
     dictionaryDescription = "NONE";
+  }
   else {
     try {
       vector< char > chunk;
@@ -371,14 +380,17 @@ QString XdxfDictionary::getMainFilename()
 void XdxfDictionary::makeFTSIndex( QAtomicInt & isCancelled )
 {
   if ( !( Dictionary::needToRebuildIndex( getDictionaryFilenames(), ftsIdxName )
-          || FtsHelpers::ftsIndexIsOldOrBad( this ) ) )
+          || FtsHelpers::ftsIndexIsOldOrBad( this ) ) ) {
     FTS_index_completed.ref();
+  }
 
-  if ( haveFTSIndex() )
+  if ( haveFTSIndex() ) {
     return;
+  }
 
-  if ( ensureInitDone().size() )
+  if ( ensureInitDone().size() ) {
     return;
+  }
 
 
   gdDebug( "Xdxf: Building the full-text index for dictionary: %s\n", getName().c_str() );
@@ -485,8 +497,9 @@ void XdxfArticleRequest::run()
                                     // by only allowing them to appear once.
 
   wstring wordCaseFolded = Folding::applySimpleCaseOnly( word );
-  if ( ignoreDiacritics )
+  if ( ignoreDiacritics ) {
     wordCaseFolded = Folding::applyDiacriticsOnly( wordCaseFolded );
+  }
 
   for ( const auto & x : chain ) {
     if ( Utils::AtomicInt::loadAcquire( isCancelled ) ) {
@@ -494,8 +507,9 @@ void XdxfArticleRequest::run()
       return;
     }
 
-    if ( articlesIncluded.find( x.articleOffset ) != articlesIncluded.end() )
+    if ( articlesIncluded.find( x.articleOffset ) != articlesIncluded.end() ) {
       continue; // We already have this article in the body.
+    }
 
     // Now grab that article
 
@@ -512,8 +526,9 @@ void XdxfArticleRequest::run()
       // We do the case-folded comparison here.
 
       wstring headwordStripped = Folding::applySimpleCaseOnly( headword );
-      if ( ignoreDiacritics )
+      if ( ignoreDiacritics ) {
         headwordStripped = Folding::applyDiacriticsOnly( headwordStripped );
+      }
 
       multimap< wstring, pair< string, string > > & mapToUse =
         ( wordCaseFolded == headwordStripped ) ? mainArticles : alternateArticles;
@@ -672,8 +687,9 @@ protected:
 GzippedFile::GzippedFile( char const * fileName )
 {
   gz = gd_gzopen( fileName );
-  if ( !gz )
+  if ( !gz ) {
     throw exCantReadFile( fileName );
+  }
 
   DZ_ERRORS error;
   dz = dict_data_open( fileName, &error, 0 );
@@ -682,8 +698,9 @@ GzippedFile::GzippedFile( char const * fileName )
 GzippedFile::~GzippedFile()
 {
   gzclose( gz );
-  if ( dz )
+  if ( dz ) {
     dict_data_close( dz );
+  }
 }
 
 bool GzippedFile::atEnd() const
@@ -700,8 +717,9 @@ size_t GzippedFile::gzTell()
 
 qint64 GzippedFile::readData( char * data, qint64 maxSize )
 {
-  if ( maxSize > 1 )
+  if ( maxSize > 1 ) {
     maxSize = 1;
+  }
 
   // The returning value translates directly to QIODevice semantics
   int n = gzread( gz, data, maxSize );
@@ -713,16 +731,20 @@ qint64 GzippedFile::readData( char * data, qint64 maxSize )
     char ch      = *data;
     int addBytes = 0;
     if ( ch & 0x80 ) {
-      if ( ( ch & 0xF8 ) == 0xF0 )
+      if ( ( ch & 0xF8 ) == 0xF0 ) {
         addBytes = 3;
-      else if ( ( ch & 0xF0 ) == 0xE0 )
+      }
+      else if ( ( ch & 0xF0 ) == 0xE0 ) {
         addBytes = 2;
-      else if ( ( ch & 0xE0 ) == 0xC0 )
+      }
+      else if ( ( ch & 0xE0 ) == 0xC0 ) {
         addBytes = 1;
+      }
     }
 
-    if ( addBytes )
+    if ( addBytes ) {
       n += gzread( gz, data + 1, addBytes );
+    }
   }
 
   return n;
@@ -730,8 +752,9 @@ qint64 GzippedFile::readData( char * data, qint64 maxSize )
 
 char * GzippedFile::readDataArray( unsigned long startPos, unsigned long size )
 {
-  if ( dz == NULL )
+  if ( dz == NULL ) {
     return NULL;
+  }
   return dict_data_read_( dz, startPos, size, 0, 0 );
 }
 
@@ -763,8 +786,9 @@ QString readXhtmlData( QXmlStreamReader & stream )
     else if ( stream.isCharacters() || stream.isWhitespace() || stream.isCDATA() ) {
       result += stream.text();
     }
-    else if ( stream.isEndElement() )
+    else if ( stream.isEndElement() ) {
       break;
+    }
   }
 
   return result;
@@ -792,23 +816,27 @@ void addAllKeyTags( QXmlStreamReader & stream, list< QString > & words )
   while ( !stream.atEnd() ) {
     stream.readNext();
 
-    if ( stream.isStartElement() )
+    if ( stream.isStartElement() ) {
       addAllKeyTags( stream, words );
-    else if ( stream.isEndElement() )
+    }
+    else if ( stream.isEndElement() ) {
       return;
+    }
   }
 }
 
 void checkArticlePosition( GzippedFile & gzFile, uint32_t * pOffset, uint32_t * pSize )
 {
   char * data = gzFile.readDataArray( *pOffset, *pSize );
-  if ( data == NULL )
+  if ( data == NULL ) {
     return;
+  }
   QString s = QString::fromUtf8( data );
   free( data );
   int n = s.lastIndexOf( "</ar" );
-  if ( n > 0 )
+  if ( n > 0 ) {
     *pSize -= s.size() - n;
+  }
   if ( s.at( 0 ) == '>' ) {
     *pOffset += 1;
     *pSize -= 1;
@@ -827,12 +855,15 @@ void indexArticle( GzippedFile & gzFile,
 
   QStringView formatValue = stream.attributes().value( "f" );
 
-  if ( formatValue == u"v" )
+  if ( formatValue == u"v" ) {
     format = Visual;
-  else if ( formatValue == u"l" )
+  }
+  else if ( formatValue == u"l" ) {
     format = Logical;
-  if ( format == Default )
+  }
+  if ( format == Default ) {
     format = defaultFormat;
+  }
   size_t articleOffset = gzFile.pos() - 1; // stream.characterOffset() is loony
 
   // uint32_t lineNumber = stream.lineNumber();
@@ -873,8 +904,9 @@ void indexArticle( GzippedFile & gzFile,
 
         // Add words to index
 
-        for ( const auto & word : words )
+        for ( const auto & word : words ) {
           indexedWords.addWord( gd::toWString( word ), offset );
+        }
 
         ++articleCount;
 
@@ -965,11 +997,13 @@ void XdxfResourceRequest::run()
         if ( dict.resourceZip.isOpen() ) {
           QMutexLocker _( &dataMutex );
 
-          if ( !dict.resourceZip.loadFile( Utf8::decode( resourceName ), data ) )
+          if ( !dict.resourceZip.loadFile( Utf8::decode( resourceName ), data ) ) {
             throw; // Make it fail since we couldn't read the archive
+          }
         }
-        else
+        else {
           throw;
+        }
       }
     }
 
@@ -1013,8 +1047,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
   for ( const auto & fileName : fileNames ) {
     // Only allow .xdxf and .xdxf.dz suffixes
 
-    if ( !Utils::endsWithIgnoreCase( fileName, ".xdxf" ) && !Utils::endsWithIgnoreCase( fileName, ".xdxf.dz" ) )
+    if ( !Utils::endsWithIgnoreCase( fileName, ".xdxf" ) && !Utils::endsWithIgnoreCase( fileName, ".xdxf.dz" ) ) {
       continue;
+    }
 
     try {
       vector< string > dictFiles( 1, fileName );
@@ -1029,8 +1064,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
       if ( File::tryPossibleZipName( baseName + ".xdxf.files.zip", zipFileName )
            || File::tryPossibleZipName( baseName + ".xdxf.dz.files.zip", zipFileName )
            || File::tryPossibleZipName( baseName + ".XDXF.FILES.ZIP", zipFileName )
-           || File::tryPossibleZipName( baseName + ".XDXF.DZ.FILES.ZIP", zipFileName ) )
+           || File::tryPossibleZipName( baseName + ".XDXF.DZ.FILES.ZIP", zipFileName ) ) {
         dictFiles.push_back( zipFileName );
+      }
 
       string dictId = Dictionary::makeDictionaryId( dictFiles );
 
@@ -1059,8 +1095,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         GzippedFile gzFile( dictFiles[ 0 ].c_str() );
 
-        if ( !gzFile.open( QIODevice::ReadOnly ) )
+        if ( !gzFile.open( QIODevice::ReadOnly ) ) {
           throw exCantReadFile( dictFiles[ 0 ] );
+        }
 
         QXmlStreamReader stream( &gzFile );
 
@@ -1076,18 +1113,21 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
           stream.readNext();
 
           if ( stream.isStartElement() ) {
-            if ( stream.name() != u"xdxf" )
+            if ( stream.name() != u"xdxf" ) {
               throw exNotXdxfFile( dictFiles[ 0 ] );
+            }
             else {
               // Read the xdxf
 
               string str = stream.attributes().value( "lang_from" ).toString().toLatin1().data();
-              if ( !str.empty() )
+              if ( !str.empty() ) {
                 idxHeader.langFrom = getLanguageId( str.c_str() );
+              }
 
               str = stream.attributes().value( "lang_to" ).toString().toLatin1().data();
-              if ( !str.empty() )
+              if ( !str.empty() ) {
                 idxHeader.langTo = getLanguageId( str.c_str() );
+              }
 
               QRegularExpression regNum( "\\d+" );
               auto match               = regNum.match( stream.attributes().value( "revision" ).toString() );
@@ -1153,8 +1193,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
                   }
                   else if ( stream.name() == u"languages" ) {
                     while ( !( stream.isEndElement() && stream.name() == u"languages" ) && !stream.atEnd() ) {
-                      if ( !stream.readNext() )
+                      if ( !stream.readNext() ) {
                         break;
+                      }
                       if ( stream.isStartElement() ) {
                         if ( stream.name() == u"from" ) {
                           if ( idxHeader.langFrom == 0 ) {
@@ -1169,8 +1210,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
                           }
                         }
                       }
-                      else if ( stream.isEndElement() && stream.name() == u"languages" )
+                      else if ( stream.isEndElement() && stream.name() == u"languages" ) {
                         break;
+                      }
                     }
                   }
                   else if ( stream.name() == u"abbreviations" ) {
@@ -1178,8 +1220,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
                     string value;
                     list< wstring > keys;
                     while ( !( stream.isEndElement() && stream.name() == u"abbreviations" ) && !stream.atEnd() ) {
-                      if ( !stream.readNextStartElement() )
+                      if ( !stream.readNextStartElement() ) {
                         break;
+                      }
                       // abbreviations tag set switch at format revision = 30
                       if ( idxHeader.revisionNumber >= 30 ) {
                         while ( !( stream.isEndElement() && stream.name() == u"abbr_def" ) || !stream.atEnd() ) {
@@ -1195,8 +1238,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
                             }
                             keys.clear();
                           }
-                          else if ( stream.isEndElement() && stream.name() == u"abbreviations" )
+                          else if ( stream.isEndElement() && stream.name() == u"abbreviations" ) {
                             break;
+                          }
                           stream.readNext();
                         }
                       }
@@ -1214,8 +1258,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
                             }
                             keys.clear();
                           }
-                          else if ( stream.isEndElement() && stream.name() == u"abbreviations" )
+                          else if ( stream.isEndElement() && stream.name() == u"abbreviations" ) {
                             break;
+                          }
                           stream.readNext();
                         }
                       }
@@ -1275,8 +1320,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
                 IndexedWords zipFileNames;
                 IndexedZip zipFile;
-                if ( zipFile.openZipFile( QDir::fromNativeSeparators( zipFileName.c_str() ) ) )
+                if ( zipFile.openZipFile( QDir::fromNativeSeparators( zipFileName.c_str() ) ) ) {
                   zipFile.indexFile( zipFileNames );
+                }
 
                 if ( !zipFileNames.empty() ) {
                   // Build the resulting zip file index
@@ -1293,8 +1339,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
                   idxHeader.zipIndexRootOffset       = 0;
                 }
               }
-              else
+              else {
                 idxHeader.hasZipFile = 0;
+              }
               // That concludes it. Update the header.
 
               idxHeader.signature     = Signature;
@@ -1313,8 +1360,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
           }
         }
 
-        if ( !hadXdxf )
+        if ( !hadXdxf ) {
           throw exNotXdxfFile( dictFiles[ 0 ] );
+        }
 
         if ( stream.hasError() ) {
           gdWarning( "%s had a parse error %s at line %lu, and therefore was indexed only up to the point of error.",

--- a/src/dict/xdxf2html.cc
+++ b/src/dict/xdxf2html.cc
@@ -48,10 +48,12 @@ string convertToRoman( int input, int lower_case )
   for ( int i = 0; i < 13; i++ ) {
     while ( input >= decimal[ i ] ) {
       input -= decimal[ i ];
-      if ( lower_case == 1 )
+      if ( lower_case == 1 ) {
         romanvalue += roman[ i + 13 ];
-      else
+      }
+      else {
         romanvalue += roman[ i ];
+      }
     }
   }
   return romanvalue;
@@ -86,8 +88,9 @@ string convert( string const & in,
     switch ( i ) {
       case '\n':
         afterEol = true;
-        if ( !isLogicalFormat )
+        if ( !isLogicalFormat ) {
           inConverted.append( "<br/>" );
+        }
         break;
 
       case '\r':
@@ -95,8 +98,9 @@ string convert( string const & in,
 
       case ' ':
         if ( afterEol ) {
-          if ( !isLogicalFormat )
+          if ( !isLogicalFormat ) {
             inConverted.append( "&#160;" ); // xml don't have &nbsp;
+          }
           break;
         }
         // Fall-through
@@ -116,12 +120,14 @@ string convert( string const & in,
   string in_data;
   if ( type == XDXF ) {
     in_data = "<div class=\"xdxf\"";
-    if ( dictPtr->isToLanguageRTL() )
+    if ( dictPtr->isToLanguageRTL() ) {
       in_data += " dir=\"rtl\"";
+    }
     in_data += ">";
   }
-  else
+  else {
     in_data = "<div class=\"sdct_x\">";
+  }
   in_data += inConverted + "</div>";
 
 
@@ -174,8 +180,9 @@ string convert( string const & in,
       el2.setAttribute( "class", "xdxf_ex_source" );
       QString text = author;
       if ( !source.isEmpty() ) {
-        if ( !text.isEmpty() )
+        if ( !text.isEmpty() ) {
           text += ", ";
+        }
         text += source;
       }
       QDomText txtNode = dd.createTextNode( text );
@@ -183,14 +190,17 @@ string convert( string const & in,
       el.appendChild( el2 );
     }
 
-    if ( el.text().isEmpty() && el.childNodes().isEmpty() )
+    if ( el.text().isEmpty() && el.childNodes().isEmpty() ) {
       el.appendChild( fakeElement( dd ) );
+    }
 
     el.setTagName( "span" );
-    if ( isLogicalFormat )
+    if ( isLogicalFormat ) {
       el.setAttribute( "class", "xdxf_ex" );
-    else
+    }
+    else {
       el.setAttribute( "class", "xdxf_ex_old" );
+    }
   }
 
   nodes = dd.elementsByTagName( "mrkd" ); // marked out words in translations/examples of usage
@@ -198,8 +208,9 @@ string convert( string const & in,
   while ( nodes.size() ) {
     QDomElement el = nodes.at( 0 ).toElement();
 
-    if ( el.text().isEmpty() && el.childNodes().isEmpty() )
+    if ( el.text().isEmpty() && el.childNodes().isEmpty() ) {
       el.appendChild( fakeElement( dd ) );
+    }
 
     el.setTagName( "span" );
     el.setAttribute( "class", "xdxf_ex_markd" );
@@ -207,22 +218,25 @@ string convert( string const & in,
 
   nodes = dd.elementsByTagName( "k" ); // Key
 
-  if ( headword )
+  if ( headword ) {
     headword->clear();
+  }
 
   while ( nodes.size() ) {
     QDomElement el = nodes.at( 0 ).toElement();
 
-    if ( el.text().isEmpty() && el.childNodes().isEmpty() )
+    if ( el.text().isEmpty() && el.childNodes().isEmpty() ) {
       el.appendChild( fakeElement( dd ) );
+    }
 
     if ( type == STARDICT ) {
       el.setTagName( "span" );
       el.setAttribute( "class", "xdxf_k" );
     }
     else {
-      if ( headword && headword->isEmpty() )
+      if ( headword && headword->isEmpty() ) {
         *headword = el.text();
+      }
 
       el.setTagName( "div" );
       el.setAttribute( "class", "xdxf_headwords" );
@@ -234,11 +248,13 @@ string convert( string const & in,
         el.setAttribute( "lang", lang );
 
         quint32 langID = Xdxf::getLanguageId( lang );
-        if ( langID )
+        if ( langID ) {
           isLanguageRtl = LangCoder::isLanguageRTL( langID );
+        }
       }
-      if ( isLanguageRtl != dictPtr->isToLanguageRTL() )
+      if ( isLanguageRtl != dictPtr->isToLanguageRTL() ) {
         el.setAttribute( "dir", isLanguageRtl ? "rtl" : "ltr" );
+      }
     }
   }
 
@@ -260,8 +276,9 @@ string convert( string const & in,
         nestingCount++;
         nestingNode = nestingNode.parentNode().toElement();
       }
-      if ( nestingCount > maxNestingDepth )
+      if ( nestingCount > maxNestingDepth ) {
         maxNestingDepth = nestingCount;
+      }
     }
     // 2. in this loop we go layer-by-layer through all <def> and insert proper numbers according to its structure
     for ( int j = maxNestingDepth; j > 0; j-- ) // j symbolizes special depth to be processed at this iteration
@@ -285,20 +302,26 @@ string convert( string const & in,
             numberText = numberText.setNum( siblingCount ) + ". ";
           }
           else if ( maxNestingDepth == 2 ) {
-            if ( nestingDepth == 1 )
+            if ( nestingDepth == 1 ) {
               numberText = numberText.setNum( siblingCount ) + ". ";
-            if ( nestingDepth == 2 )
+            }
+            if ( nestingDepth == 2 ) {
               numberText = numberText.setNum( siblingCount ) + ") ";
+            }
           }
           else {
-            if ( nestingDepth == 1 )
+            if ( nestingDepth == 1 ) {
               numberText = QString::fromStdString( convertToRoman( siblingCount, 0 ) + ". " );
-            if ( nestingDepth == 2 )
+            }
+            if ( nestingDepth == 2 ) {
               numberText = numberText.setNum( siblingCount ) + ". ";
-            if ( nestingDepth == 3 )
+            }
+            if ( nestingDepth == 3 ) {
               numberText = numberText.setNum( siblingCount ) + ") ";
-            if ( nestingDepth == 4 )
+            }
+            if ( nestingDepth == 4 ) {
               numberText = QString::fromStdString( convertToRoman( siblingCount, 1 ) + ") " );
+            }
           }
           QDomElement numberNode = dd.createElement( "span" );
           numberNode.setAttribute( "class", "xdxf_num" );
@@ -314,8 +337,9 @@ string convert( string const & in,
             el.insertAfter( cmtNode, el.firstChild() );
           }
         }
-        else if ( nestingDepth < j ) // if it goes one level up @siblingCount needs to be reset
+        else if ( nestingDepth < j ) { // if it goes one level up @siblingCount needs to be reset
           siblingCount = 0;
+        }
       }
     }
     // we finally change all <def> tags into 'xdxf_def' <span>s
@@ -331,11 +355,13 @@ string convert( string const & in,
         el.setAttribute( "lang", lang );
 
         quint32 langID = Xdxf::getLanguageId( lang );
-        if ( langID )
+        if ( langID ) {
           isLanguageRtl = LangCoder::isLanguageRTL( langID );
+        }
       }
-      if ( isLanguageRtl != dictPtr->isToLanguageRTL() )
+      if ( isLanguageRtl != dictPtr->isToLanguageRTL() ) {
         el.setAttribute( "dir", isLanguageRtl ? "rtl" : "ltr" );
+      }
     }
   }
 
@@ -344,8 +370,9 @@ string convert( string const & in,
   while ( nodes.size() ) {
     QDomElement el = nodes.at( 0 ).toElement();
 
-    if ( el.text().isEmpty() && el.childNodes().isEmpty() )
+    if ( el.text().isEmpty() && el.childNodes().isEmpty() ) {
       el.appendChild( fakeElement( dd ) );
+    }
 
     el.setTagName( "span" );
     el.setAttribute( "class", "xdxf_opt" );
@@ -356,8 +383,9 @@ string convert( string const & in,
   while ( nodes.size() ) {
     QDomElement el = nodes.at( 0 ).toElement();
 
-    if ( el.text().isEmpty() && el.childNodes().isEmpty() )
+    if ( el.text().isEmpty() && el.childNodes().isEmpty() ) {
       el.appendChild( fakeElement( dd ) );
+    }
 
     el.setTagName( "a" );
     el.setAttribute( "href", QString( "bword:" ) + el.text() );
@@ -377,28 +405,33 @@ string convert( string const & in,
   while ( nodes.size() ) {
     QDomElement el = nodes.at( 0 ).toElement();
 
-    if ( el.text().isEmpty() && el.childNodes().isEmpty() )
+    if ( el.text().isEmpty() && el.childNodes().isEmpty() ) {
       el.appendChild( fakeElement( dd ) );
+    }
 
     QString ref = el.attribute( "href" );
-    if ( ref.isEmpty() )
+    if ( ref.isEmpty() ) {
       ref = el.text();
+    }
 
     el.setAttribute( "href", ref );
     el.setTagName( "a" );
   }
 
   // Abbreviations
-  if ( revisionNumber < 29 )
+  if ( revisionNumber < 29 ) {
     nodes = dd.elementsByTagName( "abr" );
-  else
+  }
+  else {
     nodes = dd.elementsByTagName( "abbr" );
+  }
 
   while ( nodes.size() ) {
     QDomElement el = nodes.at( 0 ).toElement();
 
-    if ( el.text().isEmpty() && el.childNodes().isEmpty() )
+    if ( el.text().isEmpty() && el.childNodes().isEmpty() ) {
       el.appendChild( fakeElement( dd ) );
+    }
 
     el.setTagName( "span" );
     el.setAttribute( "class", "xdxf_abbr" );
@@ -428,12 +461,14 @@ string convert( string const & in,
               title.push_back( 0x80 );
               title.push_back( 0x91 );
             }
-            else
+            else {
               title.push_back( *c );
+            }
           }
         }
-        else
+        else {
           title = i->second;
+        }
         el.setAttribute( "title", QString::fromStdU32String( Utf8::decode( title ) ) );
       }
     }
@@ -444,8 +479,9 @@ string convert( string const & in,
   while ( nodes.size() ) {
     QDomElement el = nodes.at( 0 ).toElement();
 
-    if ( el.text().isEmpty() && el.childNodes().isEmpty() )
+    if ( el.text().isEmpty() && el.childNodes().isEmpty() ) {
       el.appendChild( fakeElement( dd ) );
+    }
 
     el.setTagName( "span" );
     el.setAttribute( "class", "xdxf_dtrn" );
@@ -456,8 +492,9 @@ string convert( string const & in,
   while ( nodes.size() ) {
     QDomElement el = nodes.at( 0 ).toElement();
 
-    if ( el.text().isEmpty() && el.childNodes().isEmpty() )
+    if ( el.text().isEmpty() && el.childNodes().isEmpty() ) {
       el.appendChild( fakeElement( dd ) );
+    }
 
     el.setTagName( "span" );
 
@@ -465,8 +502,9 @@ string convert( string const & in,
       el.setAttribute( "style", "color:" + el.attribute( "c" ) );
       el.removeAttribute( "c" );
     }
-    else
+    else {
       el.setAttribute( "style", "color:blue" );
+    }
   }
 
   nodes = dd.elementsByTagName( "co" ); // Editorial comment
@@ -474,14 +512,17 @@ string convert( string const & in,
   while ( nodes.size() ) {
     QDomElement el = nodes.at( 0 ).toElement();
 
-    if ( el.text().isEmpty() && el.childNodes().isEmpty() )
+    if ( el.text().isEmpty() && el.childNodes().isEmpty() ) {
       el.appendChild( fakeElement( dd ) );
+    }
 
     el.setTagName( "span" );
-    if ( isLogicalFormat )
+    if ( isLogicalFormat ) {
       el.setAttribute( "class", "xdxf_co" );
-    else
+    }
+    else {
       el.setAttribute( "class", "xdxf_co_old" );
+    }
   }
 
   /* grammar information */
@@ -489,40 +530,49 @@ string convert( string const & in,
   while ( nodes.size() ) {
     QDomElement el = nodes.at( 0 ).toElement();
 
-    if ( el.text().isEmpty() && el.childNodes().isEmpty() )
+    if ( el.text().isEmpty() && el.childNodes().isEmpty() ) {
       el.appendChild( fakeElement( dd ) );
+    }
 
     el.setTagName( "span" );
-    if ( isLogicalFormat )
+    if ( isLogicalFormat ) {
       el.setAttribute( "class", "xdxf_gr" );
-    else
+    }
+    else {
       el.setAttribute( "class", "xdxf_gr_old" );
+    }
   }
   nodes = dd.elementsByTagName( "pos" ); // deprecated grammar tag
   while ( nodes.size() ) {
     QDomElement el = nodes.at( 0 ).toElement();
 
-    if ( el.text().isEmpty() && el.childNodes().isEmpty() )
+    if ( el.text().isEmpty() && el.childNodes().isEmpty() ) {
       el.appendChild( fakeElement( dd ) );
+    }
 
     el.setTagName( "span" );
-    if ( isLogicalFormat )
+    if ( isLogicalFormat ) {
       el.setAttribute( "class", "xdxf_gr" );
-    else
+    }
+    else {
       el.setAttribute( "class", "xdxf_gr_old" );
+    }
   }
   nodes = dd.elementsByTagName( "tense" ); // deprecated grammar tag
   while ( nodes.size() ) {
     QDomElement el = nodes.at( 0 ).toElement();
 
-    if ( el.text().isEmpty() && el.childNodes().isEmpty() )
+    if ( el.text().isEmpty() && el.childNodes().isEmpty() ) {
       el.appendChild( fakeElement( dd ) );
+    }
 
     el.setTagName( "span" );
-    if ( isLogicalFormat )
+    if ( isLogicalFormat ) {
       el.setAttribute( "class", "xdxf_gr" );
-    else
+    }
+    else {
       el.setAttribute( "class", "xdxf_gr_old" );
+    }
   }
   /* end of grammar generation */
 
@@ -531,14 +581,17 @@ string convert( string const & in,
   while ( nodes.size() ) {
     QDomElement el = nodes.at( 0 ).toElement();
 
-    if ( el.text().isEmpty() && el.childNodes().isEmpty() )
+    if ( el.text().isEmpty() && el.childNodes().isEmpty() ) {
       el.appendChild( fakeElement( dd ) );
+    }
 
     el.setTagName( "span" );
-    if ( isLogicalFormat )
+    if ( isLogicalFormat ) {
       el.setAttribute( "class", "xdxf_tr" );
-    else
+    }
+    else {
       el.setAttribute( "class", "xdxf_tr_old" );
+    }
   }
 
   // Ensure that ArticleNetworkAccessManager can deal with XDXF images.
@@ -550,8 +603,9 @@ string convert( string const & in,
   for ( int i = 0; i < nodes.size(); i++ ) {
     QDomElement el = nodes.at( i ).toElement();
 
-    if ( el.text().isEmpty() && el.childNodes().isEmpty() )
+    if ( el.text().isEmpty() && el.childNodes().isEmpty() ) {
       el.appendChild( fakeElement( dd ) );
+    }
 
     if ( el.hasAttribute( "src" ) ) {
       fixLink( el, dictPtr->getId(), "src" );
@@ -571,8 +625,9 @@ string convert( string const & in,
   while ( nodes.size() ) {
     QDomElement el = nodes.at( 0 ).toElement();
 
-    if ( el.text().isEmpty() && el.childNodes().isEmpty() )
+    if ( el.text().isEmpty() && el.childNodes().isEmpty() ) {
       el.appendChild( fakeElement( dd ) );
+    }
 
     //    if( type == XDXF && dictPtr != NULL && !el.hasAttribute( "start" ) )
     if ( dictPtr != NULL && !el.hasAttribute( "start" ) ) {

--- a/src/dict/zim.cc
+++ b/src/dict/zim.cc
@@ -219,9 +219,10 @@ public:
     if ( metadata_enable_fts.has_value() ) {
       can_FTS = fts.enabled && metadata_enable_fts.value();
     }
-    else
+    else {
       can_FTS = fts.enabled && !fts.disabledTypes.contains( "ZIM", Qt::CaseInsensitive )
         && ( fts.maxDictionarySize == 0 || getArticleCount() <= fts.maxDictionarySize );
+    }
   }
 
 protected:
@@ -264,8 +265,9 @@ ZimDictionary::ZimDictionary( string const & id, string const & indexFile, vecto
 
 void ZimDictionary::loadIcon() noexcept
 {
-  if ( dictionaryIconLoaded )
+  if ( dictionaryIconLoaded ) {
     return;
+  }
 
   // Try to load Original GD's user provided icon
   QString fileName = QDir::fromNativeSeparators( getDictionaryFilenames()[ 0 ].c_str() );
@@ -304,8 +306,9 @@ quint32 ZimDictionary::loadArticle( quint32 address, string & articleText, bool 
     QMutexLocker _( &zimMutex );
     ret = readArticle( df, address, articleText );
   }
-  if ( !rawText )
+  if ( !rawText ) {
     articleText = convert( articleText );
+  }
 
   return ret;
 }
@@ -386,8 +389,9 @@ string ZimDictionary::convert( const string & in )
 
     QStringList list = match.capturedTexts();
     // Add empty strings for compatibility with regex behaviour
-    for ( int i = list.size(); i < 5; i++ )
+    for ( int i = list.size(); i < 5; i++ ) {
       list.append( QString() );
+    }
 
     QString formatTag;
     QString tag = list[ 3 ]; // a url, ex: Precambrian_Chaotian.html
@@ -433,8 +437,9 @@ string ZimDictionary::convert( const string & in )
 
     QStringList list = match.capturedTexts();
     // Add empty strings for compatibility with regex behaviour
-    for ( int i = match.lastCapturedIndex() + 1; i < 3; i++ )
+    for ( int i = match.lastCapturedIndex() + 1; i < 3; i++ ) {
       list.append( QString() );
+    }
 
     QString tag = list[ 2 ];
     tag
@@ -460,16 +465,18 @@ string ZimDictionary::convert( const string & in )
 
 void ZimDictionary::loadResource( std::string & resourceName, string & data )
 {
-  if ( resourceName.empty() )
+  if ( resourceName.empty() ) {
     return;
+  }
   QMutexLocker _( &zimMutex );
   readArticleByPath( df, resourceName, data );
 }
 
 QString const & ZimDictionary::getDescription()
 {
-  if ( !dictionaryDescription.isEmpty() )
+  if ( !dictionaryDescription.isEmpty() ) {
     return dictionaryDescription;
+  }
 
   dictionaryDescription = QString::fromStdString( df.getMetadata( "Description" ) );
   return dictionaryDescription;
@@ -478,14 +485,17 @@ QString const & ZimDictionary::getDescription()
 void ZimDictionary::makeFTSIndex( QAtomicInt & isCancelled )
 {
   if ( !( Dictionary::needToRebuildIndex( getDictionaryFilenames(), ftsIdxName )
-          || FtsHelpers::ftsIndexIsOldOrBad( this ) ) )
+          || FtsHelpers::ftsIndexIsOldOrBad( this ) ) ) {
     FTS_index_completed.ref();
+  }
 
-  if ( haveFTSIndex() )
+  if ( haveFTSIndex() ) {
     return;
+  }
 
-  if ( !ensureInitDone().empty() )
+  if ( !ensureInitDone().empty() ) {
     return;
+  }
 
   gdDebug( "Zim: Building the full-text index for dictionary: %s\n", getName().c_str() );
   try {
@@ -585,8 +595,9 @@ void ZimArticleRequest::run()
                                    // by only allowing them to appear once.
 
   wstring wordCaseFolded = Folding::applySimpleCaseOnly( word );
-  if ( ignoreDiacritics )
+  if ( ignoreDiacritics ) {
     wordCaseFolded = Folding::applyDiacriticsOnly( wordCaseFolded );
+  }
 
   for ( auto & x : chain ) {
     if ( Utils::AtomicInt::loadAcquire( isCancelled ) ) {
@@ -607,11 +618,13 @@ void ZimArticleRequest::run()
     catch ( ... ) {
     }
 
-    if ( articleNumber == 0xFFFFFFFF )
+    if ( articleNumber == 0xFFFFFFFF ) {
       continue; // No article loaded
+    }
 
-    if ( articlesIncluded.find( articleNumber ) != articlesIncluded.end() )
+    if ( articlesIncluded.find( articleNumber ) != articlesIncluded.end() ) {
       continue; // We already have this article in the body.
+    }
 
     // Ok. Now, does it go to main articles, or to alternate ones? We list
     // main ones first, and alternates after.
@@ -619,8 +632,9 @@ void ZimArticleRequest::run()
     // We do the case-folded comparison here.
 
     wstring headwordStripped = Folding::applySimpleCaseOnly( headword );
-    if ( ignoreDiacritics )
+    if ( ignoreDiacritics ) {
       headwordStripped = Folding::applyDiacriticsOnly( headwordStripped );
+    }
 
     multimap< wstring, pair< string, string > > & mapToUse =
       ( wordCaseFolded == headwordStripped ) ? mainArticles : alternateArticles;
@@ -725,8 +739,9 @@ void ZimResourceRequest::run()
   try {
     string resource;
     dict.loadResource( resourceName, resource );
-    if ( resource.empty() )
+    if ( resource.empty() ) {
       throw File::Ex();
+    }
 
     if ( Filetype::isNameOfCSS( resourceName ) ) {
       QString css = QString::fromUtf8( resource.data(), resource.size() );
@@ -824,10 +839,12 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
         idxHeader.descriptionPtr = 0xFFFFFFFF;
 
         auto lang = df.getMetadata( "Language" );
-        if ( lang.size() == 2 )
+        if ( lang.size() == 2 ) {
           idxHeader.langFrom = LangCoder::code2toInt( lang.c_str() );
-        else if ( lang.size() == 3 )
+        }
+        else if ( lang.size() == 3 ) {
           idxHeader.langFrom = LangCoder::findIdForLanguageCode3( lang.c_str() );
+        }
         idxHeader.langTo = idxHeader.langFrom;
         // We write a dummy header first. At the end of the process the header
         // will be rewritten with the right values.

--- a/src/dict/zipsounds.cc
+++ b/src/dict/zipsounds.cc
@@ -80,16 +80,19 @@ wstring stripExtension( string const & str )
 
   if ( Filetype::isNameOfSound( str ) ) {
     wstring::size_type pos = name.rfind( L'.' );
-    if ( pos != wstring::npos )
+    if ( pos != wstring::npos ) {
       name.erase( pos );
+    }
 
     // Strip spaces at the end of name
     string::size_type n = name.length();
-    while ( n && name.at( n - 1 ) == L' ' )
+    while ( n && name.at( n - 1 ) == L' ' ) {
       n--;
+    }
 
-    if ( n != name.length() )
+    if ( n != name.length() ) {
       name.erase( n );
+    }
   }
   return name;
 }
@@ -185,12 +188,14 @@ sptr< Dictionary::DataRequest > ZipSoundsDictionary::getArticle( wstring const &
                                     // by only allowing them to appear once.
 
   wstring wordCaseFolded = Folding::applySimpleCaseOnly( word );
-  if ( ignoreDiacritics )
+  if ( ignoreDiacritics ) {
     wordCaseFolded = Folding::applyDiacriticsOnly( wordCaseFolded );
+  }
 
   for ( auto & x : chain ) {
-    if ( articlesIncluded.find( x.articleOffset ) != articlesIncluded.end() )
+    if ( articlesIncluded.find( x.articleOffset ) != articlesIncluded.end() ) {
       continue; // We already have this article in the body.
+    }
 
     // Ok. Now, does it go to main articles, or to alternate ones? We list
     // main ones first, and alternates after.
@@ -198,8 +203,9 @@ sptr< Dictionary::DataRequest > ZipSoundsDictionary::getArticle( wstring const &
     // We do the case-folded comparison here.
 
     wstring headwordStripped = Folding::applySimpleCaseOnly( x.word );
-    if ( ignoreDiacritics )
+    if ( ignoreDiacritics ) {
       headwordStripped = Folding::applyDiacriticsOnly( headwordStripped );
+    }
 
     multimap< wstring, uint32_t > & mapToUse =
       ( wordCaseFolded == headwordStripped ) ? mainArticles : alternateArticles;
@@ -209,8 +215,9 @@ sptr< Dictionary::DataRequest > ZipSoundsDictionary::getArticle( wstring const &
     articlesIncluded.insert( x.articleOffset );
   }
 
-  if ( mainArticles.empty() && alternateArticles.empty() )
+  if ( mainArticles.empty() && alternateArticles.empty() ) {
     return std::make_shared< Dictionary::DataRequestInstant >( false ); // No such word
+  }
 
   string result;
 
@@ -321,8 +328,9 @@ sptr< Dictionary::DataRequest > ZipSoundsDictionary::getResource( string const &
 
   vector< WordArticleLink > chain = findArticles( strippedName );
 
-  if ( chain.empty() )
+  if ( chain.empty() ) {
     return std::make_shared< Dictionary::DataRequestInstant >( false ); // No such resource
+  }
 
   // Find sound
 
@@ -340,22 +348,25 @@ sptr< Dictionary::DataRequest > ZipSoundsDictionary::getResource( string const &
 
     memcpy( &dataOffset, nameBlock, sizeof( uint32_t ) );
 
-    if ( name.compare( fileName ) == 0 )
+    if ( name.compare( fileName ) == 0 ) {
       break;
+    }
   }
 
   sptr< Dictionary::DataRequestInstant > dr = std::make_shared< Dictionary::DataRequestInstant >( true );
 
-  if ( zipsFile.loadFile( dataOffset, dr->getData() ) )
+  if ( zipsFile.loadFile( dataOffset, dr->getData() ) ) {
     return dr;
+  }
 
   return std::make_shared< Dictionary::DataRequestInstant >( false );
 }
 
 void ZipSoundsDictionary::loadIcon() noexcept
 {
-  if ( dictionaryIconLoaded )
+  if ( dictionaryIconLoaded ) {
     return;
+  }
 
   QString fileName = QDir::fromNativeSeparators( getDictionaryFilenames()[ 0 ].c_str() );
 
@@ -382,8 +393,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
   for ( const auto & fileName : fileNames ) {
     /// Only allow .zips extension
-    if ( !Utils::endsWithIgnoreCase( fileName, ".zips" ) )
+    if ( !Utils::endsWithIgnoreCase( fileName, ".zips" ) ) {
       continue;
+    }
 
     try {
       vector< string > dictFiles( 1, fileName );
@@ -408,8 +420,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
         quint32 namesCount = 0;
 
         IndexedZip zipFile;
-        if ( zipFile.openZipFile( QDir::fromNativeSeparators( fileName.c_str() ) ) )
+        if ( zipFile.openZipFile( QDir::fromNativeSeparators( fileName.c_str() ) ) ) {
           zipFile.indexFile( zipFileNames, &namesCount );
+        }
 
         if ( !zipFileNames.empty() ) {
           for ( auto & zipFileName : zipFileNames ) {
@@ -426,8 +439,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
               // Remove extension for sound files (like in sound dirs)
 
               wstring word = stripExtension( link.word );
-              if ( !word.empty() )
+              if ( !word.empty() ) {
                 names.addWord( word, offset );
+              }
             }
           }
 

--- a/src/dictionary_group.cc
+++ b/src/dictionary_group.cc
@@ -20,14 +20,16 @@ const std::vector< sptr< Dictionary::Class > > * DictionaryGroup::getActiveDicti
   std::vector< sptr< Dictionary::Class > > const * activeDicts = nullptr;
 
   if ( !groups.empty() ) {
-    for ( const auto & group : groups )
+    for ( const auto & group : groups ) {
       if ( group.id == currentGroup ) {
         activeDicts = &( group.dictionaries );
         break;
       }
+    }
   }
-  else
+  else {
     activeDicts = &allDictionaries;
+  }
 
   return activeDicts;
 }

--- a/src/externalaudioplayer.cc
+++ b/src/externalaudioplayer.cc
@@ -41,8 +41,9 @@ QString ExternalAudioPlayer::play( const char * data, int size )
     return e.what();
   }
 
-  if ( exitingViewer )
+  if ( exitingViewer ) {
     return QString(); // Will start later.
+  }
   return startViewer();
 }
 
@@ -58,8 +59,9 @@ void ExternalAudioPlayer::stop()
     //      while synchronously waiting for the external process to exit.
     exitingViewer = viewer.release();
   }
-  else // viewer is either not started or already stopped -> simply destroy it.
+  else { // viewer is either not started or already stopped -> simply destroy it.
     viewer.reset();
+  }
 }
 
 void ExternalAudioPlayer::onViewerDestroyed( QObject * destroyedViewer )
@@ -68,12 +70,14 @@ void ExternalAudioPlayer::onViewerDestroyed( QObject * destroyedViewer )
     exitingViewer = 0;
     if ( viewer ) {
       QString errorMessage = startViewer();
-      if ( !errorMessage.isEmpty() )
+      if ( !errorMessage.isEmpty() ) {
         emit error( errorMessage );
+      }
     }
   }
-  else if ( viewer.get() == destroyedViewer )
+  else if ( viewer.get() == destroyedViewer ) {
     viewer.reset( nullptr ); // viewer finished and died -> reset
+  }
 }
 
 QString ExternalAudioPlayer::startViewer()

--- a/src/externalviewer.cc
+++ b/src/externalviewer.cc
@@ -13,8 +13,9 @@ ExternalViewer::ExternalViewer(
   viewer( this ),
   viewerCmdLine( viewerCmdLine_ )
 {
-  if ( !tempFile.open() || tempFile.write( data, size ) != size )
+  if ( !tempFile.open() || tempFile.write( data, size ) != size ) {
     throw exCantCreateTempFile();
+  }
 
   tempFileName = tempFile.fileName(); // For some reason it loses it after it was closed()
 
@@ -49,8 +50,9 @@ void ExternalViewer::start()
 
 bool ExternalViewer::stop()
 {
-  if ( viewer.state() == QProcess::NotRunning )
+  if ( viewer.state() == QProcess::NotRunning ) {
     return true;
+  }
   viewer.terminate();
   QTimer::singleShot( 1000, &viewer, &QProcess::kill ); // In case terminate() fails.
   return false;
@@ -59,16 +61,18 @@ bool ExternalViewer::stop()
 void ExternalViewer::stopSynchronously()
 {
   // This implementation comes straight from QProcess::~QProcess().
-  if ( viewer.state() == QProcess::NotRunning )
+  if ( viewer.state() == QProcess::NotRunning ) {
     return;
+  }
   viewer.kill();
   viewer.waitForFinished();
 }
 
 void stopAndDestroySynchronously( ExternalViewer * viewer )
 {
-  if ( !viewer )
+  if ( !viewer ) {
     return;
+  }
   viewer->stopSynchronously();
   delete viewer;
 }

--- a/src/ftshelpers.cc
+++ b/src/ftshelpers.cc
@@ -30,7 +30,7 @@ bool ftsIndexIsOldOrBad( BtreeIndexing::BtreeDictionary * dict )
     auto docid    = db.get_lastdocid();
     auto document = db.get_document( docid );
 
-    string const lastDoc   = document.get_data();
+    string const lastDoc = document.get_data();
     return lastDoc != finish_mark;
     //use a special document to mark the end of the index.
   }
@@ -50,12 +50,14 @@ void makeFTSIndex( BtreeIndexing::BtreeDictionary * dict, QAtomicInt & isCancell
   QMutexLocker const _( &dict->getFtsMutex() );
 
   //check the index again.
-  if ( dict->haveFTSIndex() )
+  if ( dict->haveFTSIndex() ) {
     return;
+  }
 
   try {
-    if ( Utils::AtomicInt::loadAcquire( isCancelled ) )
+    if ( Utils::AtomicInt::loadAcquire( isCancelled ) ) {
       throw exUserAbort();
+    }
 
     // Open the database for update, creating a new database if necessary.
     Xapian::WritableDatabase db( dict->ftsIndexName() + "_temp", Xapian::DB_CREATE_OR_OPEN );
@@ -73,8 +75,9 @@ void makeFTSIndex( BtreeIndexing::BtreeDictionary * dict, QAtomicInt & isCancell
 
     dict->findArticleLinks( nullptr, &setOfOffsets, nullptr, &isCancelled );
 
-    if ( Utils::AtomicInt::loadAcquire( isCancelled ) )
+    if ( Utils::AtomicInt::loadAcquire( isCancelled ) ) {
       throw exUserAbort();
+    }
 
     QList< uint32_t > offsets;
     offsets.resize( setOfOffsets.size() );
@@ -88,8 +91,9 @@ void makeFTSIndex( BtreeIndexing::BtreeDictionary * dict, QAtomicInt & isCancell
     // Free memory
     setOfOffsets.clear();
 
-    if ( Utils::AtomicInt::loadAcquire( isCancelled ) )
+    if ( Utils::AtomicInt::loadAcquire( isCancelled ) ) {
       throw exUserAbort();
+    }
 
     // incremental build the index.
     // get the last address.
@@ -214,8 +218,9 @@ void FTSResultsRequest::run()
       for ( Xapian::MSetIterator i = matches.begin(); i != matches.end(); ++i ) {
         qDebug() << i.get_rank() + 1 << ": " << i.get_weight() << " docid=" << *i << " ["
                  << i.get_document().get_data().c_str() << "]";
-        if ( i.get_document().get_data() == finish_mark )
+        if ( i.get_document().get_data() == finish_mark ) {
           continue;
+        }
         offsetsForHeadwords.append( atoi( i.get_document().get_data().c_str() ) );
       }
 

--- a/src/fulltextsearch.cc
+++ b/src/fulltextsearch.cc
@@ -55,16 +55,18 @@ void Indexing::timeout()
 {
   QString indexingDicts;
   for ( const auto & dictionary : dictionaries ) {
-    if ( Utils::AtomicInt::loadAcquire( isCancelled ) )
+    if ( Utils::AtomicInt::loadAcquire( isCancelled ) ) {
       break;
+    }
     //Finished, clear the msg.
     if ( dictionary->haveFTSIndex() ) {
       continue;
     }
     auto newProgress = dictionary->getIndexingFtsProgress();
     if ( newProgress > 0 && newProgress < 100 ) {
-      if ( !indexingDicts.isEmpty() )
+      if ( !indexingDicts.isEmpty() ) {
         indexingDicts.append( "," );
+      }
       indexingDicts.append(
         QString( "%1......%%2" ).arg( QString::fromStdString( dictionary->getName() ) ).arg( newProgress ) );
     }
@@ -83,12 +85,14 @@ FtsIndexing::FtsIndexing( std::vector< sptr< Dictionary::Class > > const & dicts
 
 void FtsIndexing::doIndexing()
 {
-  if ( started )
+  if ( started ) {
     stopIndexing();
+  }
 
   if ( !started ) {
-    while ( Utils::AtomicInt::loadAcquire( isCancelled ) )
+    while ( Utils::AtomicInt::loadAcquire( isCancelled ) ) {
       isCancelled.deref();
+    }
 
     Indexing * idx = new Indexing( isCancelled, dictionaries, indexingExited );
 
@@ -103,8 +107,9 @@ void FtsIndexing::doIndexing()
 void FtsIndexing::stopIndexing()
 {
   if ( started ) {
-    if ( !Utils::AtomicInt::loadAcquire( isCancelled ) )
+    if ( !Utils::AtomicInt::loadAcquire( isCancelled ) ) {
       isCancelled.ref();
+    }
 
     indexingExited.acquire();
     started = false;
@@ -132,8 +137,9 @@ void addSortedHeadwords( QList< FtsHeadword > & base_list, QList< FtsHeadword > 
 {
   QList< FtsHeadword > list;
 
-  if ( add_list.isEmpty() )
+  if ( add_list.isEmpty() ) {
     return;
+  }
 
   if ( base_list.isEmpty() ) {
     base_list = add_list;
@@ -171,8 +177,9 @@ void addSortedHeadwords( QList< FtsHeadword > & base_list, QList< FtsHeadword > 
       for ( QStringList::const_iterator itr = add_it->foundHiliteRegExps.constBegin();
             itr != add_it->foundHiliteRegExps.constEnd();
             ++itr ) {
-        if ( !base_it->foundHiliteRegExps.contains( *itr ) )
+        if ( !base_it->foundHiliteRegExps.contains( *itr ) ) {
           base_it->foundHiliteRegExps.append( *itr );
+        }
       }
       ++add_it;
     }
@@ -205,8 +212,9 @@ FullTextSearchDialog::FullTextSearchDialog( QWidget * parent,
 
   setWindowTitle( tr( "Full-text search" ) );
 
-  if ( cfg.preferences.fts.dialogGeometry.size() > 0 )
+  if ( cfg.preferences.fts.dialogGeometry.size() > 0 ) {
     restoreGeometry( cfg.preferences.fts.dialogGeometry );
+  }
 
   setNewIndexingName( ftsIdx.nowIndexingName() );
 
@@ -251,8 +259,9 @@ FullTextSearchDialog::FullTextSearchDialog( QWidget * parent,
   ui.headwordsView->installEventFilter( this );
 
   delegate = new WordListItemDelegate( ui.headwordsView->itemDelegate() );
-  if ( delegate )
+  if ( delegate ) {
     ui.headwordsView->setItemDelegate( delegate );
+  }
 
   ui.searchLine->selectAll();
 }
@@ -264,19 +273,24 @@ void FullTextSearchDialog::setSearchText( const QString & text )
 
 FullTextSearchDialog::~FullTextSearchDialog()
 {
-  if ( delegate )
+  if ( delegate ) {
     delegate->deleteLater();
+  }
 }
 
 void FullTextSearchDialog::stopSearch()
 {
   if ( !searchReqs.empty() ) {
-    for ( std::list< sptr< Dictionary::DataRequest > >::iterator it = searchReqs.begin(); it != searchReqs.end(); ++it )
-      if ( !( *it )->isFinished() )
+    for ( std::list< sptr< Dictionary::DataRequest > >::iterator it = searchReqs.begin(); it != searchReqs.end();
+          ++it ) {
+      if ( !( *it )->isFinished() ) {
         ( *it )->cancel();
+      }
+    }
 
-    while ( searchReqs.size() )
+    while ( searchReqs.size() ) {
       QApplication::processEvents();
+    }
   }
 }
 
@@ -286,10 +300,12 @@ void FullTextSearchDialog::showDictNumbers()
 
   unsigned ready = 0, toIndex = 0;
   for ( unsigned x = 0; x < activeDicts.size(); x++ ) {
-    if ( activeDicts.at( x )->haveFTSIndex() )
+    if ( activeDicts.at( x )->haveFTSIndex() ) {
       ready++;
-    else
+    }
+    else {
       toIndex++;
+    }
   }
 
   ui.readyDicts->setText( QString::number( ready ) );
@@ -402,14 +418,16 @@ void FullTextSearchDialog::searchReqFinished()
       GD_DPRINTF( "erase done..\n" );
       continue;
     }
-    else
+    else {
       break;
+    }
   }
 
   if ( !allHeadwords.isEmpty() ) {
     model->addResults( QModelIndex(), allHeadwords );
-    if ( results.size() > matchedCount )
+    if ( results.size() > matchedCount ) {
       ui.articlesFoundLabel->setText( tr( "Articles found: " ) + QString::number( results.size() ) );
+    }
   }
 
   if ( searchReqs.empty() ) {
@@ -427,8 +445,9 @@ void FullTextSearchDialog::matchCount( int _matchCount )
 
 void FullTextSearchDialog::reject()
 {
-  if ( !searchReqs.empty() )
+  if ( !searchReqs.empty() ) {
     stopSearch();
+  }
   else {
     saveData();
     emit closeDialog();
@@ -459,11 +478,12 @@ void FullTextSearchDialog::updateDictionaries()
 
   Instances::Group const * activeGroup = 0;
 
-  for ( unsigned x = 0; x < groups.size(); ++x )
+  for ( unsigned x = 0; x < groups.size(); ++x ) {
     if ( groups[ x ].id == group ) {
       activeGroup = &groups[ x ];
       break;
     }
+  }
 
   // If we've found a group, use its dictionaries; otherwise, use the global
   // heap.
@@ -474,21 +494,27 @@ void FullTextSearchDialog::updateDictionaries()
   Config::Group const * grp = cfg.getGroup( group );
   Config::MutedDictionaries const * mutedDicts;
 
-  if ( group == Instances::Group::AllGroupId )
+  if ( group == Instances::Group::AllGroupId ) {
     mutedDicts = &cfg.mutedDictionaries;
-  else
+  }
+  else {
     mutedDicts = grp ? &grp->mutedDictionaries : 0;
+  }
 
   if ( mutedDicts && !mutedDicts->isEmpty() ) {
     activeDicts.reserve( groupDicts.size() );
-    for ( unsigned x = 0; x < groupDicts.size(); ++x )
-      if ( groupDicts[ x ]->canFTS() && !mutedDicts->contains( QString::fromStdString( groupDicts[ x ]->getId() ) ) )
+    for ( unsigned x = 0; x < groupDicts.size(); ++x ) {
+      if ( groupDicts[ x ]->canFTS() && !mutedDicts->contains( QString::fromStdString( groupDicts[ x ]->getId() ) ) ) {
         activeDicts.push_back( groupDicts[ x ] );
+      }
+    }
   }
   else {
-    for ( unsigned x = 0; x < groupDicts.size(); ++x )
-      if ( groupDicts[ x ]->canFTS() )
+    for ( unsigned x = 0; x < groupDicts.size(); ++x ) {
+      if ( groupDicts[ x ]->canFTS() ) {
         activeDicts.push_back( groupDicts[ x ] );
+      }
+    }
   }
 
   showDictNumbers();
@@ -515,24 +541,28 @@ int HeadwordsListModel::rowCount( QModelIndex const & ) const
 
 QVariant HeadwordsListModel::data( QModelIndex const & index, int role ) const
 {
-  if ( index.row() < 0 )
+  if ( index.row() < 0 ) {
     return QVariant();
+  }
 
   FtsHeadword const & head = headwords[ index.row() ];
 
-  if ( head.headword.isEmpty() )
+  if ( head.headword.isEmpty() ) {
     return QVariant();
+  }
 
   switch ( role ) {
     case Qt::ToolTipRole: {
       QString tt;
       for ( int x = 0; x < head.dictIDs.size(); x++ ) {
-        if ( x != 0 )
+        if ( x != 0 ) {
           tt += "<br>";
+        }
 
         int n = getDictIndex( head.dictIDs[ x ] );
-        if ( n != -1 )
+        if ( n != -1 ) {
           tt += QString::fromUtf8( dictionaries[ n ]->getName().c_str() );
+        }
       }
       return tt;
     }
@@ -577,8 +607,9 @@ int HeadwordsListModel::getDictIndex( QString const & id ) const
 {
   std::string dictID( id.toUtf8().data() );
   for ( unsigned x = 0; x < dictionaries.size(); x++ ) {
-    if ( dictionaries[ x ]->getId().compare( dictID ) == 0 )
+    if ( dictionaries[ x ]->getId().compare( dictID ) == 0 ) {
       return x;
+    }
   }
   return -1;
 }
@@ -588,13 +619,16 @@ QString FtsHeadword::trimQuotes( QString const & str ) const
   QString trimmed( str );
 
   int n = 0;
-  while ( str[ n ] == '\"' || str[ n ] == '\'' )
+  while ( str[ n ] == '\"' || str[ n ] == '\'' ) {
     n++;
-  if ( n )
+  }
+  if ( n ) {
     trimmed = trimmed.mid( n );
+  }
 
-  while ( trimmed.endsWith( '\"' ) || trimmed.endsWith( '\'' ) )
+  while ( trimmed.endsWith( '\"' ) || trimmed.endsWith( '\'' ) ) {
     trimmed.chop( 1 );
+  }
 
   return trimmed;
 }
@@ -605,13 +639,15 @@ bool FtsHeadword::operator<( FtsHeadword const & other ) const
   QString second = trimQuotes( other.headword );
 
   int result = first.localeAwareCompare( second );
-  if ( result )
+  if ( result ) {
     return result < 0;
+  }
 
   // Headwords without quotes are equal
 
-  if ( first.size() != headword.size() || second.size() != other.headword.size() )
+  if ( first.size() != headword.size() || second.size() != other.headword.size() ) {
     return headword.localeAwareCompare( other.headword ) < 0;
+  }
 
   return false;
 }

--- a/src/headwordsmodel.cc
+++ b/src/headwordsmodel.cc
@@ -88,13 +88,15 @@ void HeadwordListModel::requestFinished()
       }
       else if ( ( *i )->matchesCount() ) {
         auto allmatches = ( *i )->getAllMatches();
-        for ( auto & match : allmatches )
+        for ( auto & match : allmatches ) {
           filterWords.append( QString::fromStdU32String( match.word ) );
+        }
       }
       queuedRequests.erase( i++ );
     }
-    else
+    else {
       ++i;
+    }
   }
 
   if ( queuedRequests.empty() ) {
@@ -115,11 +117,13 @@ int HeadwordListModel::wordCount() const
 
 QVariant HeadwordListModel::data( const QModelIndex & index, int role ) const
 {
-  if ( !index.isValid() )
+  if ( !index.isValid() ) {
     return {};
+  }
 
-  if ( index.row() >= totalSize || index.row() < 0 || index.row() >= words.size() )
+  if ( index.row() >= totalSize || index.row() < 0 || index.row() >= words.size() ) {
     return {};
+  }
 
   if ( role == Qt::DisplayRole ) {
     return words.at( index.row() );
@@ -129,15 +133,17 @@ QVariant HeadwordListModel::data( const QModelIndex & index, int role ) const
 
 bool HeadwordListModel::canFetchMore( const QModelIndex & parent ) const
 {
-  if ( parent.isValid() || filtering || finished )
+  if ( parent.isValid() || filtering || finished ) {
     return false;
+  }
   return ( words.size() < totalSize );
 }
 
 void HeadwordListModel::fetchMore( const QModelIndex & parent )
 {
-  if ( parent.isValid() || filtering || finished )
+  if ( parent.isValid() || filtering || finished ) {
     return;
+  }
 
   //arbitrary number
   if ( totalSize < HEADWORDS_MAX_LIMIT ) {
@@ -192,8 +198,9 @@ QSet< QString > HeadwordListModel::getRemainRows( int & nodeIndex )
 
   QSet< QString > filtered;
   for ( const auto & word : headword ) {
-    if ( !containWord( word ) )
+    if ( !containWord( word ) ) {
       filtered.insert( word );
+    }
   }
   return filtered;
 }

--- a/src/history.cc
+++ b/src/history.cc
@@ -16,8 +16,9 @@ History::History( unsigned size, unsigned maxItemLength_ ):
 {
   QFile file( Config::getHistoryFileName() );
 
-  if ( !file.open( QFile::ReadOnly | QIODevice::Text ) )
+  if ( !file.open( QFile::ReadOnly | QIODevice::Text ) ) {
     return; // No file -- no history
+  }
 
   QTextStream in( &file );
   while ( !in.atEnd() && items.size() <= maxSize ) {
@@ -47,8 +48,9 @@ History::Item History::getItem( int index )
 
 void History::addItem( Item const & item )
 {
-  if ( !enabled() )
+  if ( !enabled() ) {
     return;
+  }
 
   if ( item.word.isEmpty() || item.word.size() > maxItemLength ) {
     // The search looks bogus. Don't save it.
@@ -56,8 +58,9 @@ void History::addItem( Item const & item )
   }
 
   //from the normal operation ,there should be only one item in the history at a time.
-  if ( items.contains( item ) )
+  if ( items.contains( item ) ) {
     items.removeOne( item );
+  }
 
   items.push_front( item );
 
@@ -101,8 +104,9 @@ int History::size() const
 
 bool History::save()
 {
-  if ( !dirty )
+  if ( !dirty ) {
     return true;
+  }
 
   QSaveFile file( Config::getHistoryFileName() );
   if ( !file.open( QFile::WriteOnly | QIODevice::Text ) ) {

--- a/src/hotkeywrapper.cc
+++ b/src/hotkeywrapper.cc
@@ -68,8 +68,9 @@ void QHotkeyApplication::removeDataCommiter( DataCommitter & d )
 
 void QHotkeyApplication::hotkeyAppCommitData( QSessionManager & mgr )
 {
-  for ( int x = 0; x < dataCommitters.size(); ++x )
+  for ( int x = 0; x < dataCommitters.size(); ++x ) {
     dataCommitters[ x ]->commitData( mgr );
+  }
 }
 
 void QHotkeyApplication::hotkeyAppSaveState( QSessionManager & mgr )
@@ -79,14 +80,16 @@ void QHotkeyApplication::hotkeyAppSaveState( QSessionManager & mgr )
 
 void QHotkeyApplication::registerWrapper( HotkeyWrapper * wrapper )
 {
-  if ( wrapper && !hotkeyWrappers.contains( wrapper ) )
+  if ( wrapper && !hotkeyWrappers.contains( wrapper ) ) {
     hotkeyWrappers.append( wrapper );
+  }
 }
 
 void QHotkeyApplication::unregisterWrapper( HotkeyWrapper * wrapper )
 {
-  if ( wrapper && hotkeyWrappers.contains( wrapper ) )
+  if ( wrapper && hotkeyWrappers.contains( wrapper ) ) {
     hotkeyWrappers.removeAll( wrapper );
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -556,8 +559,8 @@ void HotkeyWrapper::init()
   lMetaCode = XKeysymToKeycode( display, XK_Super_L );
   rMetaCode = XKeysymToKeycode( display, XK_Super_R );
 
-  cCode = XKeysymToKeycode( display, XK_c );
-  insertCode = XKeysymToKeycode( display, XK_Insert );
+  cCode        = XKeysymToKeycode( display, XK_c );
+  insertCode   = XKeysymToKeycode( display, XK_Insert );
   kpInsertCode = XKeysymToKeycode( display, XK_KP_Insert );
 
   currentModifiers = 0;
@@ -576,8 +579,8 @@ void HotkeyWrapper::init()
   }
 
   recordRange->device_events.first = KeyPress;
-  recordRange->device_events.last = KeyRelease;
-  recordClientSpec = XRecordAllClients;
+  recordRange->device_events.last  = KeyRelease;
+  recordClientSpec                 = XRecordAllClients;
 
   recordContext = XRecordCreateContext( display, 0, &recordClientSpec, 1, &recordRange, 1 );
 
@@ -660,7 +663,7 @@ bool HotkeyWrapper::setGlobalKey( int key, int key2, Qt::KeyboardModifiers modif
   if ( !key )
     return false; // We don't monitor empty combinations
 
-  int vk = nativeKey( key );
+  int vk  = nativeKey( key );
   int vk2 = key2 ? nativeKey( key2 ) : 0;
 
   quint32 mod = 0;
@@ -718,7 +721,7 @@ public:
 
   X11GrabUngrabErrorHandler()
   {
-    error = false;
+    error                 = false;
     previousErrorHandler_ = XSetErrorHandler( grab_ungrab_error_handler );
   }
 

--- a/src/hotkeywrapper.hh
+++ b/src/hotkeywrapper.hh
@@ -83,11 +83,11 @@ protected slots:
 
   void waitKey2();
 
-  #ifndef Q_OS_MAC
+#ifndef Q_OS_MAC
 private slots:
 
   bool checkState( quint32 vk, quint32 mod );
-  #endif
+#endif
 
 private:
 
@@ -99,16 +99,16 @@ private:
   bool state2;
   HotkeyStruct state2waiter;
 
-  #ifdef Q_OS_WIN32
+#ifdef Q_OS_WIN32
 
-    #if ( QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 ) )
+  #if ( QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 ) )
   virtual bool winEvent( MSG * message, long * result );
-    #else
+  #else
   virtual bool winEvent( MSG * message, qintptr * result );
-    #endif
+  #endif
   HWND hwnd;
 
-  #elif defined( Q_OS_MAC )
+#elif defined( Q_OS_MAC )
 
 public:
   void activated( int hkId );
@@ -120,7 +120,7 @@ private:
   quint32 keyC;
   EventHandlerRef handlerRef;
 
-  #else
+#else
 
   static void recordEventCallback( XPointer, XRecordInterceptData * );
 
@@ -165,7 +165,7 @@ signals:
   /// Emitted from the thread
   void keyRecorded( quint32 vk, quint32 mod );
 
-  #endif
+#endif
 };
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/iframeschemehandler.cc
+++ b/src/iframeschemehandler.cc
@@ -37,10 +37,12 @@ void IframeSchemeHandler::requestStarted( QWebEngineUrlRequestJob * requestJob )
     QString articleString;
 
     QTextCodec * codec = QTextCodec::codecForUtfText( replyData, QTextCodec::codecForName( codecName.toUtf8() ) );
-    if ( codec )
+    if ( codec ) {
       articleString = codec->toUnicode( replyData );
-    else
+    }
+    else {
       articleString = QString::fromUtf8( replyData );
+    }
     // Handle reply data
     // 404 response may have response body.
     if ( reply->error() != QNetworkReply::NoError && articleString.isEmpty() ) {

--- a/src/instances.cc
+++ b/src/instances.cc
@@ -20,8 +20,9 @@ Group::Group( Config::Group const & cfgGroup,
   favoritesFolder( cfgGroup.favoritesFolder ),
   shortcut( cfgGroup.shortcut )
 {
-  if ( !cfgGroup.iconData.isEmpty() )
+  if ( !cfgGroup.iconData.isEmpty() ) {
     iconData = iconFromData( cfgGroup.iconData );
+  }
 
   QMap< string, sptr< Dictionary::Class > > groupDicts;
   QList< string > dictOrderList;
@@ -89,8 +90,9 @@ Config::Group Group::makeConfigGroup()
 
 QIcon Group::makeIcon() const
 {
-  if ( !iconData.isNull() )
+  if ( !iconData.isNull() ) {
     return iconData;
+  }
 
   QIcon i = icon.size() ? QIcon( ":/flags/" + icon ) : QIcon();
 
@@ -103,26 +105,31 @@ void Group::checkMutedDictionaries( Config::MutedDictionaries * mutedDictionarie
 
   for ( auto const & dict : dictionaries ) {
     auto dictId = QString::fromStdString( dict->getId() );
-    if ( mutedDictionaries->contains( dictId ) )
+    if ( mutedDictionaries->contains( dictId ) ) {
       temp.insert( dictId );
+    }
   }
   *mutedDictionaries = temp;
 }
 
 Group * Groups::findGroup( unsigned id )
 {
-  for ( unsigned x = 0; x < size(); ++x )
-    if ( operator[]( x ).id == id )
+  for ( unsigned x = 0; x < size(); ++x ) {
+    if ( operator[]( x ).id == id ) {
       return &( operator[]( x ) );
+    }
+  }
 
   return nullptr;
 }
 
 Group const * Groups::findGroup( unsigned id ) const
 {
-  for ( unsigned x = 0; x < size(); ++x )
-    if ( operator[]( x ).id == id )
+  for ( unsigned x = 0; x < size(); ++x ) {
+    if ( operator[]( x ).id == id ) {
       return &( operator[]( x ) );
+    }
+  }
 
   return nullptr;
 }
@@ -133,15 +140,18 @@ void complementDictionaryOrder( Group & group,
 {
   set< string, std::less<> > presentIds;
 
-  for ( unsigned x = group.dictionaries.size(); x--; )
+  for ( unsigned x = group.dictionaries.size(); x--; ) {
     presentIds.insert( group.dictionaries[ x ]->getId() );
+  }
 
-  for ( unsigned x = inactiveDictionaries.dictionaries.size(); x--; )
+  for ( unsigned x = inactiveDictionaries.dictionaries.size(); x--; ) {
     presentIds.insert( inactiveDictionaries.dictionaries[ x ]->getId() );
+  }
 
   for ( const auto & dict : dicts ) {
-    if ( presentIds.find( dict->getId() ) == presentIds.end() )
+    if ( presentIds.find( dict->getId() ) == presentIds.end() ) {
       group.dictionaries.push_back( dict );
+    }
   }
 }
 
@@ -151,18 +161,20 @@ void updateNames( Config::Group & group, vector< sptr< Dictionary::Class > > con
   for ( unsigned x = group.dictionaries.size(); x--; ) {
     std::string const id = group.dictionaries[ x ].id.toStdString();
 
-    for ( unsigned y = allDictionaries.size(); y--; )
+    for ( unsigned y = allDictionaries.size(); y--; ) {
       if ( allDictionaries[ y ]->getId() == id ) {
         group.dictionaries[ x ].name = QString::fromUtf8( allDictionaries[ y ]->getName().c_str() );
         break;
       }
+    }
   }
 }
 
 void updateNames( Config::Groups & groups, vector< sptr< Dictionary::Class > > const & allDictionaries )
 {
-  for ( auto & group : groups )
+  for ( auto & group : groups ) {
     updateNames( group, allDictionaries );
+  }
 }
 
 void updateNames( Config::Class & cfg, vector< sptr< Dictionary::Class > > const & allDictionaries )

--- a/src/keyboardstate.hh
+++ b/src/keyboardstate.hh
@@ -12,10 +12,10 @@ class KeyboardState
 public:
 
   enum Modifier {
-    Alt        = 1,
-    Ctrl       = 2,
-    Shift      = 4,
-    Win        = 8, // Ironically, Linux only, since it's no use under Windows
+    Alt   = 1,
+    Ctrl  = 2,
+    Shift = 4,
+    Win   = 8, // Ironically, Linux only, since it's no use under Windows
   };
 
   /// Returns true if all Modifiers present within the given mask are pressed

--- a/src/langcoder.cc
+++ b/src/langcoder.cc
@@ -205,8 +205,9 @@ QMap< QString, GDLangCode > LangCoder::LANG_CODE_MAP = {
 
 QString LangCoder::decode( quint32 _code )
 {
-  if ( auto code = intToCode2( _code ); code2Exists( code ) )
+  if ( auto code = intToCode2( _code ); code2Exists( code ) ) {
     return QString::fromStdString( LANG_CODE_MAP[ code ].lang );
+  }
 
   return {};
 }
@@ -217,8 +218,9 @@ bool LangCoder::code2Exists( const QString & _code )
 
 QString LangCoder::intToCode2( quint32 val )
 {
-  if ( !val || val == 0xFFffFFff )
+  if ( !val || val == 0xFFffFFff ) {
     return {};
+  }
 
   QByteArray ba;
   ba.append( val & 0xFF );
@@ -256,8 +258,9 @@ quint32 LangCoder::guessId( const QString & lang )
   QString lstr = lang.simplified().toLower();
 
   // too small to guess
-  if ( lstr.size() < 2 )
+  if ( lstr.size() < 2 ) {
     return 0;
+  }
 
   // check if it could be the whole language name
   if ( lstr.size() >= 3 ) {

--- a/src/language.cc
+++ b/src/language.cc
@@ -469,8 +469,9 @@ quint32 findBlgLangIDByEnglishName( gd::wstring const & lang )
 {
   QString enName = QString::fromStdU32String( lang );
   for ( const auto & idx : BabylonDb ) {
-    if ( QString::compare( idx.englishName, enName, Qt::CaseInsensitive ) == 0 )
+    if ( QString::compare( idx.englishName, enName, Qt::CaseInsensitive ) == 0 ) {
       return idx.id;
+    }
   }
   return 0;
 }
@@ -483,8 +484,9 @@ QString englishNameForId( Id id )
   }
   const auto i = Db::instance().getIso2ToLangData().find( LangCoder::intToCode2( id ) );
 
-  if ( i == Db::instance().getIso2ToLangData().end() )
+  if ( i == Db::instance().getIso2ToLangData().end() ) {
     return {};
+  }
 
   return i->english;
 }
@@ -497,8 +499,9 @@ QString localizedNameForId( Id id )
   }
   const auto i = Db::instance().getIso2ToLangData().find( LangCoder::intToCode2( id ) );
 
-  if ( i == Db::instance().getIso2ToLangData().end() )
+  if ( i == Db::instance().getIso2ToLangData().end() ) {
     return {};
+  }
 
   return i->localized;
 }
@@ -511,8 +514,9 @@ QString countryCodeForId( Id id )
   }
   const auto i = Db::instance().getIso2ToLangData().find( LangCoder::intToCode2( id ) );
 
-  if ( i == Db::instance().getIso2ToLangData().end() )
+  if ( i == Db::instance().getIso2ToLangData().end() ) {
     return {};
+  }
 
   return i->country;
 }
@@ -521,13 +525,15 @@ QString localizedStringForId( Id langId )
 {
   QString name = localizedNameForId( langId );
 
-  if ( name.isEmpty() )
+  if ( name.isEmpty() ) {
     return name;
+  }
 
   QString iconId = countryCodeForId( langId );
 
-  if ( iconId.isEmpty() )
+  if ( iconId.isEmpty() ) {
     return name;
+  }
   return QString( "<img src=\":/flags/%1.png\"> %2" ).arg( iconId, name );
 }
 

--- a/src/macos/machotkeywrapper.mm
+++ b/src/macos/machotkeywrapper.mm
@@ -41,10 +41,12 @@ void createMapping()
   if( mapping == NULL )
   {
     TISInputSourceRef inputSourceRef = TISCopyInputSourceForLanguage( CFSTR( "en" ) );
-    if ( !inputSourceRef )
+    if ( !inputSourceRef ) {
       inputSourceRef = TISCopyCurrentKeyboardInputSource();
-    if ( !inputSourceRef )
+}
+    if ( !inputSourceRef ) {
       return;
+}
 
     CFDataRef dataRef = ( CFDataRef )TISGetInputSourceProperty( inputSourceRef,
                                      kTISPropertyUnicodeKeyLayoutData ); 
@@ -60,12 +62,14 @@ void createMapping()
     }
 
     const UCKeyboardLayout * keyboardLayoutPtr = ( const UCKeyboardLayout * )CFDataGetBytePtr( dataRef );
-    if( !keyboardLayoutPtr )
+    if( !keyboardLayoutPtr ) {
       return;
+}
 
     mapping = ( struct ReverseMapEntry * )calloc( 128 , sizeof(struct ReverseMapEntry) );
-    if( !mapping )
+    if( !mapping ) {
       return;
+}
 
     mapEntries = 0;
 
@@ -89,13 +93,15 @@ void createMapping()
 quint32 qtKeyToNativeKey( quint32 key )
 {
   createMapping();
-  if( mapping == NULL )
+  if( mapping == NULL ) {
     return 0;
+}
 
   for( int i = 0; i < mapEntries; i++ )
   {
-    if( mapping[ i ].character == key )
+    if( mapping[ i ].character == key ) {
       return mapping[ i ].keyCode;
+}
   }
 
   return 0;
@@ -214,8 +220,9 @@ void HotkeyWrapper::unregister()
 
     UnregisterEventHotKey( hk.hkRef );
 
-    if ( hk.key2 && hk.key2 != hk.key )
+    if ( hk.key2 && hk.key2 != hk.key ) {
       UnregisterEventHotKey( hk.hkRef2 );
+}
   }
 
   (static_cast< QHotkeyApplication * >( qApp ))->unregisterWrapper( this );
@@ -229,29 +236,36 @@ bool HotkeyWrapper::setGlobalKey( QKeySequence const & seq, int handle )
 
 bool HotkeyWrapper::setGlobalKey( int key, int key2, Qt::KeyboardModifiers modifier, int handle )
 {
-  if ( !key )
+  if ( !key ) {
     return false; // We don't monitor empty combinations
+}
 
   quint32 vk = nativeKey( key );
 
-  if( vk == 0 )
+  if( vk == 0 ) {
     return false;
+}
 
   quint32 vk2 = key2 ? nativeKey( key2 ) : 0;
 
   static int nextId = 1;
-  if( nextId > 0xBFFF - 1 )
+  if( nextId > 0xBFFF - 1 ) {
     nextId = 1;
+}
 
   quint32 mod = 0;
-  if( modifier & Qt::CTRL )
+  if( modifier & Qt::CTRL ) {
     mod |= cmdKey;
-  if( modifier & Qt::ALT )
+}
+  if( modifier & Qt::ALT ) {
     mod |= optionKey;
-  if( modifier & Qt::SHIFT )
+}
+  if( modifier & Qt::SHIFT ) {
     mod |= shiftKey;
-  if( modifier & Qt::META )
+}
+  if( modifier & Qt::META ) {
     mod |= controlKey;
+}
 
   hotkeys.append( HotkeyStruct( vk, vk2, mod, handle, nextId ) );
   HotkeyStruct &hk = hotkeys.last();
@@ -261,8 +275,9 @@ bool HotkeyWrapper::setGlobalKey( int key, int key2, Qt::KeyboardModifiers modif
   hotKeyID.id = nextId;
 
   OSStatus ret = RegisterEventHotKey( vk, mod, hotKeyID, GetApplicationEventTarget(), 0, &hk.hkRef );
-  if ( ret != 0 )
+  if ( ret != 0 ) {
     return false;
+}
 
   if ( vk2 && vk2 != vk )
   {

--- a/src/main.cc
+++ b/src/main.cc
@@ -481,8 +481,9 @@ int main( int argc, char ** argv )
       wasMessage = true;
     }
 
-    if ( !wasMessage )
+    if ( !wasMessage ) {
       app.sendMessage( "bringToFront" );
+    }
 
     return 0; // Another instance is running
   }
@@ -507,8 +508,9 @@ int main( int argc, char ** argv )
         QHotkeyApplication::translate( "Main", "Error in configuration file. Continue with default settings?" ),
         QMessageBox::Yes | QMessageBox::No );
       mb.exec();
-      if ( mb.result() != QMessageBox::Yes )
+      if ( mb.result() != QMessageBox::Yes ) {
         return -1;
+      }
 
       QString configFile = Config::getConfigFileName();
       QFile::rename( configFile,
@@ -585,14 +587,17 @@ int main( int argc, char ** argv )
 
   QObject::connect( &app, &QtSingleApplication::messageReceived, &m, &MainWindow::messageFromAnotherInstanceReceived );
 
-  if ( gdcl.needSetGroup() )
+  if ( gdcl.needSetGroup() ) {
     m.setGroupByName( gdcl.getGroupName(), true );
+  }
 
-  if ( gdcl.needSetPopupGroup() )
+  if ( gdcl.needSetPopupGroup() ) {
     m.setGroupByName( gdcl.getPopupGroupName(), false );
+  }
 
-  if ( gdcl.needTranslateWord() )
+  if ( gdcl.needTranslateWord() ) {
     m.wordReceived( gdcl.wordToTranslate() );
+  }
 
 #ifdef Q_OS_UNIX
   // handle Unix's shutdown signals for graceful exit
@@ -604,8 +609,9 @@ int main( int argc, char ** argv )
 
   app.removeDataCommiter( m );
 
-  if ( logFilePtr->isOpen() )
+  if ( logFilePtr->isOpen() ) {
     logFilePtr->close();
+  }
 
   return r;
 }

--- a/src/multimediaaudioplayer.cc
+++ b/src/multimediaaudioplayer.cc
@@ -45,8 +45,9 @@ QString MultimediaAudioPlayer::play( const char * data, int size )
   stop();
   audioBuffer = new QBuffer();
   audioBuffer->setData( data, size );
-  if ( !audioBuffer->open( QIODevice::ReadOnly ) )
+  if ( !audioBuffer->open( QIODevice::ReadOnly ) ) {
     return tr( "Couldn't open audio buffer for reading." );
+  }
   #if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
   player.setSourceDevice( audioBuffer );
     #if ( QT_VERSION > QT_VERSION_CHECK( 6, 2, 0 ) )

--- a/src/pronounceengine.cc
+++ b/src/pronounceengine.cc
@@ -20,11 +20,13 @@ void PronounceEngine::reset()
 
 void PronounceEngine::sendAudio( std::string dictId, QString audioLink )
 {
-  if ( state == PronounceState::OCCUPIED )
+  if ( state == PronounceState::OCCUPIED ) {
     return;
+  }
 
-  if ( !Utils::Url::isAudioUrl( QUrl( audioLink ) ) )
+  if ( !Utils::Url::isAudioUrl( QUrl( audioLink ) ) ) {
     return;
+  }
 
   QMutexLocker _( &mutex );
 
@@ -33,15 +35,17 @@ void PronounceEngine::sendAudio( std::string dictId, QString audioLink )
 
 void PronounceEngine::finishDictionary( std::string dictId )
 {
-  if ( state == PronounceState::OCCUPIED )
+  if ( state == PronounceState::OCCUPIED ) {
     return;
+  }
 
   if ( dictAudioMap.contains( dictId ) ) {
     {
       //limit the mutex scope.
       QMutexLocker _( &mutex );
-      if ( state == PronounceState::OCCUPIED )
+      if ( state == PronounceState::OCCUPIED ) {
         return;
+      }
       state = PronounceState::OCCUPIED;
     }
     emit emitAudio( dictAudioMap[ dictId ].first() );

--- a/src/resourceschemehandler.cc
+++ b/src/resourceschemehandler.cc
@@ -20,10 +20,11 @@ void ResourceSchemeHandler::requestStarted( QWebEngineUrlRequestJob * requestJob
   else if ( reply->isFinished() ) {
     replyJob( reply, requestJob, content_type );
   }
-  else
+  else {
     connect( reply.get(), &Dictionary::DataRequest::finished, requestJob, [ = ]() {
       replyJob( reply, requestJob, content_type );
     } );
+  }
 }
 
 

--- a/src/speechclient.cc
+++ b/src/speechclient.cc
@@ -20,13 +20,13 @@ SpeechClient::Engines SpeechClient::availableEngines()
   for ( const auto & engine_name : innerEngines ) {
     const auto sp = new QTextToSpeech( engine_name );
 
-#if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
+  #if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
     if ( sp->state() == QTextToSpeech::Error )
       continue;
-#else
+  #else
     if ( !sp || sp->state() == QTextToSpeech::BackendError )
       continue;
-#endif
+  #endif
 
     qDebug() << engine_name << sp->state();
 

--- a/src/speechclient.hh
+++ b/src/speechclient.hh
@@ -43,13 +43,13 @@ public:
       engine( e )
     {
       qDebug() << QStringLiteral( "initialize tts" ) << e.engine_name;
-#if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
+  #if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
       if ( !sp || sp->state() == QTextToSpeech::Error )
         return;
-#else
+  #else
       if ( !sp || sp->state() == QTextToSpeech::BackendError )
         return;
-#endif
+  #endif
       sp->setLocale( e.locale );
       auto voices = sp->availableVoices();
       for ( const auto & voice : voices ) {

--- a/src/termination.cc
+++ b/src/termination.cc
@@ -11,8 +11,9 @@ static void termHandler()
 {
   qDebug() << "GoldenDict has crashed unexpectedly.\n\n";
 
-  if ( logFilePtr && logFilePtr->isOpen() )
+  if ( logFilePtr && logFilePtr->isOpen() ) {
     logFilePtr->close();
+  }
 
   abort();
 }

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -295,8 +295,9 @@ void ArticleView::showDefinition( QString const & word,
 {
   GlobalBroadcaster::instance()->pronounce_engine.reset();
   currentWord = word.trimmed();
-  if ( currentWord.isEmpty() )
+  if ( currentWord.isEmpty() ) {
     return;
+  }
   historyMode = false;
   currentActiveDictIds.clear();
   // first, let's stop the player
@@ -309,11 +310,13 @@ void ArticleView::showDefinition( QString const & word,
   req.setHost( "localhost" );
   Utils::Url::addQueryItem( req, "word", word );
   Utils::Url::addQueryItem( req, "group", QString::number( group ) );
-  if ( cfg.preferences.ignoreDiacritics )
+  if ( cfg.preferences.ignoreDiacritics ) {
     Utils::Url::addQueryItem( req, "ignore_diacritics", "1" );
+  }
 
-  if ( scrollTo.size() )
+  if ( scrollTo.size() ) {
     Utils::Url::addQueryItem( req, "scrollto", scrollTo );
+  }
 
   if ( delayedHighlightText.size() ) {
     Utils::Url::addQueryItem( req, "regexp", delayedHighlightText );
@@ -341,8 +344,9 @@ void ArticleView::showDefinition( QString const & word,
 
   QString mutedDicts = getMutedForGroup( group );
 
-  if ( mutedDicts.size() )
+  if ( mutedDicts.size() ) {
     Utils::Url::addQueryItem( req, "muted", mutedDicts );
+  }
 
   // Any search opened is probably irrelevant now
   closeSearch();
@@ -360,11 +364,13 @@ void ArticleView::showDefinition( QString const & word,
                                   unsigned group,
                                   bool ignoreDiacritics )
 {
-  if ( dictIDs.isEmpty() )
+  if ( dictIDs.isEmpty() ) {
     return;
+  }
   currentWord = word.trimmed();
-  if ( currentWord.isEmpty() )
+  if ( currentWord.isEmpty() ) {
     return;
+  }
   historyMode = false;
   //clear founded dicts.
   currentActiveDictIds.clear();
@@ -378,13 +384,15 @@ void ArticleView::showDefinition( QString const & word,
   Utils::Url::addQueryItem( req, "word", word );
   Utils::Url::addQueryItem( req, "dictionaries", dictIDs.join( "," ) );
   Utils::Url::addQueryItem( req, "regexp", searchRegExp.pattern() );
-  if ( !searchRegExp.patternOptions().testFlag( QRegularExpression::CaseInsensitiveOption ) )
+  if ( !searchRegExp.patternOptions().testFlag( QRegularExpression::CaseInsensitiveOption ) ) {
     Utils::Url::addQueryItem( req, "matchcase", "1" );
+  }
   //  if ( searchRegExp.patternSyntax() == QRegExp::WildcardUnix )
   //    Utils::Url::addQueryItem( req, "wildcards", "1" );
   Utils::Url::addQueryItem( req, "group", QString::number( group ) );
-  if ( ignoreDiacritics )
+  if ( ignoreDiacritics ) {
     Utils::Url::addQueryItem( req, "ignore_diacritics", "1" );
+  }
 
   // Any search opened is probably irrelevant now
   closeSearch();
@@ -477,14 +485,16 @@ void ArticleView::loadFinished( bool result )
 
 void ArticleView::handleTitleChanged( QString const & title )
 {
-  if ( !title.isEmpty() && !title.contains( "://" ) )
+  if ( !title.isEmpty() && !title.contains( "://" ) ) {
     emit titleChanged( this, title );
+  }
 }
 
 unsigned ArticleView::getGroup( QUrl const & url )
 {
-  if ( url.scheme() == "gdlookup" && Utils::Url::hasQueryItem( url, "group" ) )
+  if ( url.scheme() == "gdlookup" && Utils::Url::hasQueryItem( url, "group" ) ) {
     return Utils::Url::queryItemValue( url, "group" ).toUInt();
+  }
 
   return 0;
 }
@@ -521,16 +531,19 @@ void ArticleView::jumpToDictionary( QString const & id, bool force )
 
 bool ArticleView::setCurrentArticle( QString const & id, bool moveToIt )
 {
-  if ( !isScrollTo( id ) )
+  if ( !isScrollTo( id ) ) {
     return false; // Incorrect id
+  }
 
-  if ( !webview->isVisible() )
+  if ( !webview->isVisible() ) {
     return false; // No action on background page, scrollIntoView there don't work
+  }
 
   if ( moveToIt ) {
     QString dictId = id.mid( 7 );
-    if ( dictId.isEmpty() )
+    if ( dictId.isEmpty() ) {
       return false;
+    }
     QString script =
       QString(
         "var elem=document.getElementById('%1'); "
@@ -553,8 +566,9 @@ void ArticleView::selectCurrentArticle()
 
 void ArticleView::isFramedArticle( QString const & ca, const std::function< void( bool ) > & callback )
 {
-  if ( ca.isEmpty() )
+  if ( ca.isEmpty() ) {
     callback( false );
+  }
 
   webview->page()->runJavaScript( QString( "!!document.getElementById('gdexpandframe-%1');" ).arg( ca.mid( 7 ) ),
                                   [ callback ]( const QVariant & res ) {
@@ -566,8 +580,9 @@ void ArticleView::tryMangleWebsiteClickedUrl( QUrl & url, Contexts & contexts )
 {
   // Don't try mangling audio urls, even if they are from the framed websites
 
-  if ( !url.isValid() )
+  if ( !url.isValid() ) {
     return;
+  }
   if ( ( url.scheme() == "http" || url.scheme() == "https" ) && !Utils::Url::isWebAudioUrl( url ) ) {
     // Maybe a link inside a website was clicked?
 
@@ -585,10 +600,12 @@ void ArticleView::cleanupTemp()
 {
   auto it = desktopOpenedTempFiles.begin();
   while ( it != desktopOpenedTempFiles.end() ) {
-    if ( QFile::remove( *it ) )
+    if ( QFile::remove( *it ) ) {
       it = desktopOpenedTempFiles.erase( it );
-    else
+    }
+    else {
       ++it;
+    }
   }
 }
 
@@ -598,16 +615,18 @@ bool ArticleView::handleF3( QObject * /*obj*/, QEvent * ev )
     QKeyEvent * ke = static_cast< QKeyEvent * >( ev );
     if ( ke->key() == Qt::Key_F3 && isSearchOpened() ) {
       if ( !ke->modifiers() ) {
-        if ( ev->type() == QEvent::KeyPress )
+        if ( ev->type() == QEvent::KeyPress ) {
           on_searchNext_clicked();
+        }
 
         ev->accept();
         return true;
       }
 
       if ( ke->modifiers() == Qt::ShiftModifier ) {
-        if ( ev->type() == QEvent::KeyPress )
+        if ( ev->type() == QEvent::KeyPress ) {
           on_searchPrevious_clicked();
+        }
 
         ev->accept();
         return true;
@@ -615,16 +634,18 @@ bool ArticleView::handleF3( QObject * /*obj*/, QEvent * ev )
     }
     if ( ke->key() == Qt::Key_F3 && ftsSearchPanel->isVisible() ) {
       if ( !ke->modifiers() ) {
-        if ( ev->type() == QEvent::KeyPress )
+        if ( ev->type() == QEvent::KeyPress ) {
           on_ftsSearchNext_clicked();
+        }
 
         ev->accept();
         return true;
       }
 
       if ( ke->modifiers() == Qt::ShiftModifier ) {
-        if ( ev->type() == QEvent::KeyPress )
+        if ( ev->type() == QEvent::KeyPress ) {
           on_ftsSearchPrevious_clicked();
+        }
 
         ev->accept();
         return true;
@@ -714,11 +735,14 @@ bool ArticleView::eventFilter( QObject * obj, QEvent * ev )
     if ( ev->type() == QEvent::KeyPress ) {
       auto keyEvent = static_cast< QKeyEvent * >( ev );
 
-      if ( keyEvent->modifiers() & ( Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier ) )
+      if ( keyEvent->modifiers() & ( Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier ) ) {
         return false; // A non-typing modifier is pressed
+      }
 
-      if ( Utils::ignoreKeyEvent( keyEvent ) || keyEvent->key() == Qt::Key_Return || keyEvent->key() == Qt::Key_Enter )
+      if ( Utils::ignoreKeyEvent( keyEvent ) || keyEvent->key() == Qt::Key_Return
+           || keyEvent->key() == Qt::Key_Enter ) {
         return false; // Those key have other uses than to start typing
+      }
 
       QString text = keyEvent->text();
 
@@ -739,8 +763,9 @@ bool ArticleView::eventFilter( QObject * obj, QEvent * ev )
       }
     }
   }
-  else
+  else {
     return QWidget::eventFilter( obj, ev );
+  }
 
   return false;
 }
@@ -754,12 +779,15 @@ QString ArticleView::getMutedForGroup( unsigned group )
     // Find muted dictionaries for current group
     Config::Group const * grp = cfg.getGroup( group );
     Config::MutedDictionaries const * mutedDictionaries;
-    if ( group == Instances::Group::AllGroupId )
+    if ( group == Instances::Group::AllGroupId ) {
       mutedDictionaries = popupView ? &cfg.popupMutedDictionaries : &cfg.mutedDictionaries;
-    else
+    }
+    else {
       mutedDictionaries = grp ? ( popupView ? &grp->popupMutedDictionaries : &grp->mutedDictionaries ) : nullptr;
-    if ( !mutedDictionaries )
+    }
+    if ( !mutedDictionaries ) {
       return {};
+    }
 
     QStringList mutedDicts;
 
@@ -767,13 +795,15 @@ QString ArticleView::getMutedForGroup( unsigned group )
       for ( const auto & dictionarie : groupInstance->dictionaries ) {
         QString id = QString::fromStdString( dictionarie->getId() );
 
-        if ( mutedDictionaries->contains( id ) )
+        if ( mutedDictionaries->contains( id ) ) {
           mutedDicts.append( id );
+        }
       }
     }
 
-    if ( !mutedDicts.empty() )
+    if ( !mutedDicts.empty() ) {
       return mutedDicts.join( "," );
+    }
   }
 
   return {};
@@ -788,12 +818,15 @@ QStringList ArticleView::getMutedDictionaries( unsigned group )
     // Find muted dictionaries for current group
     Config::Group const * grp = cfg.getGroup( group );
     Config::MutedDictionaries const * mutedDictionaries;
-    if ( group == Instances::Group::AllGroupId )
+    if ( group == Instances::Group::AllGroupId ) {
       mutedDictionaries = popupView ? &cfg.popupMutedDictionaries : &cfg.mutedDictionaries;
-    else
+    }
+    else {
       mutedDictionaries = grp ? ( popupView ? &grp->popupMutedDictionaries : &grp->mutedDictionaries ) : nullptr;
-    if ( !mutedDictionaries )
+    }
+    if ( !mutedDictionaries ) {
       return {};
+    }
 
     QStringList mutedDicts;
 
@@ -801,8 +834,9 @@ QStringList ArticleView::getMutedDictionaries( unsigned group )
       for ( const auto & dictionarie : groupInstance->dictionaries ) {
         QString id = QString::fromStdString( dictionarie->getId() );
 
-        if ( mutedDictionaries->contains( id ) )
+        if ( mutedDictionaries->contains( id ) ) {
           mutedDicts.append( id );
+        }
       }
     }
 
@@ -847,15 +881,18 @@ void ArticleView::linkHovered( const QString & link )
     if ( Utils::Url::hasQueryItem( url, "dict" ) ) {
       // Link to other dictionary
       QString dictName( Utils::Url::queryItemValue( url, "dict" ) );
-      if ( !dictName.isEmpty() )
+      if ( !dictName.isEmpty() ) {
         msg = tr( "Definition from dictionary \"%1\": %2" ).arg( dictName, def );
+      }
     }
 
     if ( msg.isEmpty() ) {
-      if ( def.isEmpty() && url.hasFragment() )
+      if ( def.isEmpty() && url.hasFragment() ) {
         msg = '#' + url.fragment(); // this must be a citation, footnote or backlink
-      else
+      }
+      else {
         msg = tr( "Definition: %1" ).arg( def );
+      }
     }
   }
   else {
@@ -880,8 +917,9 @@ void ArticleView::linkClicked( QUrl const & url_ )
   Qt::KeyboardModifiers kmod = QApplication::keyboardModifiers();
 
   // Lock jump on links while Alt key is pressed
-  if ( kmod & Qt::AltModifier )
+  if ( kmod & Qt::AltModifier ) {
     return;
+  }
 
   QUrl url( url_ );
   Contexts contexts;
@@ -894,8 +932,9 @@ void ArticleView::linkClicked( QUrl const & url_ )
     webview->resetMidButtonPressed();
     emit openLinkInNewTab( url, webview->url(), getCurrentArticle(), contexts );
   }
-  else
+  else {
     openLink( url, webview->url(), getCurrentArticle(), contexts );
+  }
 }
 
 void ArticleView::linkClickedInHtml( QUrl const & url_ )
@@ -950,8 +989,9 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref, QString const & 
 
       showDefinition( word, dictsList, getGroup( ref ), false );
     }
-    else
+    else {
       showDefinition( word, getGroup( ref ), scrollTo, contexts );
+    }
   }
   else if ( url.scheme() == "gdlookup" ) // Plain html links inherit gdlookup scheme
   {
@@ -986,8 +1026,9 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref, QString const & 
         }
       }
 
-      if ( Utils::Url::hasQueryItem( url, "gdanchor" ) )
+      if ( Utils::Url::hasQueryItem( url, "gdanchor" ) ) {
         contexts[ "gdanchor" ] = Utils::Url::queryItemValue( url, "gdanchor" );
+      }
 
       showDefinition( word, getGroup( ref ), newScrollTo, contexts );
     }
@@ -1055,8 +1096,9 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref, QString const & 
         }
         for ( unsigned x = 0; x < activeDicts->size(); ++x ) {
           try {
-            if ( x == preferred )
+            if ( x == preferred ) {
               continue;
+            }
 
             sptr< Dictionary::DataRequest > req =
               ( *activeDicts )[ x ]->getResource( url.path().mid( 1 ).toUtf8().data() );
@@ -1112,8 +1154,9 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref, QString const & 
       qDebug() << tr( "The referenced resource doesn't exist." );
       return;
     }
-    else
+    else {
       resourceDownloadFinished(); // Check any requests finished already
+    }
   }
   else if ( url.scheme() == "gdprg" ) {
     // Program. Run it.
@@ -1221,8 +1264,9 @@ ResourceToSaveHandler * ArticleView::saveResource( const QUrl & url, const QUrl 
         }
         for ( unsigned x = 0; x < activeDicts->size(); ++x ) {
           try {
-            if ( x == preferred )
+            if ( x == preferred ) {
               continue;
+            }
 
             req = ( *activeDicts )[ x ]->getResource( Utils::Url::path( url ).mid( 1 ).toUtf8().data() );
 
@@ -1274,13 +1318,15 @@ void ArticleView::updateMutedContents()
 {
   QUrl currentUrl = webview->url();
 
-  if ( currentUrl.scheme() != "gdlookup" )
+  if ( currentUrl.scheme() != "gdlookup" ) {
     return; // Weird url -- do nothing
+  }
 
   unsigned group = getGroup( currentUrl );
 
-  if ( !group )
+  if ( !group ) {
     return; // No group in url -- do nothing
+  }
 
   QString mutedDicts = getMutedForGroup( group );
 
@@ -1289,8 +1335,9 @@ void ArticleView::updateMutedContents()
 
     Utils::Url::removeQueryItem( currentUrl, "muted" );
 
-    if ( mutedDicts.size() )
+    if ( mutedDicts.size() ) {
       Utils::Url::addQueryItem( currentUrl, "muted", mutedDicts );
+    }
 
     load( currentUrl );
 
@@ -1373,8 +1420,9 @@ void ArticleView::hasSound( const std::function< void( bool ) > & callback )
   webview->page()->runJavaScript( R"(if(typeof(gdAudioLinks)!="undefined") gdAudioLinks.first)",
                                   [ callback ]( const QVariant & v ) {
                                     bool has = false;
-                                    if ( v.type() == QVariant::String )
+                                    if ( v.type() == QVariant::String ) {
                                       has = !v.toString().isEmpty();
+                                    }
                                     callback( has );
                                   } );
 }
@@ -1391,8 +1439,9 @@ void ArticleView::playSound()
   webview->page()->runJavaScript( variable, [ this ]( const QVariant & result ) {
     if ( result.typeId() == qMetaTypeId< QString >() ) {
       QString soundScript = result.toString();
-      if ( !soundScript.isEmpty() )
+      if ( !soundScript.isEmpty() ) {
         openLink( QUrl::fromEncoded( soundScript.toUtf8() ), webview->url() );
+      }
     }
   } );
 }
@@ -1423,8 +1472,9 @@ void ArticleView::setContent( const QByteArray & data, const QString & mimeType,
 QString ArticleView::getTitle()
 {
   auto title = webview->title();
-  if ( title.contains( "://" ) )
+  if ( title.contains( "://" ) ) {
     return {};
+  }
   return webview->title();
 }
 
@@ -1584,8 +1634,9 @@ void ArticleView::contextMenuRequested( QPoint const & pos )
 
   if ( text.isEmpty() && !cfg.preferences.storeHistory ) {
     QString txt = webview->title();
-    if ( txt.size() > 60 )
+    if ( txt.size() > 60 ) {
       txt = txt.left( 60 ) + "...";
+    }
 
     addHeaderToHistoryAction = new QAction( tr( R"(&Add "%1" to history)" ).arg( txt ), &menu );
     menu.addAction( addHeaderToHistoryAction );
@@ -1605,8 +1656,9 @@ void ArticleView::contextMenuRequested( QPoint const & pos )
   // Add table of contents
   QStringList ids = getArticlesList();
 
-  if ( !menu.isEmpty() && !ids.empty() )
+  if ( !menu.isEmpty() && !ids.empty() ) {
     menu.addSeparator();
+  }
 
   unsigned refsAdded            = 0;
   bool maxDictionaryRefsReached = false;
@@ -1636,28 +1688,34 @@ void ArticleView::contextMenuRequested( QPoint const & pos )
         tableOfContents[ action ] = *i;
       }
 
-      if ( maxDictionaryRefsReached )
+      if ( maxDictionaryRefsReached ) {
         break;
+      }
     }
   }
 
   menu.addSeparator();
-  if ( !popupView || cfg.pinPopupWindow )
+  if ( !popupView || cfg.pinPopupWindow ) {
     menu.addAction( &inspectAction );
+  }
 
   if ( !menu.isEmpty() ) {
     connect( this, &ArticleView::closePopupMenu, &menu, &QWidget::close );
     QAction * result = menu.exec( webview->mapToGlobal( pos ) );
 
-    if ( !result )
+    if ( !result ) {
       return;
+    }
 
-    if ( result == followLink )
+    if ( result == followLink ) {
       openLink( targetUrl, webview->url(), getCurrentArticle(), contexts );
-    else if ( result == followLinkExternal )
+    }
+    else if ( result == followLinkExternal ) {
       QDesktopServices::openUrl( targetUrl );
-    else if ( result == lookupSelection )
+    }
+    else if ( result == lookupSelection ) {
       showDefinition( text, getGroup( webview->url() ), getCurrentArticle() );
+    }
     else if ( result == saveBookmark ) {
       emit saveBookmarkSignal( text.left( 60 ) );
     }
@@ -1665,31 +1723,40 @@ void ArticleView::contextMenuRequested( QPoint const & pos )
       // This action is handled by a slot.
       return;
     }
-    else if ( result == lookupSelectionGr && currentGroupId )
+    else if ( result == lookupSelectionGr && currentGroupId ) {
       showDefinition( selectedText, currentGroupId, QString() );
-    else if ( result == addWordToHistoryAction )
+    }
+    else if ( result == addWordToHistoryAction ) {
       emit forceAddWordToHistory( selectedText );
-    else if ( result == addHeaderToHistoryAction )
+    }
+    else if ( result == addHeaderToHistoryAction ) {
       emit forceAddWordToHistory( webview->title() );
-    else if ( result == sendWordToInputLineAction )
+    }
+    else if ( result == sendWordToInputLineAction ) {
       emit sendWordToInputLine( selectedText );
-    else if ( !popupView && result == followLinkNewTab )
+    }
+    else if ( !popupView && result == followLinkNewTab ) {
       emit openLinkInNewTab( targetUrl, webview->url(), getCurrentArticle(), contexts );
-    else if ( !popupView && result == lookupSelectionNewTab )
+    }
+    else if ( !popupView && result == lookupSelectionNewTab ) {
       emit showDefinitionInNewTab( selectedText, getGroup( webview->url() ), getCurrentArticle(), Contexts() );
-    else if ( !popupView && result == lookupSelectionNewTabGr && currentGroupId )
+    }
+    else if ( !popupView && result == lookupSelectionNewTabGr && currentGroupId ) {
       emit showDefinitionInNewTab( selectedText, currentGroupId, QString(), Contexts() );
+    }
     else if ( result == saveImageAction || result == saveSoundAction ) {
       QUrl url = ( result == saveImageAction ) ? imageUrl : targetUrl;
       QString savePath;
       QString fileName;
 
-      if ( cfg.resourceSavePath.isEmpty() )
+      if ( cfg.resourceSavePath.isEmpty() ) {
         savePath = QDir::homePath();
+      }
       else {
         savePath = QDir::fromNativeSeparators( cfg.resourceSavePath );
-        if ( !QDir( savePath ).exists() )
+        if ( !QDir( savePath ).exists() ) {
           savePath = QDir::homePath();
+        }
       }
 
       QString name = Utils::Url::path( url ).section( '/', -1 );
@@ -1711,10 +1778,12 @@ void ArticleView::contextMenuRequested( QPoint const & pos )
         // Image data
 
         // Check for babylon image name
-        if ( name[ 0 ] == '\x1E' )
+        if ( name[ 0 ] == '\x1E' ) {
           name.remove( 0, 1 );
-        if ( name.length() && name[ name.length() - 1 ] == '\x1F' )
+        }
+        if ( name.length() && name[ name.length() - 1 ] == '\x1F' ) {
           name.chop( 1 );
+        }
 
         fileName = savePath + "/" + name;
         fileName = QFileDialog::getSaveFileName( parentWidget(),
@@ -1738,10 +1807,12 @@ void ArticleView::contextMenuRequested( QPoint const & pos )
       // Image data
 
       // Check for babylon image name
-      if ( name[ 0 ] == '\x1E' )
+      if ( name[ 0 ] == '\x1E' ) {
         name.remove( 0, 1 );
-      if ( name.length() && name[ name.length() - 1 ] == '\x1F' )
+      }
+      if ( name.length() && name[ name.length() - 1 ] == '\x1F' ) {
         name.chop( 1 );
+      }
 
       fileName = QDir::temp().filePath( QString::number( QRandomGenerator::global()->generate() ) + name );
 
@@ -1760,14 +1831,16 @@ void ArticleView::contextMenuRequested( QPoint const & pos )
       }
     }
     else {
-      if ( !popupView && result == maxDictionaryRefsAction )
+      if ( !popupView && result == maxDictionaryRefsAction ) {
         emit showDictsPane();
+      }
 
       // Match against table of contents
       QString id = tableOfContents[ result ];
 
-      if ( id.size() )
+      if ( id.size() ) {
         setCurrentArticle( scrollToFromDictionaryId( id ), true );
+      }
     }
   }
 
@@ -1776,8 +1849,9 @@ void ArticleView::contextMenuRequested( QPoint const & pos )
 
 void ArticleView::resourceDownloadFinished()
 {
-  if ( resourceDownloadRequests.empty() )
+  if ( resourceDownloadRequests.empty() ) {
     return; // Stray signal
+  }
 
   // Find any finished resources
   for ( list< sptr< Dictionary::DataRequest > >::iterator i = resourceDownloadRequests.begin();
@@ -1797,8 +1871,9 @@ void ArticleView::resourceDownloadFinished()
                    &ArticleView::audioPlayerError,
                    Qt::UniqueConnection );
           QString errorMessage = audioPlayer->play( data.data(), data.size() );
-          if ( !errorMessage.isEmpty() )
+          if ( !errorMessage.isEmpty() ) {
             QMessageBox::critical( this, "GoldenDict", tr( "Failed to play sound file: %1" ).arg( errorMessage ) );
+          }
         }
         else {
           // Create a temporary file
@@ -1820,11 +1895,12 @@ void ArticleView::resourceDownloadFinished()
             desktopOpenedTempFiles.insert( fileName = tmp.fileName() );
           }
 
-          if ( !QDesktopServices::openUrl( QUrl::fromLocalFile( fileName ) ) )
+          if ( !QDesktopServices::openUrl( QUrl::fromLocalFile( fileName ) ) ) {
             QMessageBox::critical(
               this,
               "GoldenDict",
               tr( "Failed to auto-open resource file, try opening manually: %1." ).arg( fileName ) );
+          }
         }
 
         // Ok, whatever it was, it's finished. Remove this and any other
@@ -1839,8 +1915,9 @@ void ArticleView::resourceDownloadFinished()
         resourceDownloadRequests.erase( i++ );
       }
     }
-    else // Unfinished, wait.
+    else { // Unfinished, wait.
       break;
+    }
   }
 
   if ( resourceDownloadRequests.empty() ) {
@@ -1887,8 +1964,9 @@ void ArticleView::moveOneArticleUp()
     if ( idx != -1 ) {
       --idx;
 
-      if ( idx < 0 )
+      if ( idx < 0 ) {
         idx = lst.size() - 1;
+      }
 
       setCurrentArticle( scrollToFromDictionaryId( lst[ idx ] ), true );
     }
@@ -1915,11 +1993,13 @@ void ArticleView::moveOneArticleDown()
 
 void ArticleView::openSearch()
 {
-  if ( !isVisible() )
+  if ( !isVisible() ) {
     return;
+  }
 
-  if ( ftsSearchPanel->isVisible() )
+  if ( ftsSearchPanel->isVisible() ) {
     closeSearch();
+  }
 
   if ( !searchPanel->isVisible() ) {
     searchPanel->show();
@@ -1939,14 +2019,16 @@ void ArticleView::openSearch()
 
 void ArticleView::on_searchPrevious_clicked()
 {
-  if ( searchPanel->isVisible() )
+  if ( searchPanel->isVisible() ) {
     performFindOperation( true );
+  }
 }
 
 void ArticleView::on_searchNext_clicked()
 {
-  if ( searchPanel->isVisible() )
+  if ( searchPanel->isVisible() ) {
     performFindOperation( false );
+  }
 }
 
 void ArticleView::on_searchText_textEdited()
@@ -1975,8 +2057,9 @@ void ArticleView::on_searchCaseSensitive_clicked( bool checked )
 //the id start with "gdform-"
 void ArticleView::onJsActiveArticleChanged( QString const & id )
 {
-  if ( !isScrollTo( id ) )
+  if ( !isScrollTo( id ) ) {
     return; // Incorrect id
+  }
 
   QString dictId = dictionaryIdFromScrollTo( id );
   setActiveArticleId( dictId );
@@ -1991,8 +2074,9 @@ void ArticleView::doubleClicked( QPoint pos )
     QString selectedText = webview->selectedText();
 
     // ignore empty word;
-    if ( selectedText.isEmpty() )
+    if ( selectedText.isEmpty() ) {
       return;
+    }
 
     emit sendWordToInputLine( selectedText );
     // Do some checks to make sure there's a sensible selection indeed
@@ -2013,8 +2097,9 @@ void ArticleView::doubleClicked( QPoint pos )
           QStringList dictsList = Utils::Url::queryItemValue( ref, "dictionaries" ).split( ",", Qt::SkipEmptyParts );
           showDefinition( selectedText, dictsList, groupId, false );
         }
-        else
+        else {
           showDefinition( selectedText, groupId, getCurrentArticle() );
+        }
       }
     }
   }
@@ -2027,11 +2112,13 @@ void ArticleView::performFindOperation( bool backwards )
 
   QWebEnginePage::FindFlags f( 0 );
 
-  if ( searchPanel->caseSensitive->isChecked() )
+  if ( searchPanel->caseSensitive->isChecked() ) {
     f |= QWebEnginePage::FindCaseSensitively;
+  }
 
-  if ( backwards )
+  if ( backwards ) {
     f |= QWebEnginePage::FindBackward;
+  }
 
   findText( text, f, [ text, this ]( bool match ) {
     bool nomatch = !text.isEmpty() && !match;
@@ -2046,8 +2133,9 @@ void ArticleView::findText( QString & text,
 #if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
   webview->findText( text, f, [ callback ]( const QWebEngineFindTextResult & result ) {
     auto r = result.numberOfMatches() > 0;
-    if ( callback )
+    if ( callback ) {
       callback( r );
+    }
   } );
 #else
   webview->findText( text, f, [ callback ]( bool result ) {
@@ -2087,8 +2175,9 @@ bool ArticleView::isSearchOpened()
 void ArticleView::copyAsText()
 {
   QString text = webview->selectedText();
-  if ( !text.isEmpty() )
+  if ( !text.isEmpty() ) {
     QApplication::clipboard()->setText( text );
+  }
 }
 
 void ArticleView::highlightFTSResults()
@@ -2097,16 +2186,18 @@ void ArticleView::highlightFTSResults()
   // Clear any current selection
   webview->findText( "" );
   QString regString = Utils::Url::queryItemValue( webview->url(), "regexp" );
-  if ( regString.isEmpty() )
+  if ( regString.isEmpty() ) {
     return;
+  }
 
 
   //replace any unicode Number ,Symbol ,Punctuation ,Mark character to whitespace
   regString.replace( QRegularExpression( R"([\p{N}\p{S}\p{P}\p{M}])", QRegularExpression::UseUnicodePropertiesOption ),
                      " " );
 
-  if ( regString.trimmed().isEmpty() )
+  if ( regString.trimmed().isEmpty() ) {
     return;
+  }
 
   QString script = QString(
                      "var context = document.querySelector(\"body\");\n"
@@ -2160,8 +2251,9 @@ void ArticleView::dictionaryClear( const ActiveDictIds & ad )
 
 void ArticleView::performFtsFindOperation( bool backwards )
 {
-  if ( !ftsSearchPanel->isVisible() )
+  if ( !ftsSearchPanel->isVisible() ) {
     return;
+  }
 
   if ( firstAvailableText.isEmpty() ) {
     ftsSearchPanel->statusLabel->setText( searchStatusMessageNoMatches() );
@@ -2177,11 +2269,13 @@ void ArticleView::performFtsFindOperation( bool backwards )
     webview->findText( firstAvailableText,
                        flags | QWebEnginePage::FindBackward,
                        [ this ]( const QWebEngineFindTextResult & result ) {
-                         if ( result.numberOfMatches() == 0 )
+                         if ( result.numberOfMatches() == 0 ) {
                            return;
+                         }
                          ftsSearchPanel->previous->setEnabled( true );
-                         if ( !ftsSearchPanel->next->isEnabled() )
+                         if ( !ftsSearchPanel->next->isEnabled() ) {
                            ftsSearchPanel->next->setEnabled( true );
+                         }
 
                          ftsSearchPanel->statusLabel->setText(
                            searchStatusMessage( result.activeMatch(), result.numberOfMatches() ) );
@@ -2197,11 +2291,13 @@ void ArticleView::performFtsFindOperation( bool backwards )
   else {
 #if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
     webview->findText( firstAvailableText, flags, [ this ]( const QWebEngineFindTextResult & result ) {
-      if ( result.numberOfMatches() == 0 )
+      if ( result.numberOfMatches() == 0 ) {
         return;
+      }
       ftsSearchPanel->next->setEnabled( true );
-      if ( !ftsSearchPanel->previous->isEnabled() )
+      if ( !ftsSearchPanel->previous->isEnabled() ) {
         ftsSearchPanel->previous->setEnabled( true );
+      }
 
       ftsSearchPanel->statusLabel->setText( searchStatusMessage( result.activeMatch(), result.numberOfMatches() ) );
     } );
@@ -2252,8 +2348,9 @@ void ResourceToSaveHandler::addRequest( const sptr< Dictionary::DataRequest > & 
 
 void ResourceToSaveHandler::downloadFinished()
 {
-  if ( downloadRequests.empty() )
+  if ( downloadRequests.empty() ) {
     return; // Stray signal
+  }
 
   // Find any finished resources
   for ( auto i = downloadRequests.begin(); i != downloadRequests.end(); ) {
@@ -2293,8 +2390,9 @@ void ResourceToSaveHandler::downloadFinished()
         downloadRequests.erase( i++ );
       }
     }
-    else // Unfinished, wait.
+    else { // Unfinished, wait.
       break;
+    }
   }
 
   if ( downloadRequests.empty() ) {

--- a/src/ui/articlewebview.cc
+++ b/src/ui/articlewebview.cc
@@ -111,8 +111,9 @@ bool ArticleWebView::eventFilter( QObject * obj, QEvent * ev )
 
 void ArticleWebView::singleClickAction( QMouseEvent * event )
 {
-  if ( !singleClickToDbClick )
+  if ( !singleClickToDbClick ) {
     return;
+  }
 
   if ( selectionBySingleClick ) {
     findText( "" ); // clear the selection first, if any

--- a/src/ui/dictheadwords.cc
+++ b/src/ui/dictheadwords.cc
@@ -32,13 +32,15 @@ DictHeadwords::DictHeadwords( QWidget * parent, Config::Class & cfg_, Dictionary
 
   const bool fromMainWindow = parent->objectName() == "MainWindow";
 
-  if ( fromMainWindow )
+  if ( fromMainWindow ) {
     setAttribute( Qt::WA_DeleteOnClose, false );
+  }
 
   setWindowFlags( windowFlags() & ~Qt::WindowContextHelpButtonHint );
 
-  if ( cfg.headwordsDialog.headwordsDialogGeometry.size() > 0 )
+  if ( cfg.headwordsDialog.headwordsDialogGeometry.size() > 0 ) {
     restoreGeometry( cfg.headwordsDialog.headwordsDialogGeometry );
+  }
 
   ui.searchModeCombo->addItem( tr( "Text" ), SearchType::FixedString );
   ui.searchModeCombo->addItem( tr( "Wildcards" ), SearchType::Wildcard );
@@ -69,8 +71,9 @@ DictHeadwords::DictHeadwords( QWidget * parent, Config::Class & cfg_, Dictionary
   ui.headersListView->setUniformItemSizes( true );
 
   delegate = new WordListItemDelegate( ui.headersListView->itemDelegate() );
-  if ( delegate )
+  if ( delegate ) {
     ui.headersListView->setItemDelegate( delegate );
+  }
 
   ui.autoApply->setChecked( cfg.headwordsDialog.autoApply );
 
@@ -117,8 +120,9 @@ DictHeadwords::DictHeadwords( QWidget * parent, Config::Class & cfg_, Dictionary
 
 DictHeadwords::~DictHeadwords()
 {
-  if ( delegate )
+  if ( delegate ) {
     delegate->deleteLater();
+  }
 }
 
 void DictHeadwords::setup( Dictionary::Class * dict_ )
@@ -163,8 +167,8 @@ void DictHeadwords::setup( Dictionary::Class * dict_ )
 
 void DictHeadwords::savePos()
 {
-  cfg.headwordsDialog.searchMode = ui.searchModeCombo->currentIndex();
-  cfg.headwordsDialog.matchCase  = ui.matchCase->isChecked();
+  cfg.headwordsDialog.searchMode              = ui.searchModeCombo->currentIndex();
+  cfg.headwordsDialog.matchCase               = ui.matchCase->isChecked();
   cfg.headwordsDialog.autoApply               = ui.autoApply->isChecked();
   cfg.headwordsDialog.headwordsDialogGeometry = saveGeometry();
 }
@@ -179,8 +183,9 @@ bool DictHeadwords::eventFilter( QObject * obj, QEvent * ev )
     }
     else if ( kev->key() == Qt::Key_Up ) {
       auto index = ui.headersListView->currentIndex();
-      if ( index.row() == 0 )
+      if ( index.row() == 0 ) {
         return true;
+      }
       auto preIndex = ui.headersListView->model()->index( index.row() - 1, index.column() );
       ui.headersListView->setCurrentIndex( preIndex );
       return true;
@@ -188,8 +193,9 @@ bool DictHeadwords::eventFilter( QObject * obj, QEvent * ev )
     else if ( kev->key() == Qt::Key_Down ) {
       auto index = ui.headersListView->currentIndex();
       //last row.
-      if ( index.row() == ui.headersListView->model()->rowCount() - 1 )
+      if ( index.row() == ui.headersListView->model()->rowCount() - 1 ) {
         return true;
+      }
       auto preIndex = ui.headersListView->model()->index( index.row() + 1, index.column() );
       ui.headersListView->setCurrentIndex( preIndex );
       return true;
@@ -218,8 +224,9 @@ void DictHeadwords::exportButtonClicked()
 void DictHeadwords::filterChangedInternal()
 {
   // emit signal in async manner, to avoid UI slowdown
-  if ( ui.autoApply->isChecked() )
+  if ( ui.autoApply->isChecked() ) {
     QTimer::singleShot( 100, this, &DictHeadwords::filterChanged );
+  }
 }
 
 QRegularExpression DictHeadwords::getFilterRegex() const
@@ -228,8 +235,9 @@ QRegularExpression DictHeadwords::getFilterRegex() const
     static_cast< SearchType >( ui.searchModeCombo->itemData( ui.searchModeCombo->currentIndex() ).toInt() );
 
   QRegularExpression::PatternOptions options = QRegularExpression::UseUnicodePropertiesOption;
-  if ( !ui.matchCase->isChecked() )
+  if ( !ui.matchCase->isChecked() ) {
     options |= QRegularExpression::CaseInsensitiveOption;
+  }
 
   QString pattern;
   switch ( syntax ) {
@@ -307,12 +315,14 @@ void DictHeadwords::exportAllWords( QProgressDialog & progress, QTextStream & ou
 
   int totalCount = 0;
   for ( int i = 0; i < headwordsNumber && i < model->wordCount(); ++i ) {
-    if ( progress.wasCanceled() )
+    if ( progress.wasCanceled() ) {
       break;
+    }
 
     QVariant value = model->getRow( i );
-    if ( !value.canConvert< QString >() )
+    if ( !value.canConvert< QString >() ) {
       continue;
+    }
 
     allHeadwords.insert( value.toString() );
   }
@@ -323,22 +333,23 @@ void DictHeadwords::exportAllWords( QProgressDialog & progress, QTextStream & ou
     writeWordToFile( out, item );
   }
 
-    // continue to write the remaining headword
-    int nodeIndex  = model->getCurrentIndex();
-    auto headwords = model->getRemainRows( nodeIndex );
-    while ( !headwords.isEmpty() ) {
-      if ( progress.wasCanceled() )
-        break;
-
-      for ( const auto & item : headwords ) {
-        progress.setValue( totalCount++ );
-
-        writeWordToFile( out, item );
-      }
-
-
-      headwords = model->getRemainRows( nodeIndex );
+  // continue to write the remaining headword
+  int nodeIndex  = model->getCurrentIndex();
+  auto headwords = model->getRemainRows( nodeIndex );
+  while ( !headwords.isEmpty() ) {
+    if ( progress.wasCanceled() ) {
+      break;
     }
+
+    for ( const auto & item : headwords ) {
+      progress.setValue( totalCount++ );
+
+      writeWordToFile( out, item );
+    }
+
+
+    headwords = model->getRemainRows( nodeIndex );
+  }
 }
 
 void DictHeadwords::loadRegex( QProgressDialog & progress, QTextStream & out )
@@ -350,12 +361,14 @@ void DictHeadwords::loadRegex( QProgressDialog & progress, QTextStream & out )
 
   int totalCount = 0;
   for ( int i = 0; i < model->wordCount(); ++i ) {
-    if ( progress.wasCanceled() )
+    if ( progress.wasCanceled() ) {
       break;
+    }
 
     QVariant value = model->getRow( i );
-    if ( !value.canConvert< QString >() )
+    if ( !value.canConvert< QString >() ) {
       continue;
+    }
 
     allHeadwords.insert( value.toString() );
   }
@@ -371,20 +384,23 @@ void DictHeadwords::loadRegex( QProgressDialog & progress, QTextStream & out )
 void DictHeadwords::saveHeadersToFile()
 {
   QString exportPath;
-  if ( cfg.headwordsDialog.headwordsExportPath.isEmpty() )
+  if ( cfg.headwordsDialog.headwordsExportPath.isEmpty() ) {
     exportPath = QDir::homePath();
+  }
   else {
     exportPath = QDir::fromNativeSeparators( cfg.headwordsDialog.headwordsExportPath );
-    if ( !QDir( exportPath ).exists() )
+    if ( !QDir( exportPath ).exists() ) {
       exportPath = QDir::homePath();
+    }
   }
 
   QString const fileName = QFileDialog::getSaveFileName( this,
                                                          tr( "Save headwords to file" ),
                                                          exportPath,
                                                          tr( "Text files (*.txt);;All files (*.*)" ) );
-  if ( fileName.size() == 0 )
+  if ( fileName.size() == 0 ) {
     return;
+  }
 
   QFile file( fileName );
 

--- a/src/ui/dictinfo.cc
+++ b/src/ui/dictinfo.cc
@@ -10,8 +10,9 @@ DictInfo::DictInfo( Config::Class & cfg_, QWidget * parent ):
   cfg( cfg_ )
 {
   ui.setupUi( this );
-  if ( cfg.dictInfoGeometry.size() > 0 )
+  if ( cfg.dictInfoGeometry.size() > 0 ) {
     restoreGeometry( cfg.dictInfoGeometry );
+  }
   connect( this, &QDialog::finished, this, &DictInfo::savePos );
 }
 
@@ -28,10 +29,12 @@ void DictInfo::showInfo( sptr< Dictionary::Class > dict )
 
   ui.openFolder->setVisible( dict->isLocalDictionary() );
 
-  if ( dict->getWordCount() == 0 )
+  if ( dict->getWordCount() == 0 ) {
     ui.headwordsButton->setVisible( false );
-  else
+  }
+  else {
     ui.buttonsLayout->insertSpacerItem( 0, new QSpacerItem( 40, 20, QSizePolicy::Expanding ) );
+  }
 
   std::vector< std::string > const & filenames = dict->getDictionaryFilenames();
 
@@ -49,8 +52,9 @@ void DictInfo::showInfo( sptr< Dictionary::Class > dict )
     info.remove( QRegularExpression( R"(<link[^>]*>)", QRegularExpression::CaseInsensitiveOption ) );
     ui.infoLabel->setHtml( info );
   }
-  else
+  else {
     ui.infoLabel->clear();
+  }
 
   setWindowIcon( dict->getIcon() );
 }

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -35,8 +35,9 @@ static QString elideDictName( QString const & name )
 
   int const maxSize = 33;
 
-  if ( name.size() <= maxSize )
+  if ( name.size() <= maxSize ) {
     return name;
+  }
 
   int const pieceSize = maxSize / 2 - 1;
 
@@ -131,16 +132,18 @@ void DictionaryBar::showContextMenu( QContextMenuEvent * event, bool extended )
       infoAction = menu.addAction( tr( "Dictionary info" ) );
 
       if ( pDict->isLocalDictionary() ) {
-        if ( pDict->getWordCount() > 0 )
+        if ( pDict->getWordCount() > 0 ) {
           headwordsAction = menu.addAction( tr( "Dictionary headwords" ) );
+        }
 
         openDictFolderAction = menu.addAction( tr( "Open dictionary folder" ) );
       }
     }
   }
 
-  if ( !dictActions.empty() )
+  if ( !dictActions.empty() ) {
     menu.addSeparator();
+  }
 
   unsigned refsAdded = 0;
 
@@ -195,10 +198,12 @@ void DictionaryBar::showContextMenu( QContextMenuEvent * event, bool extended )
     showContextMenu( event, true );
   }
 
-  if ( result == editAction )
+  if ( result == editAction ) {
     emit editGroupRequested();
-  else if ( result && result->data().value< void * >() )
+  }
+  else if ( result && result->data().value< void * >() ) {
     ( (QAction *)( result->data().value< void * >() ) )->trigger();
+  }
 
   event->accept();
 }
@@ -207,8 +212,9 @@ void DictionaryBar::mutedDictionariesChanged()
 {
   //GD_DPRINTF( "Muted dictionaries changed\n" );
 
-  if ( !mutedDictionaries )
+  if ( !mutedDictionaries ) {
     return;
+  }
 
   // Update actions
 
@@ -217,8 +223,9 @@ void DictionaryBar::mutedDictionariesChanged()
   for ( const auto & dictAction : dictActions ) {
     bool const isUnmuted = !mutedDictionaries->contains( dictAction->data().toString() );
 
-    if ( isUnmuted != dictAction->isChecked() )
+    if ( isUnmuted != dictAction->isChecked() ) {
       dictAction->setChecked( isUnmuted );
+    }
   }
 
   setUpdatesEnabled( true );
@@ -226,13 +233,15 @@ void DictionaryBar::mutedDictionariesChanged()
 
 void DictionaryBar::actionWasTriggered( QAction * action )
 {
-  if ( !mutedDictionaries )
+  if ( !mutedDictionaries ) {
     return;
+  }
 
   QString const id = action->data().toString();
 
-  if ( id.isEmpty() )
+  if ( id.isEmpty() ) {
     return; // Some weird action, not our button
+  }
 
   if ( QApplication::keyboardModifiers() & ( Qt::ControlModifier | Qt::ShiftModifier ) ) {
     // Ctrl ,solo mode with single dictionary
@@ -266,18 +275,21 @@ void DictionaryBar::actionWasTriggered( QAction * action )
       }
 
       if ( isSolo ) {
-        for ( const auto & dictAction : dictActions )
+        for ( const auto & dictAction : dictActions ) {
           mutedDictionaries->remove( dictAction->data().toString() );
+        }
       }
       else {
         // Make dictionary solo
         for ( const auto & dictAction : dictActions ) {
           QString const dictId = dictAction->data().toString();
 
-          if ( dictId == id )
+          if ( dictId == id ) {
             mutedDictionaries->remove( dictId );
-          else
+          }
+          else {
             mutedDictionaries->insert( dictId );
+          }
         }
       }
     }
@@ -309,8 +321,9 @@ void DictionaryBar::actionWasTriggered( QAction * action )
 
 void DictionaryBar::dictsPaneClicked( const QString & id )
 {
-  if ( !isVisible() )
+  if ( !isVisible() ) {
     return;
+  }
 
   for ( const auto & dictAction : dictActions ) {
     QString const dictId = dictAction->data().toString();

--- a/src/ui/editdictionaries.cc
+++ b/src/ui/editdictionaries.cc
@@ -90,8 +90,9 @@ void EditDictionaries::save( bool rebuildGroups )
   const Config::Group newOrder    = orderAndProps->getCurrentDictionaryOrder();
   const Config::Group newInactive = orderAndProps->getCurrentInactiveDictionaries();
 
-  if ( isSourcesChanged() )
+  if ( isSourcesChanged() ) {
     acceptChangedSources( rebuildGroups );
+  }
 
   if ( origCfg.groups != newGroups || origCfg.dictionaryOrder != newOrder
        || origCfg.inactiveDictionaries != newInactive ) {
@@ -110,8 +111,9 @@ void EditDictionaries::accept()
 
 void EditDictionaries::currentChanged( int index )
 {
-  if ( index == -1 || !isVisible() )
+  if ( index == -1 || !isVisible() ) {
     return; // Sent upon the construction/destruction
+  }
   qDebug() << ui.tabs->currentWidget()->objectName();
   if ( lastTabName.isEmpty() || lastTabName == "Sources" ) {
     // We're switching away from the Sources tab -- if its contents were
@@ -197,7 +199,7 @@ void EditDictionaries::acceptChangedSources( bool rebuildGroups )
   cfg.dictServers     = sources.getDictServers();
   cfg.programs        = sources.getPrograms();
 #ifndef NO_TTS_SUPPORT
-  cfg.voiceEngines    = sources.getVoiceEngines();
+  cfg.voiceEngines = sources.getVoiceEngines();
 #endif
   ui.tabs->setUpdatesEnabled( false );
   // Those hold pointers to dictionaries, we need to free them.
@@ -211,22 +213,25 @@ void EditDictionaries::acceptChangedSources( bool rebuildGroups )
   // If no changes to groups were made, update the original data
   const bool noGroupEdits = ( origCfg.groups == savedGroups );
 
-  if ( noGroupEdits )
+  if ( noGroupEdits ) {
     savedGroups = cfg.groups;
+  }
 
   Instances::updateNames( savedGroups, dictionaries );
 
   const bool noOrderEdits = ( origCfg.dictionaryOrder == savedOrder );
 
-  if ( noOrderEdits )
+  if ( noOrderEdits ) {
     savedOrder = cfg.dictionaryOrder;
+  }
 
   Instances::updateNames( savedOrder, dictionaries );
 
   const bool noInactiveEdits = ( origCfg.inactiveDictionaries == savedInactive );
 
-  if ( noInactiveEdits )
+  if ( noInactiveEdits ) {
     savedInactive = cfg.inactiveDictionaries;
+  }
 
   Instances::updateNames( savedInactive, dictionaries );
 
@@ -242,14 +247,17 @@ void EditDictionaries::acceptChangedSources( bool rebuildGroups )
     connect( groups, &Groups::showDictionaryInfo, this, &EditDictionaries::showDictionaryInfo );
     connect( orderAndProps, &OrderAndProps::showDictionaryHeadwords, this, &EditDictionaries::showDictionaryHeadwords );
 
-    if ( noGroupEdits )
+    if ( noGroupEdits ) {
       origCfg.groups = groups->getGroups();
+    }
 
-    if ( noOrderEdits )
+    if ( noOrderEdits ) {
       origCfg.dictionaryOrder = orderAndProps->getCurrentDictionaryOrder();
+    }
 
-    if ( noInactiveEdits )
+    if ( noInactiveEdits ) {
       origCfg.inactiveDictionaries = orderAndProps->getCurrentInactiveDictionaries();
+    }
   }
   ui.tabs->setUpdatesEnabled( true );
 }

--- a/src/ui/favoritespanewidget.cc
+++ b/src/ui/favoritespanewidget.cc
@@ -56,8 +56,9 @@ void FavoritesPaneWidget::setUp( Config::Class * cfg, QMenu * menu )
   m_favoritesMenu = new QMenu( this );
   m_separator     = m_favoritesMenu->addSeparator();
   QListIterator< QAction * > actionsIter( menu->actions() );
-  while ( actionsIter.hasNext() )
+  while ( actionsIter.hasNext() ) {
     m_favoritesMenu->addAction( actionsIter.next() );
+  }
 
   // Make the favorites pane's titlebar
 
@@ -84,8 +85,9 @@ void FavoritesPaneWidget::setUp( Config::Class * cfg, QMenu * menu )
 
   QAbstractItemModel * oldModel = m_favoritesTree->model();
   m_favoritesTree->setModel( m_favoritesModel );
-  if ( oldModel )
+  if ( oldModel ) {
     oldModel->deleteLater();
+  }
 
   connect( m_favoritesTree, &QTreeView::expanded, m_favoritesModel, &FavoritesModel::itemExpanded );
 
@@ -123,8 +125,9 @@ void FavoritesPaneWidget::setUp( Config::Class * cfg, QMenu * menu )
 
 FavoritesPaneWidget::~FavoritesPaneWidget()
 {
-  if ( listItemDelegate )
+  if ( listItemDelegate ) {
     delete listItemDelegate;
+  }
 }
 
 bool FavoritesPaneWidget::eventFilter( QObject * obj, QEvent * ev )
@@ -163,8 +166,9 @@ void FavoritesPaneWidget::deleteSelectedItems()
                     tr( "All selected items will be deleted. Continue?" ),
                     QMessageBox::Yes | QMessageBox::No );
     mb.exec();
-    if ( mb.result() != QMessageBox::Yes )
+    if ( mb.result() != QMessageBox::Yes ) {
       return;
+    }
   }
 
   m_favoritesModel->removeItemsForIndexes( selectedIdxs );
@@ -197,8 +201,9 @@ void FavoritesPaneWidget::onSelectionChanged( const QItemSelection & selection, 
 {
   Q_UNUSED( deselected )
 
-  if ( m_favoritesTree->selectionModel()->selectedIndexes().size() != 1 || selection.indexes().isEmpty() )
+  if ( m_favoritesTree->selectionModel()->selectedIndexes().size() != 1 || selection.indexes().isEmpty() ) {
     return;
+  }
 
   itemSelectionChanged = true;
   emitFavoritesItemRequested( selection.indexes().front() );
@@ -222,24 +227,29 @@ void FavoritesPaneWidget::emitFavoritesItemRequested( QModelIndex const & idx )
   QString headword = m_favoritesModel->data( idx, Qt::DisplayRole ).toString();
   QString path     = m_favoritesModel->pathToItem( idx );
 
-  if ( !headword.isEmpty() )
+  if ( !headword.isEmpty() ) {
     emit favoritesItemRequested( headword, path );
+  }
 }
 
 void FavoritesPaneWidget::addFolder()
 {
   QModelIndexList selectedIdx = m_favoritesTree->selectionModel()->selectedIndexes();
-  if ( selectedIdx.size() > 1 )
+  if ( selectedIdx.size() > 1 ) {
     return;
+  }
 
   QModelIndex folderIdx;
-  if ( selectedIdx.size() )
+  if ( selectedIdx.size() ) {
     folderIdx = m_favoritesModel->addNewFolder( selectedIdx.front() );
-  else
+  }
+  else {
     folderIdx = m_favoritesModel->addNewFolder( QModelIndex() );
+  }
 
-  if ( folderIdx.isValid() )
+  if ( folderIdx.isValid() ) {
     m_favoritesTree->edit( folderIdx );
+  }
 }
 
 void FavoritesPaneWidget::addHeadword( QString const & path, QString const & headword )
@@ -325,8 +335,9 @@ void TreeItem::appendChild( TreeItem * item )
 
 void TreeItem::insertChild( int row, TreeItem * item )
 {
-  if ( row > childItems.count() )
+  if ( row > childItems.count() ) {
     row = childItems.count();
+  }
   childItems.insert( row, item );
 }
 
@@ -337,8 +348,9 @@ TreeItem * TreeItem::child( int row ) const
 
 void TreeItem::deleteChild( int row )
 {
-  if ( row < 0 || row >= childItems.count() )
+  if ( row < 0 || row >= childItems.count() ) {
     return;
+  }
 
   TreeItem * it = childItems.at( row );
   childItems.removeAt( row );
@@ -362,8 +374,9 @@ void TreeItem::setData( const QVariant & newData )
 
 int TreeItem::row() const
 {
-  if ( parentItem )
+  if ( parentItem ) {
     return parentItem->childItems.indexOf( const_cast< TreeItem * >( this ) );
+  }
 
   return 0;
 }
@@ -376,10 +389,12 @@ TreeItem * TreeItem::parent()
 Qt::ItemFlags TreeItem::flags() const
 {
   Qt::ItemFlags f = Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsDragEnabled;
-  if ( m_type == Folder )
+  if ( m_type == Folder ) {
     f |= Qt::ItemIsEditable | Qt::ItemIsDropEnabled;
-  else if ( m_type == Root )
+  }
+  else if ( m_type == Root ) {
     f |= Qt::ItemIsDropEnabled;
+  }
 
   return f;
 }
@@ -390,8 +405,9 @@ QString TreeItem::fullPath() const
   QString path;
   TreeItem * par = parentItem;
   for ( ;; ) {
-    if ( !par )
+    if ( !par ) {
       break;
+    }
     path = par->data().toString() + "/" + path;
     par  = par->parentItem;
   }
@@ -403,8 +419,9 @@ TreeItem * TreeItem::duplicateItem( TreeItem * newParent ) const
   TreeItem * newItem = new TreeItem( itemData, newParent, m_type );
   if ( m_type == Folder ) {
     QList< TreeItem * >::const_iterator it = childItems.begin();
-    for ( ; it != childItems.end(); ++it )
+    for ( ; it != childItems.end(); ++it ) {
       newItem->appendChild( ( *it )->duplicateItem( newItem ) );
+    }
   }
   return newItem;
 }
@@ -413,10 +430,12 @@ bool TreeItem::haveAncestor( TreeItem * item )
 {
   TreeItem * par = parentItem;
   for ( ;; ) {
-    if ( !par )
+    if ( !par ) {
       break;
-    if ( par == item )
+    }
+    if ( par == item ) {
       return true;
+    }
     par = par->parent();
   }
   return false;
@@ -427,10 +446,12 @@ bool TreeItem::haveSameItem( TreeItem * item, bool allowSelf )
   QList< TreeItem * >::const_iterator it = childItems.begin();
   QString name                           = item->data().toString();
   for ( ; it != childItems.end(); ++it ) {
-    if ( *it == item && !allowSelf )
+    if ( *it == item && !allowSelf ) {
       return true;
-    if ( ( *it )->data().toString() == name && ( *it )->type() == item->type() && ( *it ) != item )
+    }
+    if ( ( *it )->data().toString() == name && ( *it )->type() == item->type() && ( *it ) != item ) {
       return true;
+    }
   }
 
   return false;
@@ -468,8 +489,9 @@ FavoritesModel::FavoritesModel( QString favoritesFilename, QObject * parent ):
 
 FavoritesModel::~FavoritesModel()
 {
-  if ( rootItem )
+  if ( rootItem ) {
     delete rootItem;
+  }
 }
 
 Qt::ItemFlags FavoritesModel::flags( const QModelIndex & idx ) const
@@ -491,33 +513,38 @@ QModelIndex FavoritesModel::index( int row, int column, const QModelIndex & pare
   TreeItem * parentItem = getItem( parentIdx );
 
   TreeItem * childItem = parentItem->child( row );
-  if ( childItem )
+  if ( childItem ) {
     return createIndex( row, column, childItem );
+  }
 
   return QModelIndex();
 }
 
 QModelIndex FavoritesModel::parent( const QModelIndex & index ) const
 {
-  if ( !index.isValid() )
+  if ( !index.isValid() ) {
     return QModelIndex();
+  }
 
   TreeItem * childItem = getItem( index );
-  if ( childItem == rootItem )
+  if ( childItem == rootItem ) {
     return QModelIndex();
+  }
 
   TreeItem * parentItem = childItem->parent();
 
-  if ( parentItem == rootItem )
+  if ( parentItem == rootItem ) {
     return QModelIndex();
+  }
 
   return createIndex( parentItem->row(), 0, parentItem );
 }
 
 int FavoritesModel::rowCount( const QModelIndex & parent ) const
 {
-  if ( parent.column() > 0 )
+  if ( parent.column() > 0 ) {
     return 0;
+  }
 
   TreeItem * parentItem = getItem( parent );
 
@@ -535,8 +562,9 @@ bool FavoritesModel::removeRows( int row, int count, const QModelIndex & parent 
 
   beginRemoveRows( parent, row, row + count - 1 );
 
-  for ( int i = 0; i < count; i++ )
+  for ( int i = 0; i < count; i++ ) {
     parentItem->deleteChild( row );
+  }
 
   endRemoveRows();
 
@@ -547,8 +575,9 @@ bool FavoritesModel::removeRows( int row, int count, const QModelIndex & parent 
 
 bool FavoritesModel::setData( const QModelIndex & index, const QVariant & value, int role )
 {
-  if ( role != Qt::EditRole || !index.isValid() || value.toString().isEmpty() )
+  if ( role != Qt::EditRole || !index.isValid() || value.toString().isEmpty() ) {
     return false;
+  }
 
   QModelIndex parentIdx = parent( index );
   if ( findItemInFolder( value.toString(), TreeItem::Folder, parentIdx ).isValid() ) {
@@ -566,25 +595,29 @@ bool FavoritesModel::setData( const QModelIndex & index, const QVariant & value,
 
 QVariant FavoritesModel::data( QModelIndex const & index, int role ) const
 {
-  if ( !index.isValid() )
+  if ( !index.isValid() ) {
     return QVariant();
+  }
 
   TreeItem * item = getItem( index );
-  if ( item == rootItem )
+  if ( item == rootItem ) {
     return QVariant();
+  }
 
   if ( role == Qt::DisplayRole || role == Qt::ToolTipRole ) {
     return item->data();
   }
   else if ( role == Qt::DecorationRole ) {
-    if ( item->type() == TreeItem::Folder || item->type() == TreeItem::Root )
+    if ( item->type() == TreeItem::Folder || item->type() == TreeItem::Root ) {
       return QIcon( ":/icons/folder.svg" );
+    }
 
     return QVariant();
   }
   if ( role == Qt::EditRole ) {
-    if ( item->type() == TreeItem::Folder )
+    if ( item->type() == TreeItem::Folder ) {
       return item->data();
+    }
 
     return QVariant();
   }
@@ -603,8 +636,9 @@ void FavoritesModel::readData()
 
   beginResetModel();
 
-  if ( rootItem )
+  if ( rootItem ) {
     delete rootItem;
+  }
 
   rootItem = new TreeItem( QVariant(), 0, TreeItem::Root );
 
@@ -632,8 +666,9 @@ void FavoritesModel::readData()
                      % QDateTime::currentDateTime().toString( QStringLiteral( "yyyyMMdd_HHmmss" ) )
                      % QStringLiteral( ".bad" ) );
   }
-  else
+  else {
     favoritesFile.close();
+  }
 
   QDomNode rootNode = dom.documentElement();
   addFolder( rootItem, rootNode );
@@ -645,8 +680,9 @@ void FavoritesModel::readData()
 
 void FavoritesModel::saveData()
 {
-  if ( !dirty )
+  if ( !dirty ) {
     return;
+  }
 
   QSaveFile tmpFile( m_favoritesFilename );
   if ( !tmpFile.open( QFile::WriteOnly ) ) {
@@ -777,14 +813,16 @@ bool FavoritesModel::dropMimeData(
       if ( mimeData ) {
         QModelIndexList const & list = mimeData->getIndexesList();
 
-        if ( list.isEmpty() )
+        if ( list.isEmpty() ) {
           return false;
+        }
 
         TreeItem * parentItem = getItem( par );
         QModelIndex parentIdx = par;
 
-        if ( row < 0 )
+        if ( row < 0 ) {
           row = 0;
+        }
 
         QList< QModelIndex >::const_iterator it = list.begin();
         QList< TreeItem * > movedItems;
@@ -792,8 +830,9 @@ bool FavoritesModel::dropMimeData(
           TreeItem * item = getItem( *it );
 
           // Check if we can copy/move this item
-          if ( parentItem->haveAncestor( item ) || parentItem->haveSameItem( item, action == Qt::MoveAction ) )
+          if ( parentItem->haveAncestor( item ) || parentItem->haveSameItem( item, action == Qt::MoveAction ) ) {
             return false;
+          }
 
           movedItems.append( item );
         }
@@ -822,8 +861,9 @@ QModelIndex FavoritesModel::findItemInFolder( const QString & itemName, int item
   TreeItem * parentItem = getItem( parentIdx );
   for ( int i = 0; i < parentItem->childCount(); i++ ) {
     TreeItem * item = parentItem->child( i );
-    if ( item->data().toString() == itemName && item->type() == itemType )
+    if ( item->data().toString() == itemName && item->type() == itemType ) {
       return createIndex( i, 0, item );
+    }
   }
   return QModelIndex();
 }
@@ -832,8 +872,9 @@ TreeItem * FavoritesModel::getItem( const QModelIndex & index ) const
 {
   if ( index.isValid() ) {
     TreeItem * item = static_cast< TreeItem * >( index.internalPointer() );
-    if ( item )
+    if ( item ) {
       return item;
+    }
   }
   return rootItem;
 }
@@ -844,10 +885,12 @@ QStringList FavoritesModel::getTextForIndexes( const QModelIndexList & idxList )
   QModelIndexList::const_iterator it = idxList.begin();
   for ( ; it != idxList.end(); ++it ) {
     TreeItem * item = getItem( *it );
-    if ( item->type() == TreeItem::Word )
+    if ( item->type() == TreeItem::Word ) {
       list.append( item->data().toString() );
-    else
+    }
+    else {
       list.append( item->getTextFromAllChilds() );
+    }
   }
   return list;
 }
@@ -863,8 +906,9 @@ void FavoritesModel::removeItemsForIndexes( const QModelIndexList & idxList )
   QModelIndexList::const_iterator it = idxList.begin();
   for ( ; it != idxList.end(); ++it ) {
     int n = level( *it );
-    if ( n > lowestLevel )
+    if ( n > lowestLevel ) {
       lowestLevel = n;
+    }
     itemsToDelete[ n ].append( *it );
   }
 
@@ -888,10 +932,12 @@ void FavoritesModel::removeItemsForIndexes( const QModelIndexList & idxList )
 QModelIndex FavoritesModel::addNewFolder( const QModelIndex & idx )
 {
   QModelIndex parentIdx;
-  if ( idx.isValid() )
+  if ( idx.isValid() ) {
     parentIdx = parent( idx );
-  else
+  }
+  else {
     parentIdx = idx;
+  }
 
   QString baseName = QString::fromLatin1( "New folder" );
 
@@ -902,11 +948,13 @@ QModelIndex FavoritesModel::addNewFolder( const QModelIndex & idx )
     int i;
     for ( i = 1; i < 1000; i++ ) {
       name = baseName + QString::number( i );
-      if ( !findItemInFolder( name, TreeItem::Folder, parentIdx ).isValid() )
+      if ( !findItemInFolder( name, TreeItem::Folder, parentIdx ).isValid() ) {
         break;
+      }
     }
-    if ( i >= 1000 )
+    if ( i >= 1000 ) {
       return QModelIndex();
+    }
   }
 
   // Create folder with unique name
@@ -941,8 +989,9 @@ bool FavoritesModel::addNewHeadword( const QString & path, const QString & headw
 
   QStringList folders            = path.split( "/", Qt::SkipEmptyParts );
   QStringList::const_iterator it = folders.begin();
-  for ( ; it != folders.end(); ++it )
+  for ( ; it != folders.end(); ++it ) {
     parentIdx = forceFolder( *it, parentIdx );
+  }
 
   // Add headword
 
@@ -959,8 +1008,9 @@ bool FavoritesModel::removeHeadword( const QString & path, const QString & headw
   QStringList::const_iterator it = folders.begin();
   for ( ; it != folders.end(); ++it ) {
     idx = findItemInFolder( *it, TreeItem::Folder, idx );
-    if ( !idx.isValid() )
+    if ( !idx.isValid() ) {
       break;
+    }
   }
 
   if ( path.isEmpty() || idx.isValid() ) {
@@ -986,8 +1036,9 @@ bool FavoritesModel::isHeadwordPresent( const QString & path, const QString & he
   QStringList::const_iterator it = folders.begin();
   for ( ; it != folders.end(); ++it ) {
     idx = findItemInFolder( *it, TreeItem::Folder, idx );
-    if ( !idx.isValid() )
+    if ( !idx.isValid() ) {
       break;
+    }
   }
 
   if ( path.isEmpty() || idx.isValid() ) {
@@ -1001,8 +1052,9 @@ bool FavoritesModel::isHeadwordPresent( const QString & path, const QString & he
 QModelIndex FavoritesModel::forceFolder( QString const & name, const QModelIndex & parentIdx )
 {
   QModelIndex idx = findItemInFolder( name, TreeItem::Folder, parentIdx );
-  if ( idx.isValid() )
+  if ( idx.isValid() ) {
     return idx;
+  }
 
   // Folder not found, create it
   TreeItem * parentItem = getItem( parentIdx );
@@ -1021,8 +1073,9 @@ QModelIndex FavoritesModel::forceFolder( QString const & name, const QModelIndex
 bool FavoritesModel::addHeadword( const QString & word, const QModelIndex & parentIdx )
 {
   QModelIndex idx = findItemInFolder( word, TreeItem::Word, parentIdx );
-  if ( idx.isValid() )
+  if ( idx.isValid() ) {
     return false;
+  }
 
   // Headword not found, append it
   TreeItem * parentItem = getItem( parentIdx );
@@ -1054,8 +1107,9 @@ QString FavoritesModel::pathToItem( QModelIndex const & idx )
   QString path;
   QModelIndex parentIdx = parent( idx );
   while ( parentIdx.isValid() ) {
-    if ( !path.isEmpty() )
+    if ( !path.isEmpty() ) {
       path = "/" + path;
+    }
 
     path = data( parentIdx, Qt::DisplayRole ).toString() + path;
 
@@ -1098,8 +1152,9 @@ bool FavoritesModel::setDataFromXml( QString const & dataStr )
 
   beginResetModel();
 
-  if ( rootItem )
+  if ( rootItem ) {
     delete rootItem;
+  }
 
   rootItem = new TreeItem( QVariant(), 0, TreeItem::Root );
 
@@ -1119,8 +1174,9 @@ bool FavoritesModel::setDataFromTxt( QString const & dataStr )
 
   beginResetModel();
 
-  if ( rootItem )
+  if ( rootItem ) {
     delete rootItem;
+  }
 
   rootItem = new TreeItem( QVariant(), 0, TreeItem::Root );
 

--- a/src/ui/groupcombobox.cc
+++ b/src/ui/groupcombobox.cc
@@ -34,21 +34,24 @@ void GroupComboBox::fill( Instances::Groups const & groups )
 {
   unsigned prevId = 0;
 
-  if ( count() )
+  if ( count() ) {
     prevId = itemData( currentIndex() ).toUInt();
+  }
 
   clear();
 
-  for ( QMap< int, int >::iterator i = shortcuts.begin(); i != shortcuts.end(); ++i )
+  for ( QMap< int, int >::iterator i = shortcuts.begin(); i != shortcuts.end(); ++i ) {
     releaseShortcut( i.key() );
+  }
 
   shortcuts.clear();
 
   for ( unsigned x = 0; x < groups.size(); ++x ) {
     addItem( groups[ x ].makeIcon(), groups[ x ].name, groups[ x ].id );
 
-    if ( prevId == groups[ x ].id )
+    if ( prevId == groups[ x ].id ) {
       setCurrentIndex( x );
+    }
 
     // Create a shortcut
 
@@ -99,8 +102,9 @@ void GroupComboBox::setCurrentGroup( unsigned id )
 
 unsigned GroupComboBox::getCurrentGroup() const
 {
-  if ( !count() )
+  if ( !count() ) {
     return 0;
+  }
 
   return itemData( currentIndex() ).toUInt();
 }
@@ -112,20 +116,24 @@ void GroupComboBox::popupGroups()
 
 void GroupComboBox::selectNextGroup()
 {
-  if ( count() <= 1 )
+  if ( count() <= 1 ) {
     return;
+  }
   int n = currentIndex() + 1;
-  if ( n >= count() )
+  if ( n >= count() ) {
     n = 0;
+  }
   setCurrentIndex( n );
 }
 
 void GroupComboBox::selectPreviousGroup()
 {
-  if ( count() <= 1 )
+  if ( count() <= 1 ) {
     return;
+  }
   int n = currentIndex() - 1;
-  if ( n < 0 )
+  if ( n < 0 ) {
     n = count() - 1;
+  }
   setCurrentIndex( n );
 }

--- a/src/ui/groups.cc
+++ b/src/ui/groups.cc
@@ -100,8 +100,9 @@ void Groups::countChanged()
   ui.removeAllGroups->setEnabled( en );
 
   int stretch = ui.groups->count() / 5;
-  if ( stretch > 3 )
+  if ( stretch > 3 ) {
     stretch = 3;
+  }
   ui.gridLayout->setColumnStretch( 2, stretch );
 }
 
@@ -143,8 +144,9 @@ void Groups::renameCurrent()
 {
   int current = ui.groups->currentIndex();
 
-  if ( current < 0 )
+  if ( current < 0 ) {
     return;
+  }
 
   bool ok;
 
@@ -155,8 +157,9 @@ void Groups::renameCurrent()
                                         ui.groups->getCurrentGroupName(),
                                         &ok );
 
-  if ( ok )
+  if ( ok ) {
     ui.groups->renameCurrentGroup( name );
+  }
 }
 
 void Groups::removeCurrent()
@@ -215,17 +218,21 @@ void Groups::showDictInfo( QPoint const & pos )
   QVariant data =
     ui.dictionaries->getModel()->data( ui.searchLine->mapToSource( ui.dictionaries->indexAt( pos ) ), Qt::EditRole );
   QString id;
-  if ( data.canConvert< QString >() )
+  if ( data.canConvert< QString >() ) {
     id = data.toString();
+  }
 
   if ( !id.isEmpty() ) {
     vector< sptr< Dictionary::Class > > const & dicts = ui.dictionaries->getCurrentDictionaries();
     unsigned n;
-    for ( n = 0; n < dicts.size(); n++ )
-      if ( id.compare( QString::fromUtf8( dicts.at( n )->getId().c_str() ) ) == 0 )
+    for ( n = 0; n < dicts.size(); n++ ) {
+      if ( id.compare( QString::fromUtf8( dicts.at( n )->getId().c_str() ) ) == 0 ) {
         break;
-    if ( n < dicts.size() )
+      }
+    }
+    if ( n < dicts.size() ) {
       emit showDictionaryInfo( id );
+    }
   }
 }
 
@@ -242,8 +249,9 @@ void Groups::fillGroupsMenu()
     }
   }
 
-  if ( groupsListMenu->actions().size() > 1 )
+  if ( groupsListMenu->actions().size() > 1 ) {
     groupsListMenu->setActiveAction( groupsListMenu->actions().at( ui.groups->currentIndex() ) );
+  }
 }
 
 void Groups::switchToGroup( QAction * act )

--- a/src/ui/groups_widgets.cc
+++ b/src/ui/groups_widgets.cc
@@ -47,10 +47,12 @@ DictGroupWidget::DictGroupWidget( QWidget * parent,
 
   const bool usesIconData = !group.iconData.isEmpty();
 
-  if ( !usesIconData )
+  if ( !usesIconData ) {
     ui.groupIcon->addItem( tr( "From file..." ), "" );
-  else
+  }
+  else {
     ui.groupIcon->addItem( Instances::iconFromData( group.iconData ), group.icon, group.icon );
+  }
 
   for ( int x = 0; x < icons.size(); ++x ) {
     QString n( icons[ x ] );
@@ -59,12 +61,14 @@ DictGroupWidget::DictGroupWidget( QWidget * parent,
 
     ui.groupIcon->addItem( QIcon( ":/flags/" + icons[ x ] ), n, icons[ x ] );
 
-    if ( !usesIconData && icons[ x ] == group.icon )
+    if ( !usesIconData && icons[ x ] == group.icon ) {
       ui.groupIcon->setCurrentIndex( x + 2 );
+    }
   }
 
-  if ( usesIconData )
+  if ( usesIconData ) {
     ui.groupIcon->setCurrentIndex( 1 );
+  }
 
   ui.shortcut->setKeySequence( group.shortcut );
 
@@ -85,8 +89,9 @@ void DictGroupWidget::groupIconActivated( int index )
 
     QString formatList( " (" );
 
-    for ( const auto & supImageFormat : supImageFormats )
+    for ( const auto & supImageFormat : supImageFormats ) {
       formatList += "*." + QString::fromLatin1( supImageFormat ) + " ";
+    }
 
     formatList.chop( 1 );
     formatList.append( ")" );
@@ -100,8 +105,9 @@ void DictGroupWidget::groupIconActivated( int index )
     if ( !chosenFile.isEmpty() ) {
       const QIcon icon( chosenFile );
 
-      if ( icon.isNull() )
+      if ( icon.isNull() ) {
         QMessageBox::critical( this, tr( "Error" ), tr( "Can't read the specified image file." ) );
+      }
       else {
         ui.groupIcon->setItemIcon( 1, icon );
 
@@ -123,8 +129,9 @@ Config::Group DictGroupWidget::makeGroup() const
 
   const int currentIndex = ui.groupIcon->currentIndex();
 
-  if ( currentIndex == 1 ) // File
+  if ( currentIndex == 1 ) { // File
     g.iconData = ui.groupIcon->itemIcon( currentIndex );
+  }
 
   g.icon = ui.groupIcon->itemData( currentIndex ).toString();
 
@@ -139,17 +146,21 @@ void DictGroupWidget::showDictInfo( QPoint const & pos )
 {
   const QVariant data = ui.dictionaries->getModel()->data( ui.dictionaries->indexAt( pos ), Qt::EditRole );
   QString id;
-  if ( data.canConvert< QString >() )
+  if ( data.canConvert< QString >() ) {
     id = data.toString();
+  }
 
   if ( !id.isEmpty() ) {
     vector< sptr< Dictionary::Class > > const & dicts = ui.dictionaries->getCurrentDictionaries();
     unsigned n;
-    for ( n = 0; n < dicts.size(); n++ )
-      if ( id.compare( QString::fromUtf8( dicts.at( n )->getId().c_str() ) ) == 0 )
+    for ( n = 0; n < dicts.size(); n++ ) {
+      if ( id.compare( QString::fromUtf8( dicts.at( n )->getId().c_str() ) ) == 0 ) {
         break;
-    if ( n < dicts.size() )
+      }
+    }
+    if ( n < dicts.size() ) {
       emit showDictionaryInfo( id );
+    }
   }
 }
 
@@ -192,10 +203,12 @@ Qt::ItemFlags DictListModel::flags( QModelIndex const & index ) const
 {
   const Qt::ItemFlags defaultFlags = QAbstractListModel::flags( index );
 
-  if ( index.isValid() )
+  if ( index.isValid() ) {
     return Qt::ItemIsDragEnabled | defaultFlags;
-  else
+  }
+  else {
     return Qt::ItemIsDropEnabled | defaultFlags;
+  }
 }
 
 int DictListModel::rowCount( QModelIndex const & ) const
@@ -205,13 +218,15 @@ int DictListModel::rowCount( QModelIndex const & ) const
 
 QVariant DictListModel::data( QModelIndex const & index, int role ) const
 {
-  if ( index.row() < 0 )
+  if ( index.row() < 0 ) {
     return QVariant();
+  }
 
   sptr< Dictionary::Class > const & item = dictionaries[ index.row() ];
 
-  if ( !item )
+  if ( !item ) {
     return QVariant();
+  }
 
   switch ( role ) {
     case Qt::ToolTipRole: {
@@ -220,17 +235,21 @@ QVariant DictListModel::data( QModelIndex const & index, int role ) const
       const QString lfrom( Language::localizedNameForId( item->getLangFrom() ) );
       const QString lto( Language::localizedNameForId( item->getLangTo() ) );
       if ( !lfrom.isEmpty() ) {
-        if ( lfrom == lto )
+        if ( lfrom == lto ) {
           tt += "<br>" + lfrom;
-        else
+        }
+        else {
           tt += "<br>" + lfrom + " - " + lto;
+        }
       }
 
       int entries = item->getArticleCount();
-      if ( !entries )
+      if ( !entries ) {
         entries = item->getWordCount();
-      if ( entries )
+      }
+      if ( entries ) {
         tt += "<br>" + tr( "%1 entries" ).arg( entries );
+      }
 
       const std::vector< std::string > & dirs = item->getDictionaryFilenames();
 
@@ -261,8 +280,9 @@ QVariant DictListModel::data( QModelIndex const & index, int role ) const
 
 bool DictListModel::insertRows( int row, int count, const QModelIndex & parent )
 {
-  if ( isSource )
+  if ( isSource ) {
     return false;
+  }
 
   beginInsertRows( parent, row, row + count - 1 );
   dictionaries.insert( dictionaries.begin() + row, count, sptr< Dictionary::Class >() );
@@ -274,8 +294,9 @@ bool DictListModel::insertRows( int row, int count, const QModelIndex & parent )
 void DictListModel::addRow( const QModelIndex & parent, sptr< Dictionary::Class > dict )
 {
   for ( const auto & dictionary : dictionaries ) {
-    if ( dictionary->getId() == dict->getId() )
+    if ( dictionary->getId() == dict->getId() ) {
       return;
+    }
   }
 
   beginInsertRows( parent, dictionaries.size(), dictionaries.size() + 1 );
@@ -286,8 +307,9 @@ void DictListModel::addRow( const QModelIndex & parent, sptr< Dictionary::Class 
 
 bool DictListModel::removeRows( int row, int count, const QModelIndex & parent )
 {
-  if ( isSource )
+  if ( isSource ) {
     return false;
+  }
 
   beginRemoveRows( parent, row, row + count - 1 );
   dictionaries.erase( dictionaries.begin() + row, dictionaries.begin() + row + count );
@@ -298,8 +320,9 @@ bool DictListModel::removeRows( int row, int count, const QModelIndex & parent )
 
 bool DictListModel::setData( QModelIndex const & index, const QVariant & value, int role )
 {
-  if ( isSource || !allDicts || !index.isValid() || index.row() >= (int)dictionaries.size() )
+  if ( isSource || !allDicts || !index.isValid() || index.row() >= (int)dictionaries.size() ) {
     return false;
+  }
 
   if ( ( role == Qt::DisplayRole ) || ( role == Qt::DecorationRole ) ) {
     // Allow changing that, but do nothing
@@ -333,13 +356,15 @@ Qt::DropActions DictListModel::supportedDropActions() const
 
 void DictListModel::removeSelectedRows( QItemSelectionModel * source )
 {
-  if ( !source )
+  if ( !source ) {
     return;
+  }
 
   const QModelIndexList rows = source->selectedRows();
 
-  if ( !rows.count() )
+  if ( !rows.count() ) {
     return;
+  }
 
   for ( int i = rows.count() - 1; i >= 0; --i ) {
     dictionaries.erase( dictionaries.begin() + rows.at( i ).row() );
@@ -352,13 +377,15 @@ void DictListModel::removeSelectedRows( QItemSelectionModel * source )
 
 void DictListModel::addSelectedUniqueFromModel( QItemSelectionModel * source )
 {
-  if ( !source )
+  if ( !source ) {
     return;
+  }
 
   const QModelIndexList rows = source->selectedRows();
 
-  if ( !rows.count() )
+  if ( !rows.count() ) {
     return;
+  }
 
   const QSortFilterProxyModel * proxyModel = dynamic_cast< const QSortFilterProxyModel * >( source->model() );
 
@@ -371,24 +398,28 @@ void DictListModel::addSelectedUniqueFromModel( QItemSelectionModel * source )
     baseModel = dynamic_cast< const DictListModel * >( source->model() );
   }
 
-  if ( !baseModel )
+  if ( !baseModel ) {
     return;
+  }
 
   QList< std::string > list;
   QList< std::string > dicts;
-  for ( const auto & dictionarie : dictionaries )
+  for ( const auto & dictionarie : dictionaries ) {
     dicts.append( dictionarie->getId() );
+  }
 
   for ( int i = 0; i < rows.count(); i++ ) {
     QModelIndex idx = proxyModel ? proxyModel->mapToSource( rows.at( i ) ) : rows.at( i );
     std::string id  = baseModel->dictionaries.at( idx.row() )->getId();
 
-    if ( !dicts.contains( id ) )
+    if ( !dicts.contains( id ) ) {
       list.append( id );
+    }
   }
 
-  if ( list.empty() )
+  if ( list.empty() ) {
     return;
+  }
 
   for ( const auto & j : list ) {
     for ( const auto & allDict : *allDicts ) {
@@ -487,8 +518,9 @@ void DictListWidget::rowsAboutToBeRemoved( QModelIndex const & parent, int start
   // an item just before the first row to be removed, if there's one.
 
   if ( const QModelIndex current = currentIndex();
-       current.isValid() && current.row() && current.row() >= start && current.row() <= end )
+       current.isValid() && current.row() && current.row() >= start && current.row() <= end ) {
     selectionModel()->setCurrentIndex( model.index( current.row() - 1, 0, parent ), QItemSelectionModel::NoUpdate );
+  }
 
   QListView::rowsAboutToBeRemoved( parent, start, end );
 }
@@ -567,8 +599,9 @@ DictListModel * DictGroupsWidget::getModelAt( int current ) const
 {
   if ( current >= 0 && current < count() ) {
     const auto w = static_cast< DictGroupWidget * >( widget( current ) );
-    if ( !w )
+    if ( !w ) {
       return nullptr;
+    }
     return w->getModel();
   }
 
@@ -578,16 +611,18 @@ DictListModel * DictGroupsWidget::getModelAt( int current ) const
 int DictGroupsWidget::getDictionaryCountAt( int current ) const
 {
   const auto model = getModelAt( current );
-  if ( !model )
+  if ( !model ) {
     return 0;
+  }
   return model->getCurrentDictionaries().size();
 }
 
 std::vector< sptr< Dictionary::Class > > DictGroupsWidget::getDictionaryAt( int current ) const
 {
   const auto model = getModelAt( current );
-  if ( !model )
+  if ( !model ) {
     return {};
+  }
   return model->getCurrentDictionaries();
 }
 
@@ -606,8 +641,9 @@ QItemSelectionModel * DictGroupsWidget::getCurrentSelectionModel() const
 
 int DictGroupsWidget::addNewGroup( QString const & name )
 {
-  if ( !allDicts )
+  if ( !allDicts ) {
     return 0;
+  }
 
   Config::Group newGroup;
 
@@ -627,18 +663,20 @@ int DictGroupsWidget::addNewGroup( QString const & name )
 
 int DictGroupsWidget::addUniqueGroup( const QString & name )
 {
-  for ( int n = 0; n < count(); n++ )
+  for ( int n = 0; n < count(); n++ ) {
     if ( tabText( n ) == name ) {
       return n;
     }
+  }
 
   return addNewGroup( name );
 }
 
 void DictGroupsWidget::addAutoGroups()
 {
-  if ( !activeDicts )
+  if ( !activeDicts ) {
     return;
+  }
 
   if ( QMessageBox::information( this,
                                  tr( "Confirmation" ),
@@ -646,8 +684,9 @@ void DictGroupsWidget::addAutoGroups()
                                      "based on language pairs?" ),
                                  QMessageBox::Yes,
                                  QMessageBox::Cancel )
-       != QMessageBox::Yes )
+       != QMessageBox::Yes ) {
     return;
+  }
 
   QMap< QString, QList< sptr< Dictionary::Class > > > dictMap;
   QMap< QString, QList< sptr< Dictionary::Class > > > morphoMap;
@@ -662,8 +701,8 @@ void DictGroupsWidget::addAutoGroups()
 
       const std::pair< quint32, quint32 > ids =
         LangCoder::findLangIdPairFromName( QString::fromUtf8( dict->getName().c_str() ) );
-      idFrom                              = ids.first;
-      idTo                                = ids.second;
+      idFrom = ids.first;
+      idTo   = ids.second;
     }
 
     QString name( tr( "Unassigned" ) );
@@ -705,11 +744,13 @@ void DictGroupsWidget::addAutoGroups()
 
     // add dictionaries into the current group
     QList< sptr< Dictionary::Class > > const vd = dictMap[ gr ];
-    DictListModel * model                   = getModelAt( idx );
-    if ( !model )
+    DictListModel * model                       = getModelAt( idx );
+    if ( !model ) {
       continue;
-    for ( int i = 0; i < vd.count(); i++ )
+    }
+    for ( int i = 0; i < vd.count(); i++ ) {
       model->addRow( QModelIndex(), vd.at( i ) );
+    }
   }
 }
 
@@ -846,8 +887,9 @@ void DictGroupsWidget::groupsByMetadata()
 
   for ( const auto & dict : *activeDicts ) {
     auto baseDir = dict->getContainingFolder();
-    if ( baseDir.isEmpty() )
+    if ( baseDir.isEmpty() ) {
       continue;
+    }
 
     auto filePath = Utils::Path::combine( baseDir, "metadata.toml" );
 
@@ -873,8 +915,9 @@ QString DictGroupsWidget::getCurrentGroupName() const
 {
   const int current = currentIndex();
 
-  if ( current >= 0 )
+  if ( current >= 0 ) {
     return Utils::unescapeAmps( tabText( current ) );
+  }
 
   return {};
 }
@@ -883,8 +926,9 @@ void DictGroupsWidget::renameCurrentGroup( QString const & name )
 {
   const int current = currentIndex();
 
-  if ( current >= 0 )
+  if ( current >= 0 ) {
     setTabText( current, Utils::escapeAmps( name ) );
+  }
 }
 
 void DictGroupsWidget::removeCurrentGroup()
@@ -907,15 +951,17 @@ void DictGroupsWidget::removeAllGroups()
 
 void DictGroupsWidget::combineGroups( int source, int target )
 {
-  if ( source < 0 || source >= count() || target < 0 || target >= count() )
+  if ( source < 0 || source >= count() || target < 0 || target >= count() ) {
     return;
+  }
 
   vector< sptr< Dictionary::Class > > const & dicts = getDictionaryAt( source );
 
   const auto model = getModelAt( target );
 
-  if ( !model )
+  if ( !model ) {
     return;
+  }
 
   disconnect( model, &DictListModel::contentChanged, this, &DictGroupsWidget::tabDataChanged );
 
@@ -933,11 +979,13 @@ void DictGroupsWidget::combineGroups( int source, int target )
 void DictGroupsWidget::contextMenu( QPoint const & pos )
 {
   const int clickedGroup = tabBar()->tabAt( pos );
-  if ( clickedGroup < 0 )
+  if ( clickedGroup < 0 ) {
     return;
+  }
   const QString name = tabText( clickedGroup );
-  if ( name.length() != 7 || name.mid( 2, 3 ) != " - " )
+  if ( name.length() != 7 || name.mid( 2, 3 ) != " - " ) {
     return;
+  }
 
   QMenu menu( this );
 
@@ -1026,8 +1074,9 @@ void DictGroupsWidget::contextMenu( QPoint const & pos )
 
     for ( int i = 0; i < count(); i++ ) {
       QString str = tabText( i );
-      if ( str.length() == 7 && str.mid( 2, 3 ) == " - " && str.startsWith( grLeft ) )
+      if ( str.length() == 7 && str.mid( 2, 3 ) == " - " && str.startsWith( grLeft ) ) {
         combineGroups( i, targetGroup );
+      }
     }
 
     setCurrentIndex( targetGroup );
@@ -1037,8 +1086,9 @@ void DictGroupsWidget::contextMenu( QPoint const & pos )
 
     for ( int i = 0; i < count(); i++ ) {
       QString str = tabText( i );
-      if ( str.length() == 7 && str.mid( 2, 3 ) == " - " && str.endsWith( grRight ) )
+      if ( str.length() == 7 && str.mid( 2, 3 ) == " - " && str.endsWith( grRight ) ) {
         combineGroups( i, targetGroup );
+      }
     }
 
     setCurrentIndex( targetGroup );
@@ -1047,9 +1097,11 @@ void DictGroupsWidget::contextMenu( QPoint const & pos )
     targetGroup       = addUniqueGroup( name + " - " + grLeft );
     const QString str = grRight + " - " + grLeft;
 
-    for ( int i = 0; i < count(); i++ )
-      if ( tabText( i ) == name || tabText( i ) == str )
+    for ( int i = 0; i < count(); i++ ) {
+      if ( tabText( i ) == name || tabText( i ) == str ) {
         combineGroups( i, targetGroup );
+      }
+    }
 
     setCurrentIndex( targetGroup );
   }
@@ -1059,8 +1111,9 @@ void DictGroupsWidget::contextMenu( QPoint const & pos )
 
     for ( int i = 0; i < count(); i++ ) {
       QString str = tabText( i );
-      if ( str.length() == 7 && str.mid( 2, 3 ) == " - " && ( str.startsWith( grBase ) || str.endsWith( grBase ) ) )
+      if ( str.length() == 7 && str.mid( 2, 3 ) == " - " && ( str.startsWith( grBase ) || str.endsWith( grBase ) ) ) {
         combineGroups( i, targetGroup );
+      }
     }
 
     setCurrentIndex( targetGroup );

--- a/src/ui/historypanewidget.cc
+++ b/src/ui/historypanewidget.cc
@@ -38,8 +38,9 @@ void HistoryPaneWidget::setUp( Config::Class * cfg, History * history, QMenu * m
   m_historyMenu = new QMenu( this );
   m_separator   = m_historyMenu->addSeparator();
   QListIterator< QAction * > actionsIter( menu->actions() );
-  while ( actionsIter.hasNext() )
+  while ( actionsIter.hasNext() ) {
     m_historyMenu->addAction( actionsIter.next() );
+  }
 
   // Make the history pane's titlebar
 
@@ -89,8 +90,9 @@ void HistoryPaneWidget::setUp( Config::Class * cfg, History * history, QMenu * m
 
 HistoryPaneWidget::~HistoryPaneWidget()
 {
-  if ( listItemDelegate )
+  if ( listItemDelegate ) {
     delete listItemDelegate;
+  }
 }
 
 void HistoryPaneWidget::copySelectedItems()
@@ -132,8 +134,9 @@ void HistoryPaneWidget::deleteSelectedItems()
   std::sort( idxsToDelete.begin(), idxsToDelete.end(), std::greater< int >() );
 
   QListIterator< int > idxs( idxsToDelete );
-  while ( idxs.hasNext() )
+  while ( idxs.hasNext() ) {
     m_history->removeItem( idxs.next() );
+  }
 
   if ( idxsToDelete.size() == 1 ) {
     // We've just removed a single entry,
@@ -183,8 +186,9 @@ void HistoryPaneWidget::onSelectionChanged( const QItemSelection & selection, co
 {
   Q_UNUSED( deselected );
 
-  if ( selection.empty() )
+  if ( selection.empty() ) {
     return;
+  }
 
   itemSelectionChanged = true;
   emitHistoryItemRequested( selection.front().topLeft() );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -173,8 +173,9 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   starIcon( ":/icons/star.svg" ),
   blueStarIcon( ":/icons/star_blue.svg" )
 {
-  if ( QThreadPool::globalInstance()->maxThreadCount() < MIN_THREAD_COUNT )
+  if ( QThreadPool::globalInstance()->maxThreadCount() < MIN_THREAD_COUNT ) {
     QThreadPool::globalInstance()->setMaxThreadCount( MIN_THREAD_COUNT );
+  }
 
 #ifndef QT_NO_SSL
   QThreadPool::globalInstance()->start( new InitSSLRunnable );
@@ -182,7 +183,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   GlobalBroadcaster::instance()->setPreference( &cfg.preferences );
 
-  localSchemeHandler = new LocalSchemeHandler( articleNetMgr, this );
+  localSchemeHandler     = new LocalSchemeHandler( articleNetMgr, this );
   QStringList htmlScheme = { "gdlookup", "bword", "entry" };
   for ( const auto & localScheme : htmlScheme ) {
     QWebEngineProfile::defaultProfile()->installUrlSchemeHandler( localScheme.toLatin1(), localSchemeHandler );
@@ -552,14 +553,16 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   Instances::Group const * igrp = groupInstances.findGroup( cfg.lastMainGroupId );
   if ( cfg.lastMainGroupId == Instances::Group::AllGroupId ) {
-    if ( igrp )
+    if ( igrp ) {
       igrp->checkMutedDictionaries( &cfg.mutedDictionaries );
+    }
     dictionaryBar.setMutedDictionaries( &cfg.mutedDictionaries );
   }
   else {
     Config::Group * grp = cfg.getGroup( cfg.lastMainGroupId );
-    if ( igrp && grp )
+    if ( igrp && grp ) {
       igrp->checkMutedDictionaries( &grp->mutedDictionaries );
+    }
     dictionaryBar.setMutedDictionaries( grp ? &grp->mutedDictionaries : nullptr );
   }
   GlobalBroadcaster::instance()->currentGroupId = cfg.lastMainGroupId;
@@ -714,8 +717,9 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
            &PronounceEngine::emitAudio,
            this,
            [ this ]( auto audioUrl ) {
-             if ( !isActiveWindow() )
+             if ( !isActiveWindow() ) {
                return;
+             }
              auto view = getCurrentArticleView();
              if ( ( cfg.preferences.pronounceOnLoadMain ) && view != nullptr ) {
 
@@ -776,10 +780,12 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   // restore should be called after all UI initialized but not necessarily after show()
   // This must be called before show() as of Qt6.5 on Windows, not sure if it is a bug
   // Due to a bug of WebEngine, this also must be called after WebEngine has a view loaded https://bugreports.qt.io/browse/QTBUG-115074
-  if ( cfg.mainWindowState.size() && !cfg.resetState )
+  if ( cfg.mainWindowState.size() && !cfg.resetState ) {
     restoreState( cfg.mainWindowState );
-  if ( cfg.mainWindowGeometry.size() )
+  }
+  if ( cfg.mainWindowGeometry.size() ) {
     restoreGeometry( cfg.mainWindowGeometry );
+  }
 
   // Show window unless it is configured not to
   if ( !cfg.preferences.enableTrayIcon || !cfg.preferences.startToTray ) {
@@ -821,8 +827,9 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
     }
 
 #ifdef Q_OS_MAC
-    if ( !MacMouseOver::isAXAPIEnabled() )
+    if ( !MacMouseOver::isAXAPIEnabled() ) {
       mainStatusBar->showMessage( tr( "Accessibility API is not enabled" ), 10000, QPixmap( ":/icons/error.svg" ) );
+    }
 
     if ( on ) {
       macClipboard->start();
@@ -877,8 +884,9 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   updateStatusLine();
 
 #ifdef Q_OS_MAC
-  if ( cfg.preferences.startWithScanPopupOn && !MacMouseOver::isAXAPIEnabled() )
+  if ( cfg.preferences.startWithScanPopupOn && !MacMouseOver::isAXAPIEnabled() ) {
     mainStatusBar->showMessage( tr( "Accessibility API is not enabled" ), 10000, QPixmap( ":/icons/error.svg" ) );
+  }
 #endif
 
   wasMaximized = isMaximized();
@@ -977,17 +985,19 @@ void MainWindow::updateMatchResults( bool finished )
 
     refreshTranslateLine();
 
-    if ( !wordFinder.getErrorString().isEmpty() )
+    if ( !wordFinder.getErrorString().isEmpty() ) {
       emit showStatusBarMessage( tr( "WARNING: %1" ).arg( wordFinder.getErrorString() ),
                                  20000,
                                  QPixmap( ":/icons/error.svg" ) );
+    }
   }
 }
 
 void MainWindow::refreshTranslateLine()
 {
-  if ( !translateLine )
+  if ( !translateLine ) {
     return;
+  }
 
   // Visually mark the input line to mark if there's no results
   bool setMark = wordFinder.getResults().empty() && !wordFinder.wasSearchUncertain();
@@ -1055,10 +1065,12 @@ void MainWindow::updateSearchPaneAndBar( bool searchInDock )
 {
   QString text = translateLine->text();
 
-  if ( ftsDlg )
+  if ( ftsDlg ) {
     removeGroupComboBoxActionsFromDialog( ftsDlg, groupList );
-  if ( headwordsDlg )
+  }
+  if ( headwordsDlg ) {
     removeGroupComboBoxActionsFromDialog( headwordsDlg, groupList );
+  }
 
   if ( searchInDock ) {
     cfg.preferences.searchInDock = true;
@@ -1093,10 +1105,12 @@ void MainWindow::updateSearchPaneAndBar( bool searchInDock )
     translateBoxToolBarAction->setVisible( true );
   }
 
-  if ( ftsDlg )
+  if ( ftsDlg ) {
     addGroupComboBoxActionsToDialog( ftsDlg, groupList );
-  if ( headwordsDlg )
+  }
+  if ( headwordsDlg ) {
     addGroupComboBoxActionsToDialog( headwordsDlg, groupList );
+  }
 
   translateLine->setToolTip( tr(
     "String to search in dictionaries. The wildcards '*', '?' and sets of symbols '[...]' are allowed.\nTo find '*', '?', '[', ']' symbols use '\\*', '\\?', '\\[', '\\]' respectively" ) );
@@ -1117,8 +1131,9 @@ void MainWindow::mousePressEvent( QMouseEvent * event )
     return;
   }
 
-  if ( event->button() != Qt::MiddleButton )
+  if ( event->button() != Qt::MiddleButton ) {
     return QMainWindow::mousePressEvent( event );
+  }
 
   // middle clicked
   QString subtype = "plain";
@@ -1191,8 +1206,9 @@ void MainWindow::addGroupComboBoxActionsToDialog( QDialog * dialog, GroupComboBo
 void MainWindow::removeGroupComboBoxActionsFromDialog( QDialog * dialog, GroupComboBox * pGroupComboBox )
 {
   QList< QAction * > actions = pGroupComboBox->getExternActions();
-  for ( QList< QAction * >::iterator it = actions.begin(); it != actions.end(); ++it )
+  for ( QList< QAction * >::iterator it = actions.begin(); it != actions.end(); ++it ) {
     dialog->removeAction( *it );
+  }
 }
 
 void MainWindow::commitData( QSessionManager & )
@@ -1203,8 +1219,9 @@ void MainWindow::commitData( QSessionManager & )
 void MainWindow::commitData()
 {
   if ( cfg.preferences.clearNetworkCacheOnExit ) {
-    if ( QAbstractNetworkCache * cache = articleNetMgr.cache() )
+    if ( QAbstractNetworkCache * cache = articleNetMgr.cache() ) {
       cache->clear();
+    }
   }
 
   //if the dictionaries is empty ,large chance that the config has corrupt.
@@ -1216,8 +1233,9 @@ void MainWindow::commitData()
     for ( auto & file : entries ) {
       QString const fileName = file.fileName();
 
-      if ( dictMap.contains( fileName.toStdString() ) )
+      if ( dictMap.contains( fileName.toStdString() ) ) {
         continue;
+      }
       //remove both normal index and fts index.
       auto filePath = file.absoluteFilePath();
       qDebug() << "remove invalid index files & fts dirs";
@@ -1241,8 +1259,9 @@ void MainWindow::commitData()
     for ( auto & file : dirs ) {
       QString const fileName = file.fileName();
 
-      if ( !fileName.endsWith( "_temp" ) )
+      if ( !fileName.endsWith( "_temp" ) ) {
         continue;
+      }
 
       const QFileInfo info( fileName );
       const QDateTime lastModified = info.lastModified();
@@ -1263,8 +1282,9 @@ void MainWindow::commitData()
     cfg.mainWindowGeometry = saveGeometry();
 
     // Save popup window state and geometry
-    if ( scanPopup )
+    if ( scanPopup ) {
       scanPopup->saveConfigData();
+    }
 
     // Save any changes in last chosen groups etc
     try {
@@ -1287,8 +1307,9 @@ void MainWindow::commitData()
 
 QPrinter & MainWindow::getPrinter()
 {
-  if ( printer.get() )
+  if ( printer.get() ) {
     return *printer;
+  }
 
   printer = std::make_shared< QPrinter >( QPrinter::HighResolution );
 
@@ -1306,7 +1327,7 @@ void MainWindow::updateAppearances( QString const & addonStyle,
 {
 #ifdef Q_OS_WIN32
   if ( darkMode ) {
-  //https://forum.qt.io/topic/101391/windows-10-dark-theme
+    //https://forum.qt.io/topic/101391/windows-10-dark-theme
 
     QPalette darkPalette;
     QColor darkColor     = QColor( 45, 45, 45 );
@@ -1372,14 +1393,16 @@ void MainWindow::updateAppearances( QString const & addonStyle,
   // Try loading a style sheet if there's one
   QFile cssFile( Config::getUserQtCssFileName() );
 
-  if ( cssFile.open( QFile::ReadOnly ) )
+  if ( cssFile.open( QFile::ReadOnly ) ) {
     css += cssFile.readAll();
+  }
 
   if ( !addonStyle.isEmpty() ) {
     QString name = Config::getStylesDir() + addonStyle + QDir::separator() + "qt-style.css";
     QFile addonCss( name );
-    if ( addonCss.open( QFile::ReadOnly ) )
+    if ( addonCss.open( QFile::ReadOnly ) ) {
       css += addonCss.readAll();
+    }
   }
 
 #ifdef Q_OS_WIN32
@@ -1439,8 +1462,9 @@ void MainWindow::wheelEvent( QWheelEvent * ev )
 void MainWindow::closeEvent( QCloseEvent * ev )
 {
   if ( cfg.preferences.enableTrayIcon && cfg.preferences.closeToTray ) {
-    if ( !cfg.preferences.searchInDock )
+    if ( !cfg.preferences.searchInDock ) {
       translateBox->setPopupEnabled( false );
+    }
 
 #ifdef Q_OS_MACOS
     if ( !ev->spontaneous() || !isVisible() ) {
@@ -1512,11 +1536,13 @@ void MainWindow::applyProxySettings()
     proxy.setHostName( cfg.preferences.proxyServer.host );
     proxy.setPort( cfg.preferences.proxyServer.port );
 
-    if ( cfg.preferences.proxyServer.user.size() )
+    if ( cfg.preferences.proxyServer.user.size() ) {
       proxy.setUser( cfg.preferences.proxyServer.user );
+    }
 
-    if ( cfg.preferences.proxyServer.password.size() )
+    if ( cfg.preferences.proxyServer.password.size() ) {
       proxy.setPassword( cfg.preferences.proxyServer.password );
+    }
   }
 
   QNetworkProxy::setApplicationProxy( proxy );
@@ -1533,8 +1559,9 @@ void MainWindow::setupNetworkCache( int maxSize )
     diskCache->setMaximumCacheSize( maxCacheSizeInBytes );
     return;
   }
-  if ( maxCacheSizeInBytes == 0 )
+  if ( maxCacheSizeInBytes == 0 ) {
     return; // There is currently no cache and it is not needed.
+  }
 
   QString cacheDirectory = Config::getCacheDir();
   if ( !QDir().mkpath( cacheDirectory ) ) {
@@ -1649,16 +1676,18 @@ void MainWindow::updateGroupList( bool reload )
 
 void MainWindow::updateDictionaryBar()
 {
-  if ( !dictionaryBar.toggleViewAction()->isChecked() )
+  if ( !dictionaryBar.toggleViewAction()->isChecked() ) {
     return; // It's not enabled, therefore hidden -- don't waste time
+  }
 
   unsigned currentId     = groupList->getCurrentGroup();
   Instances::Group * grp = groupInstances.findGroup( currentId );
 
   dictionaryBar.setMutedDictionaries( nullptr );
   if ( grp ) { // Should always be !0, but check as a safeguard
-    if ( currentId == Instances::Group::AllGroupId )
+    if ( currentId == Instances::Group::AllGroupId ) {
       dictionaryBar.setMutedDictionaries( &cfg.mutedDictionaries );
+    }
     else {
       Config::Group * _grp = cfg.getGroup( currentId );
       dictionaryBar.setMutedDictionaries( _grp ? &_grp->mutedDictionaries : nullptr );
@@ -1680,8 +1709,9 @@ void MainWindow::updateDictionaryBar()
 
 vector< sptr< Dictionary::Class > > const & MainWindow::getActiveDicts()
 {
-  if ( groupInstances.empty() )
+  if ( groupInstances.empty() ) {
     return dictionaries;
+  }
 
   int current = groupList->currentIndex();
 
@@ -1691,8 +1721,9 @@ vector< sptr< Dictionary::Class > > const & MainWindow::getActiveDicts()
   }
 
   Config::MutedDictionaries const * mutedDictionaries = dictionaryBar.getMutedDictionaries();
-  if ( !dictionaryBar.toggleViewAction()->isChecked() || mutedDictionaries == nullptr )
+  if ( !dictionaryBar.toggleViewAction()->isChecked() || mutedDictionaries == nullptr ) {
     return groupInstances[ current ].dictionaries;
+  }
   else {
     vector< sptr< Dictionary::Class > > const & activeDicts = groupInstances[ current ].dictionaries;
 
@@ -1702,9 +1733,11 @@ vector< sptr< Dictionary::Class > > const & MainWindow::getActiveDicts()
     dictionariesUnmuted.clear();
     dictionariesUnmuted.reserve( activeDicts.size() );
 
-    for ( unsigned x = 0; x < activeDicts.size(); ++x )
-      if ( !mutedDictionaries->contains( QString::fromStdString( activeDicts[ x ]->getId() ) ) )
+    for ( unsigned x = 0; x < activeDicts.size(); ++x ) {
+      if ( !mutedDictionaries->contains( QString::fromStdString( activeDicts[ x ]->getId() ) ) ) {
         dictionariesUnmuted.push_back( activeDicts[ x ] );
+      }
+    }
 
     return dictionariesUnmuted;
   }
@@ -1838,8 +1871,9 @@ ArticleView * MainWindow::createNewTab( bool switchToIt, QString const & name )
   ui.tabWidget->insertTab( index, view, escaped );
   mruList.append( dynamic_cast< QWidget * >( view ) );
 
-  if ( switchToIt )
+  if ( switchToIt ) {
     ui.tabWidget->setCurrentIndex( index );
+  }
 
   view->setZoomFactor( cfg.preferences.zoomFactor );
 
@@ -1870,16 +1904,18 @@ void MainWindow::tabCloseRequested( int x )
   else if ( ui.tabWidget->count() > 1 ) {
     //activate neighboring tab
     int n = x >= ui.tabWidget->count() - 1 ? x - 1 : x + 1;
-    if ( n >= 0 )
+    if ( n >= 0 ) {
       ui.tabWidget->setCurrentIndex( n );
+    }
   }
 
   ui.tabWidget->removeTab( x );
   delete w;
 
   // if everything is closed, add a new tab
-  if ( ui.tabWidget->count() == 0 )
+  if ( ui.tabWidget->count() == 0 ) {
     addNewTab();
+  }
 }
 
 void MainWindow::closeCurrentTab()
@@ -1889,8 +1925,9 @@ void MainWindow::closeCurrentTab()
 
 void MainWindow::closeAllTabs()
 {
-  while ( ui.tabWidget->count() > 1 )
+  while ( ui.tabWidget->count() > 1 ) {
     closeCurrentTab();
+  }
 
   // close last tab
   closeCurrentTab();
@@ -1898,37 +1935,44 @@ void MainWindow::closeAllTabs()
 
 void MainWindow::closeRestTabs()
 {
-  if ( ui.tabWidget->count() < 2 )
+  if ( ui.tabWidget->count() < 2 ) {
     return;
+  }
 
   int idx = ui.tabWidget->currentIndex();
 
-  for ( int i = 0; i < idx; i++ )
+  for ( int i = 0; i < idx; i++ ) {
     tabCloseRequested( 0 );
+  }
 
   ui.tabWidget->setCurrentIndex( 0 );
 
-  while ( ui.tabWidget->count() > 1 )
+  while ( ui.tabWidget->count() > 1 ) {
     tabCloseRequested( 1 );
+  }
 }
 
 void MainWindow::switchToNextTab()
 {
-  if ( ui.tabWidget->count() < 2 )
+  if ( ui.tabWidget->count() < 2 ) {
     return;
+  }
 
   ui.tabWidget->setCurrentIndex( ( ui.tabWidget->currentIndex() + 1 ) % ui.tabWidget->count() );
 }
 
 void MainWindow::switchToPrevTab()
 {
-  if ( ui.tabWidget->count() < 2 )
+  if ( ui.tabWidget->count() < 2 ) {
     return;
+  }
 
-  if ( !ui.tabWidget->currentIndex() )
+  if ( !ui.tabWidget->currentIndex() ) {
     ui.tabWidget->setCurrentIndex( ui.tabWidget->count() - 1 );
-  else
+  }
+  else {
     ui.tabWidget->setCurrentIndex( ui.tabWidget->currentIndex() - 1 );
+  }
 }
 
 void MainWindow::backClicked()
@@ -1960,8 +2004,9 @@ void MainWindow::titleChanged( ArticleView * view, QString const & title )
   escaped = Utils::escapeAmps( escaped );
 
   int index = ui.tabWidget->indexOf( view );
-  if ( !escaped.isEmpty() )
+  if ( !escaped.isEmpty() ) {
     ui.tabWidget->setTabText( index, escaped );
+  }
 
   if ( index == ui.tabWidget->currentIndex() ) {
     // Set icon for "Add to Favorites" action
@@ -1996,8 +2041,9 @@ void MainWindow::updateWindowTitle()
 
 void MainWindow::pageLoaded( ArticleView * view )
 {
-  if ( view != getCurrentArticleView() )
+  if ( view != getCurrentArticleView() ) {
     return; // It was background action
+  }
 
   updateBackForwardButtons();
   updatePronounceAvailability();
@@ -2005,10 +2051,12 @@ void MainWindow::pageLoaded( ArticleView * view )
 
 void MainWindow::showStatusBarMessage( QString const & message, int timeout, QPixmap const & icon )
 {
-  if ( message.isEmpty() )
+  if ( message.isEmpty() ) {
     mainStatusBar->clearMessage();
-  else
+  }
+  else {
     mainStatusBar->showMessage( message, timeout, icon );
+  }
 }
 
 void MainWindow::tabSwitched( int )
@@ -2020,8 +2068,9 @@ void MainWindow::tabSwitched( int )
   updateWindowTitle();
   if ( mruList.size() > 1 ) {
     int from = mruList.indexOf( ui.tabWidget->widget( ui.tabWidget->currentIndex() ) );
-    if ( from > 0 )
+    if ( from > 0 ) {
       mruList.move( from, 0 );
+    }
   }
 
   // Set icon for "Add to Favorites" action
@@ -2061,8 +2110,9 @@ void MainWindow::dictionaryBarToggled( bool )
 
 void MainWindow::showDictsPane()
 {
-  if ( !ui.dictsPane->isVisible() )
+  if ( !ui.dictsPane->isVisible() ) {
     ui.dictsPane->show();
+  }
 }
 
 void MainWindow::dictsPaneVisibilityChanged( bool visible )
@@ -2155,8 +2205,9 @@ void MainWindow::editDictionaries( unsigned editDictionaryGroup )
 
     connect( &dicts, &EditDictionaries::showDictionaryHeadwords, this, &MainWindow::showDictionaryHeadwords );
 
-    if ( editDictionaryGroup != Instances::Group::NoGroupId )
+    if ( editDictionaryGroup != Instances::Group::NoGroupId ) {
       dicts.editGroup( editDictionaryGroup );
+    }
 
     dicts.restoreGeometry( cfg.dictionariesDialogGeometry );
     dicts.exec();
@@ -2252,14 +2303,17 @@ void MainWindow::editPreferences()
     }
 
 
-    if ( cfg.preferences.historyStoreInterval != p.historyStoreInterval )
+    if ( cfg.preferences.historyStoreInterval != p.historyStoreInterval ) {
       history.setSaveInterval( p.historyStoreInterval );
+    }
 
-    if ( cfg.preferences.favoritesStoreInterval != p.favoritesStoreInterval )
+    if ( cfg.preferences.favoritesStoreInterval != p.favoritesStoreInterval ) {
       ui.favoritesPaneWidget->setSaveInterval( p.favoritesStoreInterval );
+    }
 
-    if ( cfg.preferences.maxNetworkCacheSize != p.maxNetworkCacheSize )
+    if ( cfg.preferences.maxNetworkCacheSize != p.maxNetworkCacheSize ) {
       setupNetworkCache( p.maxNetworkCacheSize );
+    }
 
     bool needReload =
       ( cfg.preferences.displayStyle != p.displayStyle || cfg.preferences.addonStyle != p.addonStyle
@@ -2320,19 +2374,22 @@ void MainWindow::currentGroupChanged( int )
   cfg.lastMainGroupId           = grg_id;
   Instances::Group const * igrp = groupInstances.findGroup( grg_id );
   if ( grg_id == Instances::Group::AllGroupId ) {
-    if ( igrp )
+    if ( igrp ) {
       igrp->checkMutedDictionaries( &cfg.mutedDictionaries );
+    }
     dictionaryBar.setMutedDictionaries( &cfg.mutedDictionaries );
   }
   else {
     Config::Group * grp = cfg.getGroup( grg_id );
     if ( grp ) {
-      if ( igrp )
+      if ( igrp ) {
         igrp->checkMutedDictionaries( &grp->mutedDictionaries );
+      }
       dictionaryBar.setMutedDictionaries( &grp->mutedDictionaries );
     }
-    else
+    else {
       dictionaryBar.setMutedDictionaries( nullptr );
+    }
   }
 
   if ( igrp ) {
@@ -2357,8 +2414,9 @@ void MainWindow::currentGroupChanged( int )
     }
   }
 
-  if ( ftsDlg )
+  if ( ftsDlg ) {
     ftsDlg->setCurrentGroup( grg_id );
+  }
 }
 
 void MainWindow::translateInputChanged( QString const & newValue )
@@ -2384,8 +2442,9 @@ void MainWindow::updateSuggestionList( QString const & newValue )
   // If some word is selected in the word list, unselect it. This prevents
   // triggering a set of spurious activation signals when the list changes.
 
-  if ( ui.wordList->selectionModel()->hasSelection() )
+  if ( ui.wordList->selectionModel()->hasSelection() ) {
     ui.wordList->setCurrentItem( nullptr, QItemSelectionModel::Clear );
+  }
 
   QString req = newValue.trimmed();
 
@@ -2417,14 +2476,16 @@ void MainWindow::respondToTranslationRequest( QString const & word,
 {
   if ( !word.isEmpty() ) {
     Qt::KeyboardModifiers mods = QApplication::keyboardModifiers();
-    if ( checkModifiers && ( mods & ( Qt::ControlModifier | Qt::ShiftModifier ) ) )
+    if ( checkModifiers && ( mods & ( Qt::ControlModifier | Qt::ShiftModifier ) ) ) {
       addNewTab();
+    }
 
     showTranslationFor( word, 0, scrollTo );
 
     if ( cfg.preferences.searchInDock ) {
-      if ( ui.searchPane->isFloating() )
+      if ( ui.searchPane->isFloating() ) {
         activateWindow();
+      }
     }
 
     if ( focus ) {
@@ -2435,8 +2496,9 @@ void MainWindow::respondToTranslationRequest( QString const & word,
 
 void MainWindow::setInputLineText( QString text, WildcardPolicy wildcardPolicy, TranslateBoxPopup popupAction )
 {
-  if ( wildcardPolicy == WildcardPolicy::EscapeWildcards )
+  if ( wildcardPolicy == WildcardPolicy::EscapeWildcards ) {
     text = Folding::escapeWildcardSymbols( text );
+  }
 
   if ( popupAction == NoPopupChange || cfg.preferences.searchInDock ) {
     translateLine->setText( text );
@@ -2452,25 +2514,29 @@ void MainWindow::setInputLineText( QString text, WildcardPolicy wildcardPolicy, 
 void MainWindow::handleEsc()
 {
   ArticleView * view = getCurrentArticleView();
-  if ( view && view->closeSearch() )
+  if ( view && view->closeSearch() ) {
     return;
+  }
 
   if ( cfg.preferences.escKeyHidesMainWindow ) {
     toggleMainWindow();
   }
-  else
+  else {
     focusTranslateLine();
+  }
 }
 
 void MainWindow::focusTranslateLine()
 {
   if ( cfg.preferences.searchInDock ) {
-    if ( ui.searchPane->isFloating() )
+    if ( ui.searchPane->isFloating() ) {
       ui.searchPane->activateWindow();
+    }
   }
   else {
-    if ( !isActiveWindow() )
+    if ( !isActiveWindow() ) {
       activateWindow();
+    }
   }
 
   translateLine->clearFocus();
@@ -2502,8 +2568,9 @@ bool MainWindow::handleBackForwardMouseButtons( QMouseEvent * event )
     forwardClicked();
     return true;
   }
-  else
+  else {
     return false;
+  }
 }
 
 bool MainWindow::eventFilter( QObject * obj, QEvent * ev )
@@ -2514,8 +2581,9 @@ bool MainWindow::eventFilter( QObject * obj, QEvent * ev )
     int const key = ke->key();
     if ( key == Qt::Key_F3 ) {
       ArticleView * view = getCurrentArticleView();
-      if ( view && view->handleF3( obj, ev ) )
+      if ( view && view->handleF3( obj, ev ) ) {
         return true;
+      }
     }
 
     //workaround to fix #660
@@ -2608,8 +2676,9 @@ bool MainWindow::eventFilter( QObject * obj, QEvent * ev )
 
       if ( keyEvent->matches( QKeySequence::InsertParagraphSeparator ) && ui.wordList->selectedItems().size() ) {
         if ( cfg.preferences.searchInDock ) {
-          if ( ui.searchPane->isFloating() )
+          if ( ui.searchPane->isFloating() ) {
             activateWindow();
+          }
         }
 
         focusArticleView();
@@ -2625,8 +2694,9 @@ bool MainWindow::eventFilter( QObject * obj, QEvent * ev )
       const QString text = key_event->text();
 
       if ( Utils::ignoreKeyEvent( key_event ) || key_event->key() == Qt::Key_Return
-           || key_event->key() == Qt::Key_Enter )
+           || key_event->key() == Qt::Key_Enter ) {
         return false; // Those key have other uses than to start typing
+      }
       // or don't make sense
       if ( !text.isEmpty() ) {
         typingEvent( text );
@@ -2697,8 +2767,9 @@ void MainWindow::showDefinitionInNewTab( QString const & word,
 
 void MainWindow::activeArticleChanged( ArticleView const * view, QString const & id )
 {
-  if ( view != getCurrentArticleView() )
+  if ( view != getCurrentArticleView() ) {
     return; // It was background action
+  }
 
   // select the row with the corresponding id
   for ( int i = 0; i < ui.dictsList->count(); ++i ) {
@@ -2718,16 +2789,19 @@ void MainWindow::activeArticleChanged( ArticleView const * view, QString const &
 void MainWindow::typingEvent( QString const & t )
 {
   if ( t == "\n" || t == "\r" ) {
-    if ( translateLine->isEnabled() )
+    if ( translateLine->isEnabled() ) {
       focusTranslateLine();
+    }
   }
   else {
-    if ( ( cfg.preferences.searchInDock && ui.searchPane->isFloating() ) || ui.dictsPane->isFloating() )
+    if ( ( cfg.preferences.searchInDock && ui.searchPane->isFloating() ) || ui.dictsPane->isFloating() ) {
       ui.searchPane->activateWindow();
+    }
 
     if ( translateLine->isEnabled() ) {
-      if ( navToolbar->isFloating() )
+      if ( navToolbar->isFloating() ) {
         navToolbar->activateWindow();
+      }
 
       translateLine->clear();
       translateLine->setFocus();
@@ -2740,8 +2814,9 @@ void MainWindow::typingEvent( QString const & t )
 
 void MainWindow::mutedDictionariesChanged()
 {
-  if ( dictionaryBar.toggleViewAction()->isChecked() )
+  if ( dictionaryBar.toggleViewAction()->isChecked() ) {
     applyMutedDictionariesState();
+  }
 }
 
 void MainWindow::showHistoryItem( QString const & word )
@@ -2789,8 +2864,9 @@ void MainWindow::toggleMainWindow( bool onlyShow )
 {
   bool shown = false;
 
-  if ( !cfg.preferences.searchInDock )
+  if ( !cfg.preferences.searchInDock ) {
     translateBox->setPopupEnabled( false );
+  }
 
   if ( !isVisible() ) {
     show();
@@ -2800,10 +2876,12 @@ void MainWindow::toggleMainWindow( bool onlyShow )
     shown = true;
   }
   else if ( isMinimized() ) {
-    if ( wasMaximized )
+    if ( wasMaximized ) {
       showMaximized();
-    else
+    }
+    else {
       showNormal();
+    }
     activateWindow();
     raise();
     shown = true;
@@ -2824,8 +2902,9 @@ void MainWindow::toggleMainWindow( bool onlyShow )
     // but click it won't bring it back, thus we can only minimize it.
 
 #ifdef Q_OS_MAC
-    if ( cfg.preferences.enableTrayIcon )
+    if ( cfg.preferences.enableTrayIcon ) {
       showMinimized();
+    }
 #else
     if ( cfg.preferences.enableTrayIcon )
       hide();
@@ -2834,19 +2913,23 @@ void MainWindow::toggleMainWindow( bool onlyShow )
 #endif
 
 
-    if ( headwordsDlg )
+    if ( headwordsDlg ) {
       headwordsDlg->hide();
+    }
 
-    if ( ftsDlg )
+    if ( ftsDlg ) {
       ftsDlg->hide();
+    }
   }
 
   if ( shown ) {
-    if ( headwordsDlg )
+    if ( headwordsDlg ) {
       headwordsDlg->show();
+    }
 
-    if ( ftsDlg )
+    if ( ftsDlg ) {
       ftsDlg->show();
+    }
 
     focusTranslateLine();
   }
@@ -2875,8 +2958,9 @@ void MainWindow::installHotKeys()
       return;
     }
 
-    if ( cfg.preferences.enableMainWindowHotkey )
+    if ( cfg.preferences.enableMainWindowHotkey ) {
       hotkeyWrapper->setGlobalKey( cfg.preferences.mainWindowHotkey, 0 );
+    }
 
     if ( cfg.preferences.enableClipboardHotkey ) {
       hotkeyWrapper->setGlobalKey( cfg.preferences.clipboardHotkey, 1 );
@@ -2892,8 +2976,9 @@ void MainWindow::installHotKeys()
 
 void MainWindow::hotKeyActivated( int hk )
 {
-  if ( !hk )
+  if ( !hk ) {
     toggleMainWindow();
+  }
   else if ( scanPopup ) {
 #ifdef HAVE_X11
     // When the user requests translation with the Ctrl+C+C hotkey in certain apps
@@ -2953,8 +3038,9 @@ void MainWindow::checkNewRelease()
 
             msg.exec();
 
-            if ( msg.clickedButton() == dload )
+            if ( msg.clickedButton() == dload ) {
               QDesktopServices::openUrl( QUrl( downloadUrl ) );
+            }
             else if ( msg.clickedButton() == skip ) {
               cfg.skippedRelease = latestVersion;
             }
@@ -3172,8 +3258,9 @@ void MainWindow::on_pageSetup_triggered()
 
     dialog.exec();
   }
-  else
+  else {
     QMessageBox::critical( this, tr( "Page Setup" ), tr( "No printer is available. Please install one first." ) );
+  }
 }
 
 void MainWindow::on_printPreview_triggered()
@@ -3196,8 +3283,9 @@ void MainWindow::on_print_triggered()
 
   dialog.setWindowTitle( tr( "Print Article" ) );
 
-  if ( dialog.exec() != QDialog::Accepted )
+  if ( dialog.exec() != QDialog::Accepted ) {
     return;
+  }
 
   ArticleView * view = getCurrentArticleView();
 
@@ -3227,10 +3315,12 @@ static void filterAndCollectResources( QString & html,
     QString host         = url.host();
     QString resourcePath = Utils::Url::path( url );
 
-    if ( !host.startsWith( '/' ) )
+    if ( !host.startsWith( '/' ) ) {
       host.insert( 0, '/' );
-    if ( !resourcePath.startsWith( '/' ) )
+    }
+    if ( !resourcePath.startsWith( '/' ) ) {
       resourcePath.insert( 0, '/' );
+    }
 
     QCryptographicHash hash( QCryptographicHash::Md5 );
     hash.addData( match.captured().toUtf8() );
@@ -3262,12 +3352,14 @@ void MainWindow::on_saveArticle_triggered()
   fileName += ".html";
   QString savePath;
 
-  if ( cfg.articleSavePath.isEmpty() )
+  if ( cfg.articleSavePath.isEmpty() ) {
     savePath = QDir::homePath();
+  }
   else {
     savePath = QDir::fromNativeSeparators( cfg.articleSavePath );
-    if ( !QDir( savePath ).exists() )
+    if ( !QDir( savePath ).exists() ) {
       savePath = QDir::homePath();
+    }
   }
 
   QFileDialog::Options options = QFileDialog::HideNameFilterDetails;
@@ -3287,8 +3379,9 @@ void MainWindow::on_saveArticle_triggered()
   // The " (*.html)" part of filters[i] is absent from selectedFilter in Qt 5.
   bool const complete = filters.at( 0 ).startsWith( selectedFilter );
 
-  if ( fileName.isEmpty() )
+  if ( fileName.isEmpty() ) {
     return;
+  }
 
   view->toHtml( [ = ]( QString & html ) mutable {
     QFile file( fileName );
@@ -3468,10 +3561,12 @@ void MainWindow::applyZoomFactor()
 
 void MainWindow::adjustCurrentZoomFactor()
 {
-  if ( cfg.preferences.zoomFactor >= 5 )
+  if ( cfg.preferences.zoomFactor >= 5 ) {
     cfg.preferences.zoomFactor = 5;
-  else if ( cfg.preferences.zoomFactor <= 0.25 )
+  }
+  else if ( cfg.preferences.zoomFactor <= 0.25 ) {
     cfg.preferences.zoomFactor = 0.25;
+  }
 
   zoomIn->setEnabled( cfg.preferences.zoomFactor < 5 );
   zoomOut->setEnabled( cfg.preferences.zoomFactor > 0.25 );
@@ -3518,14 +3613,16 @@ void MainWindow::applyWordsZoomLevel()
   if ( cfg.preferences.wordsZoomLevel != 0 ) {
     ps += cfg.preferences.wordsZoomLevel;
 
-    if ( ps < 1 )
+    if ( ps < 1 ) {
       ps = 1;
+    }
 
     font.setPointSize( ps );
   }
 
-  if ( ui.wordList->font().pointSize() != ps )
+  if ( ui.wordList->font().pointSize() != ps ) {
     ui.wordList->setFont( font );
+  }
 
   font = translateLineDefaultFont;
 
@@ -3534,8 +3631,9 @@ void MainWindow::applyWordsZoomLevel()
   if ( cfg.preferences.wordsZoomLevel != 0 ) {
     ps += cfg.preferences.wordsZoomLevel;
 
-    if ( ps < 1 )
+    if ( ps < 1 ) {
       ps = 1;
+    }
 
     font.setPointSize( ps );
   }
@@ -3553,8 +3651,9 @@ void MainWindow::applyWordsZoomLevel()
   if ( cfg.preferences.wordsZoomLevel != 0 ) {
     ps += cfg.preferences.wordsZoomLevel;
 
-    if ( ps < 1 )
+    if ( ps < 1 ) {
       ps = 1;
+    }
 
     font.setPointSize( ps );
   }
@@ -3607,10 +3706,12 @@ void MainWindow::messageFromAnotherInstanceReceived( QString const & message )
     }
     else {
       //default logic
-      if ( scanPopup )
+      if ( scanPopup ) {
         scanPopup->translateWord( word );
-      else
+      }
+      else {
         wordReceived( word );
+      }
     }
 
     consoleWindowOnce.clear();
@@ -3621,8 +3722,9 @@ void MainWindow::messageFromAnotherInstanceReceived( QString const & message )
   else if ( message.left( 15 ) == "setPopupGroup: " ) {
     setGroupByName( message.mid( 15 ), false );
   }
-  else
+  else {
     qWarning() << "Unknown message received from another instance: " << message;
+  }
 }
 
 ArticleView * MainWindow::getCurrentArticleView()
@@ -3692,20 +3794,23 @@ void MainWindow::toggle_historyPane()
 void MainWindow::on_exportHistory_triggered()
 {
   QString exportPath;
-  if ( cfg.historyExportPath.isEmpty() )
+  if ( cfg.historyExportPath.isEmpty() ) {
     exportPath = QDir::homePath();
+  }
   else {
     exportPath = QDir::fromNativeSeparators( cfg.historyExportPath );
-    if ( !QDir( exportPath ).exists() )
+    if ( !QDir( exportPath ).exists() ) {
       exportPath = QDir::homePath();
+    }
   }
 
   QString fileName = QFileDialog::getSaveFileName( this,
                                                    tr( "Export history to file" ),
                                                    exportPath,
                                                    tr( "Text files (*.txt);;All files (*.*)" ) );
-  if ( fileName.size() == 0 )
+  if ( fileName.size() == 0 ) {
     return;
+  }
 
   cfg.historyExportPath = QDir::toNativeSeparators( QFileInfo( fileName ).absoluteDir().absolutePath() );
   QFile file( fileName );
@@ -3753,20 +3858,23 @@ void MainWindow::on_exportHistory_triggered()
 void MainWindow::on_importHistory_triggered()
 {
   QString importPath;
-  if ( cfg.historyExportPath.isEmpty() )
+  if ( cfg.historyExportPath.isEmpty() ) {
     importPath = QDir::homePath();
+  }
   else {
     importPath = QDir::fromNativeSeparators( cfg.historyExportPath );
-    if ( !QDir( importPath ).exists() )
+    if ( !QDir( importPath ).exists() ) {
       importPath = QDir::homePath();
+    }
   }
 
   QString fileName = QFileDialog::getOpenFileName( this,
                                                    tr( "Import history from file" ),
                                                    importPath,
                                                    tr( "Text files (*.txt);;All files (*.*)" ) );
-  if ( fileName.size() == 0 )
+  if ( fileName.size() == 0 ) {
     return;
+  }
 
   QFileInfo fileInfo( fileName );
   cfg.historyExportPath = QDir::toNativeSeparators( fileInfo.absoluteDir().absolutePath() );
@@ -3785,22 +3893,26 @@ void MainWindow::on_importHistory_triggered()
 
   do {
     itemStr = fileStream.readLine();
-    if ( fileStream.status() >= QTextStream::ReadCorruptData )
+    if ( fileStream.status() >= QTextStream::ReadCorruptData ) {
       break;
+    }
 
     trimmedStr = itemStr.trimmed();
-    if ( trimmedStr.isEmpty() )
+    if ( trimmedStr.isEmpty() ) {
       continue;
+    }
 
-    if ( (unsigned)trimmedStr.size() <= history.getMaxItemLength() )
+    if ( (unsigned)trimmedStr.size() <= history.getMaxItemLength() ) {
       itemList.prepend( trimmedStr );
+    }
 
   } while ( !fileStream.atEnd() && itemList.size() < (int)history.getMaxSize() );
 
   history.enableAdd( true );
 
-  for ( QList< QString >::const_iterator i = itemList.constBegin(); i != itemList.constEnd(); ++i )
+  for ( QList< QString >::const_iterator i = itemList.constBegin(); i != itemList.constEnd(); ++i ) {
     history.addItem( { *i } );
+  }
 
   history.enableAdd( cfg.preferences.storeHistory );
 
@@ -3828,20 +3940,23 @@ void MainWindow::errorMessageOnStatusBar( const QString & errStr )
 void MainWindow::on_exportFavorites_triggered()
 {
   QString exportPath;
-  if ( cfg.historyExportPath.isEmpty() )
+  if ( cfg.historyExportPath.isEmpty() ) {
     exportPath = QDir::homePath();
+  }
   else {
     exportPath = QDir::fromNativeSeparators( cfg.historyExportPath );
-    if ( !QDir( exportPath ).exists() )
+    if ( !QDir( exportPath ).exists() ) {
       exportPath = QDir::homePath();
+    }
   }
 
   QString fileName = QFileDialog::getSaveFileName( this,
                                                    tr( "Export Favorites to file" ),
                                                    exportPath,
                                                    tr( "XML files (*.xml);;All files (*.*)" ) );
-  if ( fileName.size() == 0 )
+  if ( fileName.size() == 0 ) {
     return;
+  }
 
   cfg.historyExportPath = QDir::toNativeSeparators( QFileInfo( fileName ).absoluteDir().absolutePath() );
   QFile file( fileName );
@@ -3867,20 +3982,23 @@ void MainWindow::on_exportFavorites_triggered()
 void MainWindow::on_ExportFavoritesToList_triggered()
 {
   QString exportPath;
-  if ( cfg.historyExportPath.isEmpty() )
+  if ( cfg.historyExportPath.isEmpty() ) {
     exportPath = QDir::homePath();
+  }
   else {
     exportPath = QDir::fromNativeSeparators( cfg.historyExportPath );
-    if ( !QDir( exportPath ).exists() )
+    if ( !QDir( exportPath ).exists() ) {
       exportPath = QDir::homePath();
+    }
   }
 
   QString fileName = QFileDialog::getSaveFileName( this,
                                                    tr( "Export Favorites to file as plain list" ),
                                                    exportPath,
                                                    tr( "Text files (*.txt);;All files (*.*)" ) );
-  if ( fileName.size() == 0 )
+  if ( fileName.size() == 0 ) {
     return;
+  }
 
   cfg.historyExportPath = QDir::toNativeSeparators( QFileInfo( fileName ).absoluteDir().absolutePath() );
   QFile file( fileName );
@@ -3915,20 +4033,23 @@ void MainWindow::on_ExportFavoritesToList_triggered()
 void MainWindow::on_importFavorites_triggered()
 {
   QString importPath;
-  if ( cfg.historyExportPath.isEmpty() )
+  if ( cfg.historyExportPath.isEmpty() ) {
     importPath = QDir::homePath();
+  }
   else {
     importPath = QDir::fromNativeSeparators( cfg.historyExportPath );
-    if ( !QDir( importPath ).exists() )
+    if ( !QDir( importPath ).exists() ) {
       importPath = QDir::homePath();
+    }
   }
 
   QString fileName = QFileDialog::getOpenFileName( this,
                                                    tr( "Import Favorites from file" ),
                                                    importPath,
                                                    tr( "XML files (*.xml);;Txt files (*.txt);;All files (*.*)" ) );
-  if ( fileName.size() == 0 )
+  if ( fileName.size() == 0 ) {
     return;
+  }
 
   QFileInfo fileInfo( fileName );
   cfg.historyExportPath = QDir::toNativeSeparators( fileInfo.absoluteDir().absolutePath() );
@@ -3961,15 +4082,17 @@ void MainWindow::on_importFavorites_triggered()
 
 void MainWindow::focusWordList()
 {
-  if ( ui.wordList->count() > 0 )
+  if ( ui.wordList->count() > 0 ) {
     ui.wordList->setFocus();
+  }
 }
 
 void MainWindow::addWordToHistory( const QString & word )
 {
   //    skip epwing reference link. epwing reference link has the pattern of r%dAt%d
-  if ( QRegularExpressionMatch m = RX::Epwing::refWord.match( word ); m.hasMatch() )
+  if ( QRegularExpressionMatch m = RX::Epwing::refWord.match( word ); m.hasMatch() ) {
     return;
+  }
   history.addItem( { word.trimmed() } );
 }
 
@@ -4057,16 +4180,18 @@ void MainWindow::focusHeadwordsDialog()
 {
   if ( headwordsDlg ) {
     headwordsDlg->activateWindow();
-    if ( ftsDlg )
+    if ( ftsDlg ) {
       ftsDlg->lower();
+    }
   }
 }
 
 void MainWindow::focusArticleView()
 {
   if ( ArticleView * view = getCurrentArticleView() ) {
-    if ( !isActiveWindow() )
+    if ( !isActiveWindow() ) {
       activateWindow();
+    }
     view->focus();
   }
 }
@@ -4104,41 +4229,49 @@ void MainWindow::foundDictsContextMenuRequested( const QPoint & pos )
       }
     }
 
-    if ( pDict == nullptr )
+    if ( pDict == nullptr ) {
       return;
+    }
 
     if ( !pDict->isLocalDictionary() ) {
-      if ( scanPopup )
+      if ( scanPopup ) {
         scanPopup->blockSignals( true );
+      }
       showDictionaryInfo( id );
-      if ( scanPopup )
+      if ( scanPopup ) {
         scanPopup->blockSignals( false );
+      }
     }
     else {
       QMenu menu( ui.dictsList );
       QAction * infoAction = menu.addAction( tr( "Dictionary info" ) );
 
       QAction * headwordsAction = nullptr;
-      if ( pDict->getWordCount() > 0 )
+      if ( pDict->getWordCount() > 0 ) {
         headwordsAction = menu.addAction( tr( "Dictionary headwords" ) );
+      }
 
       QAction * openDictFolderAction = menu.addAction( tr( "Open dictionary folder" ) );
 
       QAction * result = menu.exec( ui.dictsList->mapToGlobal( pos ) );
 
       if ( result && result == infoAction ) {
-        if ( scanPopup )
+        if ( scanPopup ) {
           scanPopup->blockSignals( true );
+        }
         showDictionaryInfo( id );
-        if ( scanPopup )
+        if ( scanPopup ) {
           scanPopup->blockSignals( false );
+        }
       }
       else if ( result && result == headwordsAction ) {
-        if ( scanPopup )
+        if ( scanPopup ) {
           scanPopup->blockSignals( true );
+        }
         showDictionaryHeadwords( pDict );
-        if ( scanPopup )
+        if ( scanPopup ) {
           scanPopup->blockSignals( false );
+        }
       }
       else if ( result && result == openDictFolderAction ) {
         openDictionaryFolder( id );
@@ -4223,12 +4356,14 @@ void MainWindow::showFullTextSearchDialog()
     ftsDlg->setCurrentGroup( group );
   }
 
-  if ( !ftsDlg->isVisible() )
+  if ( !ftsDlg->isVisible() ) {
     ftsDlg->show();
+  }
   else {
     ftsDlg->activateWindow();
-    if ( headwordsDlg )
+    if ( headwordsDlg ) {
       headwordsDlg->lower();
+    }
   }
 }
 
@@ -4243,10 +4378,12 @@ void MainWindow::closeFullTextSearchDialog()
 
 void MainWindow::showFTSIndexingName( QString const & name )
 {
-  if ( name.isEmpty() )
+  if ( name.isEmpty() ) {
     mainStatusBar->setBackgroundMessage( QString() );
-  else
+  }
+  else {
     mainStatusBar->setBackgroundMessage( tr( "Now indexing for full-text search: " ) + name );
+  }
 }
 
 QString MainWindow::unescapeTabHeader( QString const & header )
@@ -4259,8 +4396,9 @@ void MainWindow::addCurrentTabToFavorites()
 {
   QString folder;
   Instances::Group const * igrp = groupInstances.findGroup( cfg.lastMainGroupId );
-  if ( igrp )
+  if ( igrp ) {
     folder = igrp->favoritesFolder;
+  }
 
   QString headword = ui.tabWidget->tabText( ui.tabWidget->currentIndex() );
 
@@ -4274,8 +4412,9 @@ void MainWindow::handleAddToFavoritesButton()
 {
   QString folder;
   Instances::Group const * igrp = groupInstances.findGroup( cfg.lastMainGroupId );
-  if ( igrp )
+  if ( igrp ) {
     folder = igrp->favoritesFolder;
+  }
   QString headword = unescapeTabHeader( ui.tabWidget->tabText( ui.tabWidget->currentIndex() ) );
 
   if ( ui.favoritesPaneWidget->isHeadwordPresent( folder, headword ) ) {
@@ -4302,13 +4441,16 @@ void MainWindow::addWordToFavorites( QString const & word, unsigned groupId, boo
 {
   QString folder;
   Instances::Group const * igrp = groupInstances.findGroup( groupId );
-  if ( igrp )
+  if ( igrp ) {
     folder = igrp->favoritesFolder;
+  }
 
-  if ( !exist )
+  if ( !exist ) {
     ui.favoritesPaneWidget->addHeadword( folder, word );
-  else
+  }
+  else {
     ui.favoritesPaneWidget->removeHeadword( folder, word );
+  }
 }
 
 void MainWindow::addBookmarkToFavorite( QString const & text )
@@ -4324,8 +4466,9 @@ void MainWindow::addAllTabsToFavorites()
 {
   QString folder;
   Instances::Group const * igrp = groupInstances.findGroup( cfg.lastMainGroupId );
-  if ( igrp )
+  if ( igrp ) {
     folder = igrp->favoritesFolder;
+  }
 
   for ( int i = 0; i < ui.tabWidget->count(); i++ ) {
     QString headword = ui.tabWidget->tabText( i );
@@ -4339,8 +4482,9 @@ bool MainWindow::isWordPresentedInFavorites( QString const & word, unsigned grou
 {
   QString folder;
   Instances::Group const * igrp = groupInstances.findGroup( groupId );
-  if ( igrp )
+  if ( igrp ) {
     folder = igrp->favoritesFolder;
+  }
 
   return ui.favoritesPaneWidget->isHeadwordPresent( folder, word );
 }
@@ -4355,8 +4499,9 @@ void MainWindow::setGroupByName( QString const & name, bool main_window )
         break;
       }
     }
-    if ( i >= groupList->count() )
+    if ( i >= groupList->count() ) {
       gdWarning( "Group \"%s\" for main window is not found\n", name.toUtf8().data() );
+    }
   }
   else {
     emit setPopupGroupByName( name );

--- a/src/ui/orderandprops.cc
+++ b/src/ui/orderandprops.cc
@@ -20,10 +20,12 @@ bool dictNameLessThan( sptr< Dictionary::Class > const & dict1, sptr< Dictionary
 {
   QString str1 = QString::fromUtf8( dict1->getName().c_str() );
   QString str2 = QString::fromUtf8( dict2->getName().c_str() );
-  if ( str1.isEmpty() && !str2.isEmpty() )
+  if ( str1.isEmpty() && !str2.isEmpty() ) {
     return false;
-  if ( !str1.isEmpty() && str2.isEmpty() )
+  }
+  if ( !str1.isEmpty() && str2.isEmpty() ) {
     return true;
+  }
 
   return str1.localeAwareCompare( str2 ) < 0;
 }
@@ -35,8 +37,8 @@ bool dictLessThan( sptr< Dictionary::Class > const & dict1, sptr< Dictionary::Cl
   if ( idFrom1 == 0 ) {
     std::pair< quint32, quint32 > ids =
       LangCoder::findLangIdPairFromName( QString::fromUtf8( dict1->getName().c_str() ) );
-    idFrom1                       = ids.first;
-    idTo1                         = ids.second;
+    idFrom1 = ids.first;
+    idTo1   = ids.second;
   }
 
   int idFrom2 = dict2->getLangFrom();
@@ -44,36 +46,44 @@ bool dictLessThan( sptr< Dictionary::Class > const & dict1, sptr< Dictionary::Cl
   if ( idFrom2 == 0 ) {
     std::pair< quint32, quint32 > ids =
       LangCoder::findLangIdPairFromName( QString::fromUtf8( dict2->getName().c_str() ) );
-    idFrom2                       = ids.first;
-    idTo2                         = ids.second;
+    idFrom2 = ids.first;
+    idTo2   = ids.second;
   }
 
   QString str1 = LangCoder::decode( idFrom1 );
   QString str2 = LangCoder::decode( idFrom2 );
-  if ( str1.isEmpty() && !str2.isEmpty() )
+  if ( str1.isEmpty() && !str2.isEmpty() ) {
     return false;
-  if ( !str1.isEmpty() && str2.isEmpty() )
+  }
+  if ( !str1.isEmpty() && str2.isEmpty() ) {
     return true;
+  }
   int res = str1.localeAwareCompare( str2 );
-  if ( res )
+  if ( res ) {
     return res < 0;
+  }
 
   str1 = LangCoder::decode( idTo1 );
   str2 = LangCoder::decode( idTo2 );
-  if ( str1.isEmpty() && !str2.isEmpty() )
+  if ( str1.isEmpty() && !str2.isEmpty() ) {
     return false;
-  if ( !str1.isEmpty() && str2.isEmpty() )
+  }
+  if ( !str1.isEmpty() && str2.isEmpty() ) {
     return true;
+  }
   res = str1.localeAwareCompare( str2 );
-  if ( res )
+  if ( res ) {
     return res < 0;
+  }
 
   str1 = QString::fromUtf8( dict1->getName().c_str() );
   str2 = QString::fromUtf8( dict2->getName().c_str() );
-  if ( str1.isEmpty() && !str2.isEmpty() )
+  if ( str1.isEmpty() && !str2.isEmpty() ) {
     return false;
-  if ( !str1.isEmpty() && str2.isEmpty() )
+  }
+  if ( !str1.isEmpty() && str2.isEmpty() ) {
     return true;
+  }
 
   return str1.localeAwareCompare( str2 ) < 0;
 }
@@ -162,16 +172,18 @@ void OrderAndProps::dictionarySelectionChanged( const QItemSelection & current, 
 {
   Q_UNUSED( deselected )
 
-  if ( current.empty() )
+  if ( current.empty() ) {
     return;
+  }
 
   describeDictionary( ui.dictionaryOrder, ui.searchLine->mapToSource( current.front().topLeft() ) );
 }
 
 void OrderAndProps::inactiveDictionarySelectionChanged( QItemSelection const & current )
 {
-  if ( current.empty() )
+  if ( current.empty() ) {
     return;
+  }
   describeDictionary( ui.inactiveDictionaries, current.front().topLeft() );
 }
 
@@ -195,8 +207,9 @@ void OrderAndProps::disableDictionaryDescription()
 
 void OrderAndProps::describeDictionary( DictListWidget * lst, QModelIndex const & idx )
 {
-  if ( !idx.isValid() || (unsigned)idx.row() >= lst->getCurrentDictionaries().size() )
+  if ( !idx.isValid() || (unsigned)idx.row() >= lst->getCurrentDictionaries().size() ) {
     disableDictionaryDescription();
+  }
   else {
     sptr< Dictionary::Class > dict = lst->getCurrentDictionaries()[ idx.row() ];
 
@@ -249,8 +262,9 @@ void OrderAndProps::contextMenuRequested( const QPoint & pos )
   QAction * showHeadwordsAction = NULL;
   QModelIndex idx               = ui.searchLine->mapToSource( ui.dictionaryOrder->indexAt( pos ) );
   sptr< Dictionary::Class > dict;
-  if ( idx.isValid() && (unsigned)idx.row() < ui.dictionaryOrder->getCurrentDictionaries().size() )
+  if ( idx.isValid() && (unsigned)idx.row() < ui.dictionaryOrder->getCurrentDictionaries().size() ) {
     dict = ui.dictionaryOrder->getCurrentDictionaries()[ idx.row() ];
+  }
   if ( dict && dict->getWordCount() > 0 ) {
     showHeadwordsAction = new QAction( tr( "Dictionary headwords" ), &menu );
     menu.addAction( showHeadwordsAction );
@@ -265,10 +279,12 @@ void OrderAndProps::contextMenuRequested( const QPoint & pos )
 
   if ( result == sortNameAction || result == sortLangAction ) {
     vector< sptr< Dictionary::Class > > sortedDicts = ui.dictionaryOrder->getCurrentDictionaries();
-    if ( result == sortNameAction )
+    if ( result == sortNameAction ) {
       sort( sortedDicts.begin(), sortedDicts.end(), dictNameLessThan );
-    else
+    }
+    else {
       sort( sortedDicts.begin(), sortedDicts.end(), dictLessThan );
+    }
     ui.dictionaryOrder->populate( sortedDicts );
   }
 

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -61,8 +61,9 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
     //remove .qm suffix.
     QString locale = availLoc.left( availLoc.size() - 3 );
 
-    if ( locale == "qt" )
+    if ( locale == "qt" ) {
       continue; // We skip qt's own localizations
+    }
 
     auto language = Language::languageForLocale( locale );
     if ( language.isEmpty() ) {
@@ -94,29 +95,33 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   prevWebFontFamily = p.customFonts;
   prevSysFont       = p.interfaceFont;
 
-  if ( !p.customFonts.standard.isEmpty() )
+  if ( !p.customFonts.standard.isEmpty() ) {
     ui.font_standard->setCurrentText( p.customFonts.standard );
+  }
   else {
     ui.font_standard->setCurrentFont(
       QWebEngineProfile::defaultProfile()->settings()->fontFamily( QWebEngineSettings::StandardFont ) );
   }
 
-  if ( !p.customFonts.serif.isEmpty() )
+  if ( !p.customFonts.serif.isEmpty() ) {
     ui.font_serif->setCurrentText( p.customFonts.serif );
+  }
   else {
     ui.font_serif->setCurrentFont(
       QWebEngineProfile::defaultProfile()->settings()->fontFamily( QWebEngineSettings::SerifFont ) );
   }
 
-  if ( !p.customFonts.sansSerif.isEmpty() )
+  if ( !p.customFonts.sansSerif.isEmpty() ) {
     ui.font_sans->setCurrentText( p.customFonts.sansSerif );
+  }
   else {
     ui.font_sans->setCurrentFont(
       QWebEngineProfile::defaultProfile()->settings()->fontFamily( QWebEngineSettings::SansSerifFont ) );
   }
 
-  if ( !p.customFonts.monospace.isEmpty() )
+  if ( !p.customFonts.monospace.isEmpty() ) {
     ui.font_monospace->setCurrentText( p.customFonts.monospace );
+  }
   else {
     ui.font_monospace->setCurrentFont(
       QWebEngineProfile::defaultProfile()->settings()->fontFamily( QWebEngineSettings::FixedFont ) );
@@ -270,8 +275,9 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
     ui.useInternalPlayer->setChecked( p.useInternalPlayer );
 
     int index = ui.internalPlayerBackend->findText( p.internalPlayerBackend.uiName() );
-    if ( index < 0 ) // The specified backend is unavailable.
+    if ( index < 0 ) { // The specified backend is unavailable.
       index = ui.internalPlayerBackend->findText( Config::InternalPlayerBackend::defaultBackend().uiName() );
+    }
     Q_ASSERT( index >= 0 && "Logic error: the default backend must be present in the backend name list." );
     ui.internalPlayerBackend->setCurrentIndex( index );
   }
@@ -366,8 +372,9 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
 void Preferences::buildDisabledTypes( QString & disabledTypes, bool is_checked, QString name )
 {
   if ( !is_checked ) {
-    if ( !disabledTypes.isEmpty() )
+    if ( !disabledTypes.isEmpty() ) {
       disabledTypes += ',';
+    }
     disabledTypes += name;
   }
 }
@@ -513,14 +520,16 @@ Config::Preferences Preferences::getPreferences()
 void Preferences::enableScanPopupModifiersToggled( bool b )
 {
   ui.scanPopupModifiers->setEnabled( b );
-  if ( b )
+  if ( b ) {
     ui.showScanFlag->setChecked( false );
+  }
 }
 
 void Preferences::showScanFlagToggled( bool b )
 {
-  if ( b )
+  if ( b ) {
     ui.enableScanPopupModifiers->setChecked( false );
+  }
 }
 
 void Preferences::on_enableMainWindowHotkey_toggled( bool checked )

--- a/src/ui/scanflag.cc
+++ b/src/ui/scanflag.cc
@@ -37,20 +37,23 @@ void ScanFlag::pushButtonClicked()
 
 void ScanFlag::hideWindow()
 {
-  if ( isVisible() )
+  if ( isVisible() ) {
     hide();
+  }
 }
 
 void ScanFlag::showScanFlag()
 {
-  if ( isVisible() )
+  if ( isVisible() ) {
     hide();
+  }
 
   QPoint currentPos = QCursor::pos();
 
   auto screen = QGuiApplication::screenAt( currentPos );
-  if ( !screen )
+  if ( !screen ) {
     return;
+  }
 
   QRect desktop = screen->geometry();
 

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -141,14 +141,16 @@ ScanPopup::ScanPopup( QWidget * parent,
 
   Instances::Group const * igrp = groups.findGroup( cfg.lastPopupGroupId );
   if ( cfg.lastPopupGroupId == Instances::Group::AllGroupId ) {
-    if ( igrp )
+    if ( igrp ) {
       igrp->checkMutedDictionaries( &cfg.popupMutedDictionaries );
+    }
     dictionaryBar.setMutedDictionaries( &cfg.popupMutedDictionaries );
   }
   else {
     Config::Group * grp = cfg.getGroup( cfg.lastPopupGroupId );
-    if ( igrp && grp )
+    if ( igrp && grp ) {
       igrp->checkMutedDictionaries( &grp->popupMutedDictionaries );
+    }
     dictionaryBar.setMutedDictionaries( grp ? &grp->popupMutedDictionaries : nullptr );
   }
 
@@ -163,19 +165,22 @@ ScanPopup::ScanPopup( QWidget * parent,
            &PronounceEngine::emitAudio,
            this,
            [ this ]( auto audioUrl ) {
-             if ( !isActiveWindow() )
+             if ( !isActiveWindow() ) {
                return;
+             }
              if ( cfg.preferences.pronounceOnLoadPopup ) {
 
                definition->openLink( QUrl::fromEncoded( audioUrl.toUtf8() ), {} );
              }
            } );
   pinnedGeometry = cfg.popupWindowGeometry;
-  if ( cfg.popupWindowGeometry.size() )
+  if ( cfg.popupWindowGeometry.size() ) {
     restoreGeometry( cfg.popupWindowGeometry );
+  }
 
-  if ( cfg.popupWindowState.size() )
+  if ( cfg.popupWindowState.size() ) {
     restoreState( cfg.popupWindowState );
+  }
 
   ui.onTopButton->setChecked( cfg.popupWindowAlwaysOnTop );
   ui.onTopButton->setVisible( cfg.pinPopupWindow );
@@ -186,8 +191,9 @@ ScanPopup::ScanPopup( QWidget * parent,
   if ( cfg.pinPopupWindow ) {
     dictionaryBar.setMovable( true );
     Qt::WindowFlags flags = pinnedWindowFlags;
-    if ( cfg.popupWindowAlwaysOnTop )
+    if ( cfg.popupWindowAlwaysOnTop ) {
       flags |= Qt::WindowStaysOnTopHint;
+    }
     setWindowFlags( flags );
 #ifdef Q_OS_MACOS
     setAttribute( Qt::WA_MacAlwaysShowToolWindow );
@@ -336,8 +342,9 @@ void ScanPopup::saveConfigData() const
 
 void ScanPopup::inspectElementWhenPinned( QWebEnginePage * page )
 {
-  if ( cfg.pinPopupWindow )
+  if ( cfg.pinPopupWindow ) {
     emit inspectSignal( page );
+  }
 }
 
 void ScanPopup::applyZoomFactor() const
@@ -352,8 +359,9 @@ void ScanPopup::applyWordsZoomLevel()
 
   if ( cfg.preferences.wordsZoomLevel != 0 ) {
     ps += cfg.preferences.wordsZoomLevel;
-    if ( ps < 1 )
+    if ( ps < 1 ) {
       ps = 1;
+    }
     font.setPointSize( ps );
   }
 
@@ -366,21 +374,24 @@ void ScanPopup::applyWordsZoomLevel()
 
   if ( cfg.preferences.wordsZoomLevel != 0 ) {
     ps += cfg.preferences.wordsZoomLevel;
-    if ( ps < 1 )
+    if ( ps < 1 ) {
       ps = 1;
+    }
     font.setPointSize( ps );
   }
 
-  if ( ui.translateBox->translateLine()->font().pointSize() != ps )
+  if ( ui.translateBox->translateLine()->font().pointSize() != ps ) {
     ui.translateBox->translateLine()->setFont( font );
+  }
 
   font = groupListDefaultFont;
   ps   = font.pointSize();
 
   if ( cfg.preferences.wordsZoomLevel != 0 ) {
     ps += cfg.preferences.wordsZoomLevel;
-    if ( ps < 1 )
+    if ( ps < 1 ) {
       ps = 1;
+    }
     font.setPointSize( ps );
   }
 
@@ -432,8 +443,9 @@ void ScanPopup::translateWord( QString const & word )
 {
   pendingWord = cfg.preferences.sanitizeInputPhrase( word );
 
-  if ( pendingWord.isEmpty() )
+  if ( pendingWord.isEmpty() ) {
     return; // Nothing there
+  }
 
 #ifdef HAVE_X11
   emit hideScanFlag();
@@ -488,8 +500,9 @@ void ScanPopup::engagePopup( bool forcePopup, bool giveFocus )
       QPoint currentPos = QCursor::pos();
 
       auto screen = QGuiApplication::screenAt( currentPos );
-      if ( !screen )
+      if ( !screen ) {
         return;
+      }
 
       QRect desktop = screen->geometry();
 
@@ -498,32 +511,39 @@ void ScanPopup::engagePopup( bool forcePopup, bool giveFocus )
       int x, y;
 
       /// Try the to-the-right placement
-      if ( currentPos.x() + 4 + windowSize.width() <= desktop.topRight().x() )
+      if ( currentPos.x() + 4 + windowSize.width() <= desktop.topRight().x() ) {
         x = currentPos.x() + 4;
+      }
       else
         /// Try the to-the-left placement
-        if ( currentPos.x() - 4 - windowSize.width() >= desktop.x() )
+        if ( currentPos.x() - 4 - windowSize.width() >= desktop.x() ) {
           x = currentPos.x() - 4 - windowSize.width();
-        else
+        }
+        else {
           // Center it
           x = desktop.x() + ( desktop.width() - windowSize.width() ) / 2;
+        }
 
       /// Try the to-the-bottom placement
-      if ( currentPos.y() + 15 + windowSize.height() <= desktop.bottomLeft().y() )
+      if ( currentPos.y() + 15 + windowSize.height() <= desktop.bottomLeft().y() ) {
         y = currentPos.y() + 15;
+      }
       else
         /// Try the to-the-top placement
-        if ( currentPos.y() - 15 - windowSize.height() >= desktop.y() )
+        if ( currentPos.y() - 15 - windowSize.height() >= desktop.y() ) {
           y = currentPos.y() - 15 - windowSize.height();
-        else
+        }
+        else {
           // Center it
           y = desktop.y() + ( desktop.height() - windowSize.height() ) / 2;
+        }
 
       move( x, y );
     }
     else {
-      if ( pinnedGeometry.size() > 0 )
+      if ( pinnedGeometry.size() > 0 ) {
         restoreGeometry( pinnedGeometry );
+      }
     }
 
     show();
@@ -551,8 +571,9 @@ void ScanPopup::engagePopup( bool forcePopup, bool giveFocus )
     }
   }
 
-  if ( ui.pinButton->isChecked() )
+  if ( ui.pinButton->isChecked() ) {
     setWindowTitle( QString( "%1 - GoldenDict-ng" ).arg( elideInputWord() ) );
+  }
 
   /// Too large strings make window expand which is probably not what user
   /// wants
@@ -571,19 +592,22 @@ void ScanPopup::currentGroupChanged( int )
   cfg.lastPopupGroupId          = ui.groupList->getCurrentGroup();
   Instances::Group const * igrp = groups.findGroup( cfg.lastPopupGroupId );
   if ( cfg.lastPopupGroupId == Instances::Group::AllGroupId ) {
-    if ( igrp )
+    if ( igrp ) {
       igrp->checkMutedDictionaries( &cfg.popupMutedDictionaries );
+    }
     dictionaryBar.setMutedDictionaries( &cfg.popupMutedDictionaries );
   }
   else {
     Config::Group * grp = cfg.getGroup( cfg.lastPopupGroupId );
     if ( grp ) {
-      if ( igrp )
+      if ( igrp ) {
         igrp->checkMutedDictionaries( &grp->popupMutedDictionaries );
+      }
       dictionaryBar.setMutedDictionaries( &grp->popupMutedDictionaries );
     }
-    else
+    else {
       dictionaryBar.setMutedDictionaries( nullptr );
+    }
   }
 
   updateDictionaryBar();
@@ -713,8 +737,9 @@ bool ScanPopup::eventFilter( QObject * watched, QEvent * event )
       const QString text = key_event->text();
 
       if ( Utils::ignoreKeyEvent( key_event ) || key_event->key() == Qt::Key_Return
-           || key_event->key() == Qt::Key_Enter )
+           || key_event->key() == Qt::Key_Enter ) {
         return false; // Those key have other uses than to start typing
+      }
       // or don't make sense
       if ( !text.isEmpty() ) {
         typingEvent( text );
@@ -754,10 +779,12 @@ void ScanPopup::reactOnMouseMove( QPoint const & p )
       // If the mouse never entered the popup, hide the window instantly --
       // the user just moved the cursor further away from the window.
 
-      if ( !mouseEnteredOnce )
+      if ( !mouseEnteredOnce ) {
         hideWindow();
-      else
+      }
+      else {
         hideTimer.start();
+      }
     }
   }
 }
@@ -842,8 +869,9 @@ void ScanPopup::showEvent( QShowEvent * ev )
 {
   QMainWindow::showEvent( ev );
 
-  if ( groups.size() <= 1 ) // Only the default group? Hide then.
+  if ( groups.size() <= 1 ) { // Only the default group? Hide then.
     ui.groupList->hide();
+  }
 
   if ( ui.showDictionaryBar->isChecked() != dictionaryBar.isVisible() ) {
     ui.showDictionaryBar->setChecked( dictionaryBar.isVisible() );
@@ -853,16 +881,18 @@ void ScanPopup::showEvent( QShowEvent * ev )
 
 void ScanPopup::closeEvent( QCloseEvent * ev )
 {
-  if ( isVisible() && ui.pinButton->isChecked() )
+  if ( isVisible() && ui.pinButton->isChecked() ) {
     pinnedGeometry = saveGeometry();
+  }
 
   QMainWindow::closeEvent( ev );
 }
 
 void ScanPopup::moveEvent( QMoveEvent * ev )
 {
-  if ( isVisible() && ui.pinButton->isChecked() )
+  if ( isVisible() && ui.pinButton->isChecked() ) {
     pinnedGeometry = saveGeometry();
+  }
 
   QMainWindow::moveEvent( ev );
 }
@@ -907,8 +937,9 @@ void ScanPopup::pinButtonClicked( bool checked )
 
     ui.onTopButton->setVisible( true );
     Qt::WindowFlags flags = pinnedWindowFlags;
-    if ( ui.onTopButton->isChecked() )
+    if ( ui.onTopButton->isChecked() ) {
       flags |= Qt::WindowStaysOnTopHint;
+    }
     setWindowFlags( flags );
 
 #ifdef Q_OS_MACOS
@@ -934,14 +965,16 @@ void ScanPopup::pinButtonClicked( bool checked )
 
   show();
 
-  if ( checked )
+  if ( checked ) {
     pinnedGeometry = saveGeometry();
+  }
 }
 
 void ScanPopup::focusTranslateLine()
 {
-  if ( !isActiveWindow() )
+  if ( !isActiveWindow() ) {
     activateWindow();
+  }
 
   ui.translateBox->translateLine()->setFocus();
   ui.translateBox->translateLine()->selectAll();
@@ -961,18 +994,21 @@ void ScanPopup::on_showDictionaryBar_clicked( bool checked )
 
 void ScanPopup::hideTimerExpired()
 {
-  if ( isVisible() )
+  if ( isVisible() ) {
     hideWindow();
+  }
 }
 
 void ScanPopup::pageLoaded( ArticleView * ) const
 {
-  if ( !isVisible() )
+  if ( !isVisible() ) {
     return;
+  }
   auto pronounceBtn = ui.pronounceButton;
   definition->hasSound( [ pronounceBtn ]( bool has ) {
-    if ( pronounceBtn )
+    if ( pronounceBtn ) {
       pronounceBtn->setDisabled( !has );
+    }
   } );
 
   updateBackForwardButtons();
@@ -985,8 +1021,9 @@ void ScanPopup::showStatusBarMessage( QString const & message, int timeout, QPix
 
 void ScanPopup::escapePressed()
 {
-  if ( !definition->closeSearch() )
+  if ( !definition->closeSearch() ) {
     hideWindow();
+  }
 }
 
 void ScanPopup::hideWindow()
@@ -1020,8 +1057,9 @@ void ScanPopup::interceptMouse()
 
 void ScanPopup::mouseGrabPoll()
 {
-  if ( mouseIntercepted )
+  if ( mouseIntercepted ) {
     reactOnMouseMove( QCursor::pos() );
+  }
 }
 
 void ScanPopup::uninterceptMouse()
@@ -1037,17 +1075,20 @@ void ScanPopup::uninterceptMouse()
 
 void ScanPopup::updateDictionaryBar()
 {
-  if ( !dictionaryBar.toggleViewAction()->isChecked() )
+  if ( !dictionaryBar.toggleViewAction()->isChecked() ) {
     return; // It's not enabled, therefore hidden -- don't waste time
+  }
 
   unsigned currentId           = ui.groupList->getCurrentGroup();
   Instances::Group const * grp = groups.findGroup( currentId );
 
-  if ( grp ) // Should always be !0, but check as a safeguard
+  if ( grp ) { // Should always be !0, but check as a safeguard
     dictionaryBar.setDictionaries( grp->dictionaries );
+  }
 
-  if ( currentId == Instances::Group::AllGroupId )
+  if ( currentId == Instances::Group::AllGroupId ) {
     dictionaryBar.setMutedDictionaries( &cfg.popupMutedDictionaries );
+  }
   else {
     Config::Group * group = cfg.getGroup( currentId );
     dictionaryBar.setMutedDictionaries( group ? &group->popupMutedDictionaries : nullptr );
@@ -1059,14 +1100,16 @@ void ScanPopup::updateDictionaryBar()
 void ScanPopup::mutedDictionariesChanged()
 {
   updateSuggestionList();
-  if ( dictionaryBar.toggleViewAction()->isChecked() )
+  if ( dictionaryBar.toggleViewAction()->isChecked() ) {
     definition->updateMutedContents();
+  }
 }
 
 void ScanPopup::on_sendWordButton_clicked()
 {
-  if ( !isVisible() )
+  if ( !isVisible() ) {
     return;
+  }
   if ( !ui.pinButton->isChecked() ) {
     definition->closeSearch();
     hideWindow();
@@ -1076,8 +1119,9 @@ void ScanPopup::on_sendWordButton_clicked()
 
 void ScanPopup::on_sendWordToFavoritesButton_clicked()
 {
-  if ( !isVisible() )
+  if ( !isVisible() ) {
     return;
+  }
   unsigned groupId   = ui.groupList->getCurrentGroup();
   auto current_exist = isWordPresentedInFavorites( definition->getTitle(), groupId );
   //if current_exist=false( not exist ),  after click ,the word should be in the favorite which is blueStar
@@ -1087,8 +1131,9 @@ void ScanPopup::on_sendWordToFavoritesButton_clicked()
 
 void ScanPopup::switchExpandOptionalPartsMode()
 {
-  if ( isVisible() )
+  if ( isVisible() ) {
     emit switchExpandMode();
+  }
 }
 
 void ScanPopup::updateBackForwardButtons() const
@@ -1130,8 +1175,9 @@ void ScanPopup::setGroupByName( QString const & name ) const
       break;
     }
   }
-  if ( i >= ui.groupList->count() )
+  if ( i >= ui.groupList->count() ) {
     gdWarning( "Group \"%s\" for popup window is not found\n", name.toUtf8().data() );
+  }
 }
 
 void ScanPopup::openSearch()
@@ -1144,12 +1190,15 @@ void ScanPopup::alwaysOnTopClicked( bool checked )
   bool wasVisible = isVisible();
   if ( ui.pinButton->isChecked() ) {
     Qt::WindowFlags flags = this->windowFlags();
-    if ( checked )
+    if ( checked ) {
       setWindowFlags( flags | Qt::WindowStaysOnTopHint );
-    else
+    }
+    else {
       setWindowFlags( flags ^ Qt::WindowStaysOnTopHint );
-    if ( wasVisible )
+    }
+    if ( wasVisible ) {
       show();
+    }
   }
 }
 

--- a/src/ui/stylescombobox.cc
+++ b/src/ui/stylescombobox.cc
@@ -36,7 +36,8 @@ void StylesComboBox::setCurrentStyle( QString const & style )
 
 QString StylesComboBox::getCurrentStyle() const
 {
-  if ( currentIndex() == 0 )
+  if ( currentIndex() == 0 ) {
     return {};
+  }
   return itemText( currentIndex() );
 }

--- a/src/ui/translatebox.cc
+++ b/src/ui/translatebox.cc
@@ -71,8 +71,9 @@ void TranslateBox::setPopupEnabled( bool enable )
 void TranslateBox::setSizePolicy( QSizePolicy policy )
 {
   QWidget::setSizePolicy( policy );
-  if ( translate_line )
+  if ( translate_line ) {
     translate_line->setSizePolicy( policy );
+  }
 }
 
 void TranslateBox::setModel( QStringList & _words )

--- a/src/webmultimediadownload.cc
+++ b/src/webmultimediadownload.cc
@@ -27,8 +27,9 @@ void WebMultimediaDownload::cancel()
 
 void WebMultimediaDownload::replyFinished( QNetworkReply * r )
 {
-  if ( !r || r != reply )
+  if ( !r || r != reply ) {
     return; // Not our reply
+  }
 
   if ( r->error() == QNetworkReply::NoError ) {
     // Check for redirect reply
@@ -62,8 +63,9 @@ void WebMultimediaDownload::replyFinished( QNetworkReply * r )
 
     hasAnyData = true;
   }
-  else
+  else {
     setErrorString( r->errorString() );
+  }
 
   disconnect( r, 0, 0, 0 );
   r->deleteLater();

--- a/src/wordfinder.cc
+++ b/src/wordfinder.cc
@@ -80,8 +80,9 @@ void WordFinder::stemmedMatch( QString const & str,
   resultsIndex.clear();
   searchResults.clear();
 
-  if ( queuedRequests.empty() )
+  if ( queuedRequests.empty() ) {
     startSearch();
+  }
 }
 
 void WordFinder::expressionMatch( QString const & str,
@@ -110,8 +111,9 @@ void WordFinder::expressionMatch( QString const & str,
 
 void WordFinder::startSearch()
 {
-  if ( !searchQueued )
+  if ( !searchQueued ) {
     return; // Search was probably cancelled
+  }
 
   // Clear the requests just in case
   queuedRequests.clear();
@@ -125,8 +127,9 @@ void WordFinder::startSearch()
 
   // Gather all writings of the word
 
-  if ( allWordWritings.size() != 1 )
+  if ( allWordWritings.size() != 1 ) {
     allWordWritings.resize( 1 );
+  }
 
   allWordWritings[ 0 ] = gd::toWString( inputWord );
 
@@ -139,8 +142,9 @@ void WordFinder::startSearch()
   // Query each dictionary for all word writings
 
   for ( const auto & inputDict : *inputDicts ) {
-    if ( ( inputDict->getFeatures() & requestedFeatures ) != requestedFeatures )
+    if ( ( inputDict->getFeatures() & requestedFeatures ) != requestedFeatures ) {
       continue;
+    }
 
     for ( const auto & allWordWriting : allWordWritings ) {
       try {
@@ -188,11 +192,13 @@ void WordFinder::requestFinished()
   // See how many new requests have finished, and if we have any new results
   for ( auto i = queuedRequests.begin(); i != queuedRequests.end(); ) {
     if ( ( *i )->isFinished() ) {
-      if ( searchInProgress && !( *i )->getErrorString().isEmpty() )
+      if ( searchInProgress && !( *i )->getErrorString().isEmpty() ) {
         searchErrorString = tr( "Failed to query some dictionaries." );
+      }
 
-      if ( ( *i )->isUncertain() )
+      if ( ( *i )->isUncertain() ) {
         searchResultsUncertain = true;
+      }
 
       if ( ( *i )->matchesCount() ) {
         newResults = true;
@@ -200,11 +206,13 @@ void WordFinder::requestFinished()
         // This list is handled by updateResults()
         finishedRequests.splice( finishedRequests.end(), queuedRequests, i++ );
       }
-      else // We won't do anything with it anymore, so we erase it
+      else { // We won't do anything with it anymore, so we erase it
         queuedRequests.erase( i++ );
+      }
     }
-    else
+    else {
       ++i;
+    }
   }
 
   if ( !searchInProgress ) {
@@ -215,8 +223,9 @@ void WordFinder::requestFinished()
       // We got rid of all queries, queued search can now start
       finishedRequests.clear();
 
-      if ( searchQueued )
+      if ( searchQueued ) {
         startSearch();
+      }
     }
 
     return;
@@ -248,14 +257,16 @@ unsigned saturated( unsigned x )
 /// is larger than 255, it is set to 255.
 bool hasSurroundedWithWs( wstring const & haystack, wstring const & needle, wstring::size_type & pos )
 {
-  if ( haystack.size() < needle.size() )
+  if ( haystack.size() < needle.size() ) {
     return false; // Needle won't even fit into a haystack
+  }
 
   for ( pos = 0;; ++pos ) {
     pos = haystack.find( needle, pos );
 
-    if ( pos == wstring::npos )
+    if ( pos == wstring::npos ) {
       return false; // Not found
+    }
 
     if ( ( !pos || Folding::isWhitespace( haystack[ pos - 1 ] ) || Folding::isPunct( haystack[ pos - 1 ] ) )
          && ( ( pos + needle.size() == haystack.size() ) || Folding::isWhitespace( haystack[ pos + needle.size() ] )
@@ -271,11 +282,13 @@ bool hasSurroundedWithWs( wstring const & haystack, wstring const & needle, wstr
 
 void WordFinder::updateResults()
 {
-  if ( !searchInProgress )
+  if ( !searchInProgress ) {
     return; // Old queued signal
+  }
 
-  if ( updateResultsTimer.isActive() )
+  if ( updateResultsTimer.isActive() ) {
     updateResultsTimer.stop(); // Can happen when we were done before it'd expire
+  }
 
   wstring original = Folding::applySimpleCaseOnly( allWordWritings[ 0 ] );
 
@@ -291,11 +304,13 @@ void WordFinder::updateResults()
         for ( ws = 0; ws < allWordWritings.size(); ws++ ) {
           if ( ws == 0 ) {
             // Check for prefix match with original expression
-            if ( lowerCased.compare( 0, original.size(), original ) == 0 )
+            if ( lowerCased.compare( 0, original.size(), original ) == 0 ) {
               break;
+            }
           }
-          else if ( lowerCased == Folding::applySimpleCaseOnly( allWordWritings[ ws ] ) )
+          else if ( lowerCased == Folding::applySimpleCaseOnly( allWordWritings[ ws ] ) ) {
             break;
+          }
         }
 
         if ( ws >= allWordWritings.size() ) {
@@ -313,8 +328,9 @@ void WordFinder::updateResults()
           // The case is different -- agree on a lowercase version
           insertResult.first->second->word = lowerCased;
         }
-        if ( !weight && insertResult.first->second->wasSuggested )
+        if ( !weight && insertResult.first->second->wasSuggested ) {
           insertResult.first->second->wasSuggested = false;
+        }
       }
       else {
         resultsArray.emplace_back();
@@ -366,38 +382,52 @@ void WordFinder::updateResults()
 
           int rank;
 
-          if ( i.first == target )
+          if ( i.first == target ) {
             rank = ExactMatch * Multiplier;
-          else if ( ( resultNoFullCase = Folding::applyFullCaseOnly( i.first ) ) == targetNoFullCase )
+          }
+          else if ( ( resultNoFullCase = Folding::applyFullCaseOnly( i.first ) ) == targetNoFullCase ) {
             rank = ExactNoFullCaseMatch * Multiplier;
-          else if ( ( resultNoDia = Folding::applyDiacriticsOnly( resultNoFullCase ) ) == targetNoDia )
+          }
+          else if ( ( resultNoDia = Folding::applyDiacriticsOnly( resultNoFullCase ) ) == targetNoDia ) {
             rank = ExactNoDiaMatch * Multiplier;
-          else if ( ( resultNoPunct = Folding::applyPunctOnly( resultNoDia ) ) == targetNoPunct )
+          }
+          else if ( ( resultNoPunct = Folding::applyPunctOnly( resultNoDia ) ) == targetNoPunct ) {
             rank = ExactNoPunctMatch * Multiplier;
-          else if ( ( resultNoWs = Folding::applyWhitespaceOnly( resultNoPunct ) ) == targetNoWs )
+          }
+          else if ( ( resultNoWs = Folding::applyWhitespaceOnly( resultNoPunct ) ) == targetNoWs ) {
             rank = ExactNoWsMatch * Multiplier;
-          else if ( hasSurroundedWithWs( i.first, target, matchPos ) )
+          }
+          else if ( hasSurroundedWithWs( i.first, target, matchPos ) ) {
             rank = ExactInsideMatch * Multiplier + matchPos;
-          else if ( hasSurroundedWithWs( resultNoDia, targetNoDia, matchPos ) )
+          }
+          else if ( hasSurroundedWithWs( resultNoDia, targetNoDia, matchPos ) ) {
             rank = ExactNoDiaInsideMatch * Multiplier + matchPos;
-          else if ( hasSurroundedWithWs( resultNoPunct, targetNoPunct, matchPos ) )
+          }
+          else if ( hasSurroundedWithWs( resultNoPunct, targetNoPunct, matchPos ) ) {
             rank = ExactNoPunctInsideMatch * Multiplier + matchPos;
-          else if ( i.first.size() > target.size() && i.first.compare( 0, target.size(), target ) == 0 )
+          }
+          else if ( i.first.size() > target.size() && i.first.compare( 0, target.size(), target ) == 0 ) {
             rank = PrefixMatch * Multiplier + saturated( i.first.size() );
+          }
           else if ( resultNoDia.size() > targetNoDia.size()
-                    && resultNoDia.compare( 0, targetNoDia.size(), targetNoDia ) == 0 )
+                    && resultNoDia.compare( 0, targetNoDia.size(), targetNoDia ) == 0 ) {
             rank = PrefixNoDiaMatch * Multiplier + saturated( i.first.size() );
+          }
           else if ( resultNoPunct.size() > targetNoPunct.size()
-                    && resultNoPunct.compare( 0, targetNoPunct.size(), targetNoPunct ) == 0 )
+                    && resultNoPunct.compare( 0, targetNoPunct.size(), targetNoPunct ) == 0 ) {
             rank = PrefixNoPunctMatch * Multiplier + saturated( i.first.size() );
+          }
           else if ( resultNoWs.size() > targetNoWs.size()
-                    && resultNoWs.compare( 0, targetNoWs.size(), targetNoWs ) == 0 )
+                    && resultNoWs.compare( 0, targetNoWs.size(), targetNoWs ) == 0 ) {
             rank = PrefixNoWsMatch * Multiplier + saturated( i.first.size() );
-          else
+          }
+          else {
             rank = WorstMatch * Multiplier;
+          }
 
-          if ( i.second->rank > rank )
+          if ( i.second->rank > rank ) {
             i.second->rank = rank; // We store the best rank of any writing
+          }
         }
       }
 
@@ -418,15 +448,18 @@ void WordFinder::updateResults()
 
           int charsInCommon = 0;
 
-          for ( wchar const *t = target.c_str(), *r = resultFolded.c_str(); *t && *t == *r; ++t, ++r, ++charsInCommon )
+          for ( wchar const *t = target.c_str(), *r = resultFolded.c_str(); *t && *t == *r;
+                ++t, ++r, ++charsInCommon ) {
             ;
+          }
 
           int rank = -charsInCommon; // Negated so the lesser-than
                                      // comparison would yield right
                                      // results.
 
-          if ( i.second->rank > rank )
+          if ( i.second->rank > rank ) {
             i.second->rank = rank; // We store the best rank of any writing
+          }
         }
       }
 
@@ -440,10 +473,12 @@ void WordFinder::updateResults()
   searchResults.reserve( resultsArray.size() < maxSearchResults ? resultsArray.size() : maxSearchResults );
 
   for ( const auto & i : resultsArray ) {
-    if ( searchResults.size() < maxSearchResults )
+    if ( searchResults.size() < maxSearchResults ) {
       searchResults.emplace_back( QString::fromStdU32String( i.word ), i.wasSuggested );
-    else
+    }
+    else {
       break;
+    }
   }
 
   if ( !queuedRequests.empty() ) {
@@ -459,6 +494,7 @@ void WordFinder::updateResults()
 
 void WordFinder::cancelSearches()
 {
-  for ( auto & queuedRequest : queuedRequests )
+  for ( auto & queuedRequest : queuedRequests ) {
     queuedRequest->cancel();
+  }
 }

--- a/thirdparty/qtsingleapplication/src/qtlocalpeer.cpp
+++ b/thirdparty/qtsingleapplication/src/qtlocalpeer.cpp
@@ -109,16 +109,18 @@ bool QtLocalPeer::isClient()
         res = server->listen(socketName);
     }
 #endif
-    if (!res)
+    if (!res) {
         qWarning("QtSingleCoreApplication: listen on local socket failed, %s", qPrintable(server->errorString()));
+}
     QObject::connect( server, &QLocalServer::newConnection, this, &QtLocalPeer::receiveConnection );
     return false;
 }
 
 bool QtLocalPeer::sendMessage(const QString &message, int timeout)
 {
-    if (!isClient())
+    if (!isClient()) {
         return false;
+}
 
     QLocalSocket socket;
     bool connOk = false;
@@ -126,8 +128,9 @@ bool QtLocalPeer::sendMessage(const QString &message, int timeout)
         // Try twice, in case the other instance is just starting up
         socket.connectToServer(socketName);
         connOk = socket.waitForConnected(timeout/2);
-        if (connOk || i)
+        if (connOk || i) {
             break;
+}
         int ms = 250;
 #if defined(Q_OS_WIN)
         Sleep(DWORD(ms));
@@ -136,8 +139,9 @@ bool QtLocalPeer::sendMessage(const QString &message, int timeout)
         nanosleep(&ts, NULL);
 #endif
     }
-    if (!connOk)
+    if (!connOk) {
         return false;
+}
 
     QByteArray uMsg(message.toUtf8());
     QDataStream ds(&socket);
@@ -145,8 +149,9 @@ bool QtLocalPeer::sendMessage(const QString &message, int timeout)
     bool res = socket.waitForBytesWritten(timeout);
     if (res) {
         res &= socket.waitForReadyRead(timeout);   // wait for ack
-        if (res)
+        if (res) {
             res &= (socket.read(qstrlen(ack)) == ack);
+}
     }
     return res;
 }
@@ -154,11 +159,13 @@ bool QtLocalPeer::sendMessage(const QString &message, int timeout)
 void QtLocalPeer::receiveConnection()
 {
     QLocalSocket* socket = server->nextPendingConnection();
-    if (!socket)
+    if (!socket) {
         return;
+}
 
-    while (socket->bytesAvailable() < (int)sizeof(quint32))
+    while (socket->bytesAvailable() < (int)sizeof(quint32)) {
         socket->waitForReadyRead();
+}
     QDataStream ds(socket);
     QByteArray uMsg;
     quint32 remaining;

--- a/thirdparty/qtsingleapplication/src/qtsingleapplication.cpp
+++ b/thirdparty/qtsingleapplication/src/qtsingleapplication.cpp
@@ -231,10 +231,11 @@ QString QtSingleApplication::appId() const
 void QtSingleApplication::setActivationWindow(QWidget* aw, bool activateOnMessage)
 {
     actWin = aw;
-    if (activateOnMessage)
+    if (activateOnMessage) {
       connect( peer, &QtLocalPeer::messageReceived, this, &QtSingleApplication::activateWindow );
-    else
+    } else {
       disconnect( peer, &QtLocalPeer::messageReceived, this, &QtSingleApplication::activateWindow );
+}
 }
 
 


### PR DESCRIPTION
This code style is actually fine:
```cpp
if ()
 doSth();
```

However, there are various abomination styles in GD's code

```cpp
if ()
  if ()
    doSth();
```

```cpp
if () {
  if ()
    doSth();	
}	
```


```cpp
for ()
  if ()
    doSth();
```


```cpp
if ()
  doSth
   but
    crossMultiLines();
```


```cpp
if ()
  doSth1();
else if ()
  doSth2();
```


```cpp
if () {
  doSth1();
} else 
  doSth2();
```


```cpp
for ()
  if () {
    doSth();
  };
```


```cpp
if ( cond1 )
  doSth1();
if ( cond2 which is related to cond1)
  doSth2();
```