### PR TITLE
fix: Revert "clean: open and resave all `.ui` files to adapt Qt6 Designer's enum changes"

### DIFF
--- a/src/ui/about.ui
+++ b/src/ui/about.ui
@@ -3,7 +3,7 @@
  <class>About</class>
  <widget class="QDialog" name="About">
   <property name="windowModality">
-   <enum>Qt::WindowModality::NonModal</enum>
+   <enum>Qt::NonModal</enum>
   </property>
   <property name="geometry">
    <rect>
@@ -46,7 +46,7 @@
         <bool>true</bool>
        </property>
        <property name="alignment">
-        <set>Qt::AlignmentFlag::AlignCenter</set>
+        <set>Qt::AlignCenter</set>
        </property>
        <property name="margin">
         <number>10</number>
@@ -66,7 +66,7 @@
             <string>GoldenDict-ng dictionary lookup program, version </string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
            </property>
           </widget>
          </item>
@@ -79,7 +79,7 @@
             <string notr="true">#.#</string>
            </property>
            <property name="textInteractionFlags">
-            <set>Qt::TextInteractionFlag::TextEditorInteraction</set>
+            <set>Qt::TextEditorInteraction</set>
            </property>
           </widget>
          </item>
@@ -91,7 +91,7 @@
           <string notr="true">(c) 2008-2013 Konstantin Isakov (ikm@goldendict.org)</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
          </property>
         </widget>
        </item>
@@ -101,7 +101,7 @@
           <string>Licensed under GNU GPLv3 or later</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
          </property>
         </widget>
        </item>
@@ -111,7 +111,7 @@
           <string notr="true">Based on Qt #.#.# (GCC #.#, 32/64 bit)</string>
          </property>
          <property name="textInteractionFlags">
-          <set>Qt::TextInteractionFlag::TextEditorInteraction</set>
+          <set>Qt::TextEditorInteraction</set>
          </property>
         </widget>
        </item>
@@ -146,7 +146,7 @@
          <item>
           <spacer name="horizontalSpacer">
            <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
+            <enum>Qt::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -168,7 +168,7 @@
       <string>Credits:</string>
      </property>
      <property name="alignment">
-      <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
@@ -188,10 +188,10 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
+      <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Ok</set>
+      <set>QDialogButtonBox::Ok</set>
      </property>
      <property name="centerButtons">
       <bool>true</bool>

--- a/src/ui/authentication.ui
+++ b/src/ui/authentication.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>428</width>
-    <height>150</height>
+    <width>389</width>
+    <height>120</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -44,24 +44,24 @@
    <item row="2" column="1">
     <widget class="QLineEdit" name="passwordEdit">
      <property name="echoMode">
-      <enum>QLineEdit::EchoMode::Password</enum>
+      <enum>QLineEdit::Password</enum>
      </property>
     </widget>
    </item>
    <item row="4" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
+      <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
    <item row="3" column="0">
     <spacer>
      <property name="orientation">
-      <enum>Qt::Orientation::Vertical</enum>
+      <enum>Qt::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/src/ui/dictgroupwidget.ui
+++ b/src/ui/dictgroupwidget.ui
@@ -35,7 +35,7 @@
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Orientation::Horizontal</enum>
+        <enum>Qt::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>

--- a/src/ui/dictheadwords.ui
+++ b/src/ui/dictheadwords.ui
@@ -101,35 +101,35 @@
         </widget>
        </item>
        <item>
-        <widget class="QLabel" name="label_2">
-         <property name="toolTip">
-          <string>Specify the maximum filtered headwords returned.</string>
-         </property>
-         <property name="text">
-          <string>Filter max results:</string>
-         </property>
-        </widget>
+           <widget class="QLabel" name="label_2">
+               <property name="toolTip">
+                   <string>Specify the maximum filtered headwords returned.</string>
+               </property>
+               <property name="text">
+                   <string>Filter max results:</string>
+               </property>
+           </widget>
        </item>
