### PR TITLE
fix: ctrl+F crashes when last tab is closed

### DIFF
--- a/.github/workflows/PR-check-cmake.yml
+++ b/.github/workflows/PR-check-cmake.yml
@@ -17,6 +17,8 @@ jobs:
     steps:             
       - name: Install dependencies
         run: |
+          sudo apt-get update
+
           sudo apt-get install build-essential ninja-build \
           libvorbis-dev zlib1g-dev libhunspell-dev x11proto-record-dev \
           libxtst-dev liblzo2-dev libbz2-dev \
@@ -34,7 +36,6 @@ jobs:
           qt6-webengine-dev
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
           submodules: false
       - name: Run build
         run: |
@@ -49,7 +50,6 @@ jobs:
     steps:             
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
           submodules: false
       - name: Install dependencies
         run: |
@@ -92,7 +92,6 @@ jobs:
           setup-python: 'false'
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
           submodules: true
       - name: Run build
         run: |

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1851,7 +1851,7 @@ ArticleView * MainWindow::createNewTab( bool switchToIt, QString const & name )
   connect( view, &ArticleView::zoomOut, this, &MainWindow::zoomout );
   connect( view, &ArticleView::saveBookmarkSignal, this, &MainWindow::addBookmarkToFavorite );
 
-  connect( ui.searchInPageAction, &QAction::triggered, this, [ this, view ]() {
+  connect( ui.searchInPageAction, &QAction::triggered, view, [ this, view ]() {
 #ifdef Q_OS_MACOS
     //workaround to fix macos popup page search Ctrl + F
     if ( scanPopup && scanPopup->isActiveWindow() ) {


### PR DESCRIPTION
The root issue is 
```cpp
connect( ui.searchInPageAction, &QAction::triggered, this, [ this, view ]() {
```

The 3rd `this` is mainwinidow, while the`connect` is only valid during the current `view`.

fix https://forum.freemdict.com/t/topic/11495/3513

The workaround for scanpopup is not invalidated by this PR.
