### PR TITLE
feat: decode program dicts as UTF-8 instead of local8bit

### DIFF
--- a/src/dict/programs.cc
+++ b/src/dict/programs.cc
@@ -200,7 +200,7 @@ void RunInstance::handleProcessFinished()
     QByteArray err = process.readAllStandardError();
 
     if ( !err.isEmpty() ) {
-      error += "\n\n" + QString::fromLocal8Bit( err );
+      error += "\n\n" + QString::fromUtf8( err );
     }
   }
 
@@ -253,7 +253,7 @@ void ProgramDataRequest::instanceFinished( QByteArray output, QString error )
             }
             else {
               // No BOM, assume local 8-bit encoding
-              prog_output = QString::fromLocal8Bit( output );
+              prog_output = QString::fromUtf8( output );
             }
           }
           catch ( std::exception & e ) {

--- a/src/dict/programs.cc
+++ b/src/dict/programs.cc
@@ -252,7 +252,7 @@ void ProgramDataRequest::instanceFinished( QByteArray output, QString error )
               prog_output = QString::fromUtf8( output.data() + 3, output.length() - 3 );
             }
             else {
-              // No BOM, assume local 8-bit encoding
+              // No BOM, assume UTF-8 encoding
               prog_output = QString::fromUtf8( output );
             }
           }


### PR DESCRIPTION
This is only a problem for windows. 

And the main issue is that people now usually don't care about whatever the hell is local 8 bit and code pages, and proceed to assume input and output are UTF-8.

Assuming UTF8 is the correct choice.

Sample issue https://forum.freemdict.com/t/topic/32765

Follow up and a mini survey of the issue https://github.com/xiaoyifang/goldendict-ng/pull/1743#issue-2503673868