-       <item>
-        <widget class="QSpinBox" name="filterMaxResult">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="minimum">
-          <number>10</number>
-         </property>
-         <property name="maximum">
-          <number>3000</number>
-         </property>
-         <property name="singleStep">
-          <number>10</number>
-         </property>
-        </widget>
-       </item>
-       <item>
+          <item>
+              <widget class="QSpinBox" name="filterMaxResult">
+                  <property name="toolTip">
+                      <string/>
+                  </property>
+                  <property name="minimum">
+                      <number>10</number>
+                  </property>
+                  <property name="maximum">
+                      <number>3000</number>
+                  </property>
+                  <property name="singleStep">
+                      <number>10</number>
+                  </property>
+              </widget>
+          </item>
+          <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
+          <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>

--- a/src/ui/dictinfo.ui
+++ b/src/ui/dictinfo.ui
@@ -50,7 +50,7 @@
          <string/>
         </property>
         <property name="textInteractionFlags">
-         <set>Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextSelectableByMouse</set>
+         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
         </property>
        </widget>
       </item>
@@ -60,7 +60,7 @@
          <string notr="true"/>
         </property>
         <property name="alignment">
-         <set>Qt::AlignmentFlag::AlignCenter</set>
+         <set>Qt::AlignCenter</set>
         </property>
        </widget>
       </item>
@@ -98,7 +98,7 @@
          <string notr="true"/>
         </property>
         <property name="alignment">
-         <set>Qt::AlignmentFlag::AlignCenter</set>
+         <set>Qt::AlignCenter</set>
         </property>
        </widget>
       </item>
@@ -160,7 +160,7 @@
       <bool>false</bool>
      </property>
      <property name="lineWrapMode">
-      <enum>QPlainTextEdit::LineWrapMode::NoWrap</enum>
+      <enum>QPlainTextEdit::NoWrap</enum>
      </property>
      <property name="readOnly">
       <bool>true</bool>
@@ -183,7 +183,7 @@
       <string notr="true"/>
      </property>
      <property name="horizontalScrollBarPolicy">
-      <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
+      <enum>Qt::ScrollBarAlwaysOff</enum>
      </property>
      <property name="readOnly">
       <bool>true</bool>
@@ -205,7 +205,7 @@
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Orientation::Horizontal</enum>
+        <enum>Qt::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -228,7 +228,7 @@
      <item>
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
-        <enum>Qt::Orientation::Horizontal</enum>
+        <enum>Qt::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>

--- a/src/ui/editdictionaries.ui
+++ b/src/ui/editdictionaries.ui
@@ -29,10 +29,10 @@
    <item>
     <widget class="QDialogButtonBox" name="buttons">
      <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
+      <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Help|QDialogButtonBox::StandardButton::Ok</set>
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/ui/fulltextsearch.ui
+++ b/src/ui/fulltextsearch.ui
@@ -73,7 +73,7 @@
         <number>-1</number>
        </property>
        <property name="alignment">
-        <set>Qt::AlignmentFlag::AlignCenter</set>
+        <set>Qt::AlignCenter</set>
        </property>
       </widget>
      </item>
@@ -142,7 +142,7 @@
      <item>
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
-        <enum>Qt::Orientation::Horizontal</enum>
+        <enum>Qt::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -168,7 +168,7 @@
      <item>
       <spacer name="horizontalSpacer_4">
        <property name="orientation">
-        <enum>Qt::Orientation::Horizontal</enum>
+        <enum>Qt::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -188,7 +188,7 @@
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Orientation::Horizontal</enum>
+        <enum>Qt::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -208,7 +208,7 @@
      <item>
       <spacer name="horizontalSpacer_3">
        <property name="orientation">
-        <enum>Qt::Orientation::Horizontal</enum>
+        <enum>Qt::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>

--- a/src/ui/groups.ui
+++ b/src/ui/groups.ui
@@ -36,7 +36,7 @@
      <item>
       <spacer name="verticalSpacer_2">
        <property name="orientation">
