### PR TITLE
actions: add Archlinux pull request check

### DIFF
--- a/.github/workflows/PR-check-cmake.yml
+++ b/.github/workflows/PR-check-cmake.yml
@@ -106,3 +106,57 @@ jobs:
             -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" `
             -DWITH_FFMPEG_PLAYER=OFF
           cmake --build "./build_dir"
+
+  job_archlinux_build_check:
+    name: archlinux Build and analyze
+    runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/archlinux/archlinux:base-devel
+    steps:
+      - name: Print Version
+        run: |
+          if [[ -f /etc/os-release ]]; then
+            cat /etc/os-release
+          fi
+      - name: Install dependencies
+        run: |
+          # https://github.com/archlinux/archlinux-docker
+          # base-devel is already included in the `base-devel` image
+          pacman --noconfirm -Syuu \
+          cmake \
+          ffmpeg \
+          fmt \
+          hunspell \
+          libvorbis \
+          libxtst \
+          libzim \
+          lzo \
+          ninja \
+          opencc \
+          qt6-5compat \
+          qt6-base \
+          qt6-multimedia \
+          qt6-speech \
+          qt6-svg \
+          qt6-tools \
+          qt6-webengine \
+          tomlplusplus \
+          xapian-core
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+      - name: Run build
+        run: |
+          mkdir build_dir
+          # eb is only available in AUR, so it is disabled
+          cmake -S . \
+            -B ./build_dir \
+            -G Ninja \
+            -DWITH_EPWING_SUPPORT=OFF \
+            -DWITH_FFMPEG_PLAYER=ON \
+            -DWITH_TTS=ON \
+            -DUSE_SYSTEM_FMT=ON \
+            -DUSE_SYSTEM_TOML=ON
+
+          cmake --build ./build_dir


### PR DESCRIPTION
Add a rolling release distro to test issues from very new versions of dependencies.

---

The container used is maintained by "official" Arch Linux team

https://gitlab.archlinux.org/archlinux/archlinux-docker

I choose the one hosted on `ghcr` aka GitHub container registry with tag `base-devel`

https://github.com/archlinux/archlinux-docker/pkgs/container/archlinux

Related github doc https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/running-jobs-in-a-container