### PR TITLE
fix: default `content` directory in portable mode

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -1401,7 +1401,7 @@ void save( Class const & c )
     // which is stored in the first element of list.
     qsizetype pos = Config::isPortableVersion();
 
-    for ( const auto & i : c.paths.mid(pos) ) {
+    for ( const auto & i : c.paths.mid( pos ) ) {
       QDomElement path = dd.createElement( "path" );
       paths.appendChild( path );
 

--- a/src/dict/sources.cc
+++ b/src/dict/sources.cc
@@ -1170,6 +1170,13 @@ QModelIndex PathsModel::parent( QModelIndex const & /*parent*/ ) const
 Qt::ItemFlags PathsModel::flags( QModelIndex const & index ) const
 {
   Qt::ItemFlags result = QAbstractItemModel::flags( index );
+  
+  if ( Config::isPortableVersion() ) {
+    if ( index.isValid() && index.row() == 0 ) {
+      result &= ~Qt::ItemIsSelectable;
+      result &= ~Qt::ItemIsEnabled;
+    }
+  }
 
   if ( index.isValid() && index.column() == 1 ) {
     result |= Qt::ItemIsUserCheckable;

--- a/src/dict/sources.cc
+++ b/src/dict/sources.cc
@@ -1170,7 +1170,7 @@ QModelIndex PathsModel::parent( QModelIndex const & /*parent*/ ) const
 Qt::ItemFlags PathsModel::flags( QModelIndex const & index ) const
 {
   Qt::ItemFlags result = QAbstractItemModel::flags( index );
-  
+
   if ( Config::isPortableVersion() ) {
     if ( index.isValid() && index.row() == 0 ) {
       result &= ~Qt::ItemIsSelectable;


### PR DESCRIPTION
I'm using `GoldenDict-ng-24.09.0-Qt6.6.3` and found that in portable mode the *content* folder is not added initially, and once added it is not portable at all, the path is saved as an absolute path in the *portable/config* file, so it cannot be used on my other PC.
![image](https://github.com/user-attachments/assets/88f42c36-9f77-4dae-9936-4a19b871a43a) 

#1320 is relevant but some code is missing in the latest source. Here is the solution. The portable *content* folder should be relative and not stored in the *portable/config* file, and I make the path always the first in the list and make it uneditable.

Finally, I bring it back as #1394 and fixed some corner cases.
![image](https://github.com/user-attachments/assets/015e8272-9b4c-4df5-bdcf-df06fa26325a)