-        <enum>Qt::Orientation::Vertical</enum>
+        <enum>Qt::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -99,7 +99,7 @@
      <item>
       <spacer name="verticalSpacer">
        <property name="orientation">
-        <enum>Qt::Orientation::Vertical</enum>
+        <enum>Qt::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -123,10 +123,10 @@
      <item>
       <widget class="DictGroupsWidget" name="groups">
        <property name="tabPosition">
-        <enum>QTabWidget::TabPosition::North</enum>
+        <enum>QTabWidget::North</enum>
        </property>
        <property name="elideMode">
-        <enum>Qt::TextElideMode::ElideNone</enum>
+        <enum>Qt::ElideNone</enum>
        </property>
        <widget class="QWidget" name="tab_4">
         <attribute name="title">
@@ -180,7 +180,7 @@
        <item>
         <spacer name="horizontalSpacer_2">
          <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
+          <enum>Qt::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -224,7 +224,7 @@
        <item>
         <spacer name="horizontalSpacer">
          <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
+          <enum>Qt::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>

--- a/src/ui/initializing.ui
+++ b/src/ui/initializing.ui
@@ -3,7 +3,7 @@
  <class>Initializing</class>
  <widget class="QDialog" name="Initializing">
   <property name="windowModality">
-   <enum>Qt::WindowModality::ApplicationModal</enum>
+   <enum>Qt::ApplicationModal</enum>
   </property>
   <property name="geometry">
    <rect>
@@ -75,7 +75,7 @@
     <number>-1</number>
    </property>
    <property name="alignment">
-    <set>Qt::AlignmentFlag::AlignCenter</set>
+    <set>Qt::AlignCenter</set>
    </property>
   </widget>
   <widget class="QWidget" name="layoutWidget">
@@ -105,7 +105,7 @@
        <string>Indexing: </string>
       </property>
       <property name="alignment">
-       <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
       </property>
      </widget>
     </item>
@@ -127,7 +127,7 @@
        <string>Dictionary Name</string>
       </property>
       <property name="alignment">
-       <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
       </property>
       <property name="wordWrap">
        <bool>true</bool>

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -39,7 +39,7 @@
        </size>
       </property>
       <property name="elideMode">
-       <enum>Qt::TextElideMode::ElideRight</enum>
+       <enum>Qt::ElideRight</enum>
       </property>
       <widget class="QWidget" name="tab">
        <attribute name="title">
@@ -293,7 +293,7 @@
     <string>F3</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::NoRole</enum>
+    <enum>QAction::NoRole</enum>
    </property>
   </action>
   <action name="preferences">
@@ -308,7 +308,7 @@
     <string>F4</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::PreferencesRole</enum>
+    <enum>QAction::PreferencesRole</enum>
    </property>
   </action>
   <action name="visitHomepage">
@@ -316,7 +316,7 @@
     <string>&amp;Homepage</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::NoRole</enum>
+    <enum>QAction::NoRole</enum>
    </property>
   </action>
   <action name="about">
@@ -327,7 +327,7 @@
     <string>About GoldenDict-ng</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::AboutRole</enum>
+    <enum>QAction::AboutRole</enum>
    </property>
   </action>
   <action name="quit">
@@ -341,7 +341,7 @@
     <string>Ctrl+Q</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::QuitRole</enum>
+    <enum>QAction::QuitRole</enum>
    </property>
   </action>
   <action name="visitForum">
@@ -349,7 +349,7 @@
     <string>&amp;Forum</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::NoRole</enum>
+    <enum>QAction::NoRole</enum>
    </property>
   </action>
   <action name="actionCloseToTray">
@@ -363,7 +363,7 @@
     <string>Ctrl+F4</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::NoRole</enum>
+    <enum>QAction::NoRole</enum>
    </property>
   </action>
   <action name="saveArticle">
@@ -382,7 +382,7 @@
     <string>F2</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::NoRole</enum>
+    <enum>QAction::NoRole</enum>
    </property>
   </action>
   <action name="print">
@@ -397,7 +397,7 @@
     <string>Ctrl+P</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::NoRole</enum>
+    <enum>QAction::NoRole</enum>
    </property>
   </action>
   <action name="pageSetup">
@@ -405,7 +405,7 @@
     <string>Page Set&amp;up</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::NoRole</enum>
+    <enum>QAction::NoRole</enum>
    </property>
   </action>
   <action name="printPreview">
@@ -413,7 +413,7 @@
     <string>Print Pre&amp;view</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::NoRole</enum>
+    <enum>QAction::NoRole</enum>
    </property>
   </action>
   <action name="rescanFiles">
@@ -424,7 +424,7 @@
     <string>Ctrl+F5</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::NoRole</enum>
+    <enum>QAction::NoRole</enum>
    </property>
   </action>
   <action name="clearHistory">
@@ -432,7 +432,7 @@
     <string>&amp;Clear</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::NoRole</enum>
+    <enum>QAction::NoRole</enum>
    </property>
   </action>
   <action name="newTab">
@@ -447,10 +447,10 @@
     <string>Ctrl+T</string>
    </property>
    <property name="shortcutContext">
-    <enum>Qt::ShortcutContext::WidgetShortcut</enum>
+    <enum>Qt::WidgetShortcut</enum>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::NoRole</enum>
+    <enum>QAction::NoRole</enum>
    </property>
   </action>
   <action name="openConfigFolder">
@@ -458,7 +458,7 @@
     <string>&amp;Configuration Folder</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::NoRole</enum>
+    <enum>QAction::NoRole</enum>
    </property>
   </action>
   <action name="showHideHistory">
@@ -469,7 +469,7 @@
     <string>Ctrl+H</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::NoRole</enum>
+    <enum>QAction::NoRole</enum>
    </property>
   </action>
   <action name="exportHistory">
@@ -477,7 +477,7 @@
     <string>&amp;Export</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::NoRole</enum>
+    <enum>QAction::NoRole</enum>
    </property>
   </action>
   <action name="importHistory">
@@ -485,7 +485,7 @@
     <string>&amp;Import</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::NoRole</enum>
+    <enum>QAction::NoRole</enum>
    </property>
   </action>
   <action name="alwaysOnTop">
@@ -522,7 +522,7 @@
     <string>Ctrl+F</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::TextHeuristicRole</enum>
+    <enum>QAction::TextHeuristicRole</enum>
    </property>
   </action>
   <action name="fullTextSearchAction">
@@ -533,10 +533,10 @@
     <string>Ctrl+Shift+F</string>
    </property>
    <property name="shortcutContext">
-    <enum>Qt::ShortcutContext::WidgetWithChildrenShortcut</enum>
+    <enum>Qt::WidgetWithChildrenShortcut</enum>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::TextHeuristicRole</enum>
+    <enum>QAction::TextHeuristicRole</enum>
    </property>
   </action>
   <action name="showReference">

--- a/src/ui/orderandprops.ui
+++ b/src/ui/orderandprops.ui
@@ -82,10 +82,10 @@
              <string notr="true">TextLabel</string>
             </property>
             <property name="textFormat">
-             <enum>Qt::TextFormat::PlainText</enum>
+             <enum>Qt::PlainText</enum>
             </property>
             <property name="textInteractionFlags">
-             <set>Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextSelectableByMouse</set>
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
             </property>
            </widget>
           </item>
@@ -95,7 +95,7 @@
              <string notr="true">TextLabel</string>
             </property>
             <property name="textFormat">
-             <enum>Qt::TextFormat::PlainText</enum>
+             <enum>Qt::PlainText</enum>
             </property>
            </widget>
           </item>
@@ -119,7 +119,7 @@
              <string notr="true">TextLabel</string>
             </property>
             <property name="textFormat">
-             <enum>Qt::TextFormat::PlainText</enum>
+             <enum>Qt::PlainText</enum>
             </property>
            </widget>
           </item>
@@ -143,7 +143,7 @@
              <string notr="true">TextLabel</string>
             </property>
             <property name="textFormat">
-             <enum>Qt::TextFormat::RichText</enum>
+             <enum>Qt::RichText</enum>
             </property>
            </widget>
           </item>
@@ -153,7 +153,7 @@
              <string notr="true">TextLabel</string>
             </property>
             <property name="textFormat">
-             <enum>Qt::TextFormat::RichText</enum>
+             <enum>Qt::RichText</enum>
             </property>
            </widget>
           </item>
@@ -169,7 +169,7 @@
         <item>
          <widget class="QTextEdit" name="dictionaryDescription">
           <property name="frameShape">
-           <enum>QFrame::Shape::NoFrame</enum>
+           <enum>QFrame::NoFrame</enum>
           </property>
           <property name="readOnly">
            <bool>true</bool>
@@ -179,7 +179,7 @@
         <item>
          <spacer name="infoVerticalSpacer">
           <property name="orientation">
-           <enum>Qt::Orientation::Vertical</enum>
+           <enum>Qt::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -192,7 +192,7 @@
         <item>
          <spacer name="horizontalSpacer_5">
           <property name="orientation">
-           <enum>Qt::Orientation::Horizontal</enum>
+           <enum>Qt::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -230,10 +230,10 @@
            </size>
           </property>
           <property name="frameShape">
-           <enum>QFrame::Shape::NoFrame</enum>
+           <enum>QFrame::NoFrame</enum>
           </property>
           <property name="lineWrapMode">
-           <enum>QPlainTextEdit::LineWrapMode::NoWrap</enum>
+           <enum>QPlainTextEdit::NoWrap</enum>
           </property>
           <property name="readOnly">
            <bool>true</bool>

--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -33,7 +33,7 @@
       </size>
      </property>
      <property name="elideMode">
-      <enum>Qt::TextElideMode::ElideNone</enum>
+      <enum>Qt::ElideNone</enum>
      </property>
      <property name="usesScrollButtons">
       <bool>false</bool>
@@ -179,7 +179,7 @@ to open main window and perform other tasks.</string>
           <string>Enable system tray icon</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
          </property>
          <property name="flat">
           <bool>false</bool>
@@ -219,7 +219,7 @@ the application.</string>
        <item row="16" column="0" colspan="2">
         <spacer name="verticalSpacer">
          <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
+          <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -322,7 +322,7 @@ the application.</string>
                </size>
               </property>
               <property name="sizeAdjustPolicy">
-               <enum>QComboBox::SizeAdjustPolicy::AdjustToContents</enum>
+               <enum>QComboBox::AdjustToContents</enum>
               </property>
              </widget>
             </item>
@@ -419,7 +419,7 @@ the application.</string>
           <item>
            <spacer name="verticalSpacer_5">
             <property name="orientation">
-             <enum>Qt::Orientation::Vertical</enum>
+             <enum>Qt::Vertical</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -508,7 +508,7 @@ the application.</string>
              </sizepolicy>
             </property>
             <property name="fontFilters">
-             <set>QFontComboBox::FontFilter::MonospacedFonts</set>
+             <set>QFontComboBox::MonospacedFonts</set>
             </property>
            </widget>
           </item>
@@ -562,7 +562,7 @@ the application.</string>
           <string>Track Selection change</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
          </property>
          <property name="checkable">
           <bool>true</bool>
@@ -582,10 +582,10 @@ in the pressed state when the word selection changes.</string>
           <item>
            <widget class="QFrame" name="scanPopupModifiers">
             <property name="frameShape">
-             <enum>QFrame::Shape::NoFrame</enum>
+             <enum>QFrame::NoFrame</enum>
             </property>
             <property name="frameShadow">
-             <enum>QFrame::Shadow::Plain</enum>
+             <enum>QFrame::Plain</enum>
             </property>
             <property name="lineWidth">
              <number>0</number>
@@ -608,7 +608,7 @@ in the pressed state when the word selection changes.</string>
                <item>
                 <spacer name="horizontalSpacer">
                  <property name="orientation">
-                  <enum>Qt::Orientation::Horizontal</enum>
+                  <enum>Qt::Horizontal</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -665,10 +665,10 @@ in the pressed state when the word selection changes.</string>
                <item>
                 <widget class="QFrame" name="frame">
                  <property name="frameShape">
-                  <enum>QFrame::Shape::NoFrame</enum>
+                  <enum>QFrame::NoFrame</enum>
                  </property>
                  <property name="frameShadow">
-                  <enum>QFrame::Shadow::Raised</enum>
+                  <enum>QFrame::Raised</enum>
                  </property>
                  <property name="lineWidth">
                   <number>0</number>
@@ -749,7 +749,7 @@ in the pressed state when the word selection changes.</string>
        <item>
         <spacer name="verticalSpacer_6">
          <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
+          <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -782,7 +782,7 @@ in the pressed state when the word selection changes.</string>
          <item>
           <spacer name="horizontalSpacer_2">
            <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
+            <enum>Qt::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -809,7 +809,7 @@ in the pressed state when the word selection changes.</string>
          <item>
           <spacer name="horizontalSpacer_4">
            <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
+            <enum>Qt::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -827,10 +827,10 @@ in the pressed state when the word selection changes.</string>
        <item>
         <spacer name="verticalSpacer_13">
          <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
+          <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Policy::Fixed</enum>
+          <enum>QSizePolicy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -853,7 +853,7 @@ in the pressed state when the word selection changes.</string>
        <item>
         <spacer name="verticalSpacer_12">
          <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
+          <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -946,7 +946,7 @@ in the pressed state when the word selection changes.</string>
        <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
+          <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1072,7 +1072,7 @@ for all program's network requests.</string>
                <item>
                 <widget class="QLineEdit" name="proxyPassword">
                  <property name="echoMode">
-                  <enum>QLineEdit::EchoMode::Password</enum>
+                  <enum>QLineEdit::Password</enum>
                  </property>
                 </widget>
                </item>
@@ -1138,7 +1138,7 @@ for all program's network requests.</string>
             <item>
              <spacer name="horizontalSpacer_16">
               <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
+               <enum>Qt::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -1175,7 +1175,7 @@ for all program's network requests.</string>
             <item>
              <spacer name="horizontalSpacer_17">
               <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
+               <enum>Qt::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -1300,7 +1300,7 @@ clears its network cache from disk during exit.</string>
          <item>
           <spacer name="horizontalSpacer_15">
            <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
+            <enum>Qt::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -1329,7 +1329,7 @@ download page.</string>
        <item>
         <spacer name="verticalSpacer_3">
          <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
+          <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1468,7 +1468,7 @@ download page.</string>
             <item>
              <spacer name="horizontalSpacer_10">
               <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
+               <enum>Qt::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -1511,7 +1511,7 @@ download page.</string>
        <item>
         <spacer name="verticalSpacer_7">
          <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
+          <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1584,7 +1584,7 @@ download page.</string>
               <item>
                <spacer name="horizontalSpacer_8">
                 <property name="orientation">
-                 <enum>Qt::Orientation::Horizontal</enum>
+                 <enum>Qt::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -1631,7 +1631,7 @@ download page.</string>
               <item>
                <spacer name="horizontalSpacer_9">
                 <property name="orientation">
-                 <enum>Qt::Orientation::Horizontal</enum>
+                 <enum>Qt::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -1646,7 +1646,7 @@ download page.</string>
             <item>
              <spacer name="verticalSpacer_8">
               <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
+               <enum>Qt::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -1721,7 +1721,7 @@ download page.</string>
             <item>
              <spacer name="verticalSpacer_4">
               <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
+               <enum>Qt::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -1799,7 +1799,7 @@ from mouse-over, selection, clipboard or command line</string>
           <item row="1" column="3">
            <spacer name="horizontalSpacer_14">
             <property name="orientation">
-             <enum>Qt::Orientation::Horizontal</enum>
+             <enum>Qt::Horizontal</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -1855,7 +1855,7 @@ from mouse-over, selection, clipboard or command line</string>
           <item row="0" column="3">
            <spacer name="horizontalSpacer_11">
             <property name="orientation">
-             <enum>Qt::Orientation::Horizontal</enum>
+             <enum>Qt::Horizontal</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -1922,7 +1922,7 @@ from Stardict, Babylon and GLS dictionaries</string>
        <item>
         <spacer name="verticalSpacer_17">
          <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
+          <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1939,10 +1939,10 @@ from Stardict, Babylon and GLS dictionaries</string>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
+      <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Help|QDialogButtonBox::StandardButton::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/ui/scanpopup.ui
+++ b/src/ui/scanpopup.ui
@@ -36,10 +36,10 @@
     <item>
      <widget class="QFrame" name="outerFrame">
       <property name="frameShape">
-       <enum>QFrame::Shape::NoFrame</enum>
+       <enum>QFrame::NoFrame</enum>
       </property>
       <property name="frameShadow">
-       <enum>QFrame::Shadow::Raised</enum>
+       <enum>QFrame::Raised</enum>
       </property>
       <property name="lineWidth">
        <number>0</number>
@@ -76,7 +76,7 @@
               </sizepolicy>
              </property>
              <property name="sizeAdjustPolicy">
-              <enum>QComboBox::SizeAdjustPolicy::AdjustToContents</enum>
+              <enum>QComboBox::AdjustToContents</enum>
              </property>
             </widget>
            </item>
@@ -177,7 +177,7 @@
            <item>
             <spacer name="horizontalSpacer">
              <property name="orientation">
-              <enum>Qt::Orientation::Horizontal</enum>
+              <enum>Qt::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>

--- a/src/ui/sources.ui
+++ b/src/ui/sources.ui
@@ -26,7 +26,7 @@
       </size>
      </property>
      <property name="elideMode">
-      <enum>Qt::TextElideMode::ElideNone</enum>
+      <enum>Qt::ElideNone</enum>
      </property>
      <property name="usesScrollButtons">
       <bool>true</bool>
@@ -71,7 +71,7 @@
            <item>
             <spacer name="verticalSpacer">
              <property name="orientation">
-              <enum>Qt::Orientation::Vertical</enum>
+              <enum>Qt::Vertical</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -134,7 +134,7 @@
            <item>
             <spacer name="verticalSpacer_3">
              <property name="orientation">
-              <enum>Qt::Orientation::Vertical</enum>
+              <enum>Qt::Vertical</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -207,7 +207,7 @@ Add appropriate dictionaries to the bottoms
 of the appropriate groups to use them.</string>
            </property>
            <property name="textFormat">
-            <enum>Qt::TextFormat::PlainText</enum>
+            <enum>Qt::PlainText</enum>
            </property>
            <property name="wordWrap">
             <bool>false</bool>
@@ -258,10 +258,10 @@ of the appropriate groups to use them.</string>
            <item>
             <spacer name="verticalSpacer_2">
              <property name="orientation">
-              <enum>Qt::Orientation::Vertical</enum>
+              <enum>Qt::Vertical</enum>
              </property>
              <property name="sizeType">
-              <enum>QSizePolicy::Policy::Expanding</enum>
+              <enum>QSizePolicy::Expanding</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -317,7 +317,7 @@ of the appropriate groups to use them.</string>
            <item>
             <spacer name="verticalSpacer_8">
              <property name="orientation">
-              <enum>Qt::Orientation::Vertical</enum>
+              <enum>Qt::Vertical</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -381,7 +381,7 @@ of the appropriate groups to use them.</string>
            <item>
             <spacer name="verticalSpacer_18">
              <property name="orientation">
-              <enum>Qt::Orientation::Vertical</enum>
+              <enum>Qt::Vertical</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -440,7 +440,7 @@ of the appropriate groups to use them.</string>
            <item>
             <spacer name="verticalSpacer_12">
              <property name="orientation">
-              <enum>Qt::Orientation::Vertical</enum>
+              <enum>Qt::Vertical</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -512,7 +512,7 @@ Full list of availiable languages can be found &lt;a href=&quot;https://linguali
        <item>
         <spacer name="verticalSpacer_4">
          <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
+          <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -567,7 +567,7 @@ Full list of availiable languages can be found &lt;a href=&quot;https://linguali
           <item>
            <layout class="QFormLayout" name="formLayout">
             <property name="fieldGrowthPolicy">
-             <enum>QFormLayout::FieldGrowthPolicy::ExpandingFieldsGrow</enum>
+             <enum>QFormLayout::ExpandingFieldsGrow</enum>
             </property>
             <item row="0" column="0">
              <widget class="QLabel" name="label_12">
@@ -586,10 +586,10 @@ Full list of availiable languages can be found &lt;a href=&quot;https://linguali
             <item row="1" column="0">
              <spacer name="horizontalSpacer_2">
               <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
+               <enum>Qt::Horizontal</enum>
               </property>
               <property name="sizeType">
-               <enum>QSizePolicy::Policy::Fixed</enum>
+               <enum>QSizePolicy::Fixed</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -629,10 +629,10 @@ Full list of availiable languages can be found &lt;a href=&quot;https://linguali
             <item row="3" column="0">
              <spacer name="horizontalSpacer">
               <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
+               <enum>Qt::Horizontal</enum>
               </property>
               <property name="sizeType">
-               <enum>QSizePolicy::Policy::Fixed</enum>
+               <enum>QSizePolicy::Fixed</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -657,7 +657,7 @@ Full list of availiable languages can be found &lt;a href=&quot;https://linguali
           <item>
            <spacer name="verticalSpacer_10">
             <property name="orientation">
-             <enum>Qt::Orientation::Vertical</enum>
+             <enum>Qt::Vertical</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>

--- a/src/ui/texttospeechsource.ui
+++ b/src/ui/texttospeechsource.ui
@@ -51,7 +51,7 @@
        <item>
         <spacer name="verticalSpacer_3">
          <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
+          <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -90,10 +90,10 @@
          <bool>false</bool>
         </property>
         <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
+         <enum>Qt::Horizontal</enum>
         </property>
         <property name="tickPosition">
-         <enum>QSlider::TickPosition::TicksAbove</enum>
+         <enum>QSlider::TicksAbove</enum>
         </property>
         <property name="tickInterval">
          <number>10</number>
@@ -128,10 +128,10 @@
          <bool>false</bool>
         </property>
         <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
+         <enum>Qt::Horizontal</enum>
         </property>
         <property name="tickPosition">
-         <enum>QSlider::TickPosition::TicksAbove</enum>
+         <enum>QSlider::TicksAbove</enum>
         </property>
         <property name="tickInterval">
          <number>10</number>
@@ -192,7 +192,7 @@
         <item>
          <spacer name="horizontalSpacer">
           <property name="orientation">
-           <enum>Qt::Orientation::Horizontal</enum>
+           <enum>Qt::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>


### PR DESCRIPTION
Reverts xiaoyifang/goldendict-ng#1834

Qt back ported scoped enums all the way back to Qt5.15.18+, Qt6.5.4+, Qt6.2.13+ (These versions will eventually available to open source uses, but not today).

Very random, but here is Qt5.15.12 😅  https://github.com/qt/qt5/tree/v5.15.15-lts-lgpl

Qt Designer of Qt6.7 is currently utterly broken (save will introduce these changes which breaks older version 💩💩💩).