### PR TITLE
opt: split the dictionaries panel into two seperate dialogs

### DIFF
--- a/src/ui/editdictionaries.cc
+++ b/src/ui/editdictionaries.cc
@@ -82,6 +82,22 @@ void EditDictionaries::editGroup( unsigned id )
   }
 }
 
+void EditDictionaries::showSource( bool show )
+{
+  if ( !show ) {
+    ui.tabs->setTabVisible( 0, false );
+
+    ui.tabs->setTabVisible( 1, true );
+    ui.tabs->setTabVisible( 2, true );
+  }
+  else {
+    ui.tabs->setTabVisible( 0, true );
+    ui.tabs->setTabVisible( 1, false );
+    ui.tabs->setTabVisible( 2, false );
+    ui.tabs->setCurrentIndex( 0 );
+  }
+}
+
 void EditDictionaries::save( bool rebuildGroups )
 {
   const Config::Groups newGroups  = groups->getGroups();

--- a/src/ui/editdictionaries.cc
+++ b/src/ui/editdictionaries.cc
@@ -74,6 +74,8 @@ EditDictionaries::EditDictionaries( QWidget * parent,
 void EditDictionaries::editGroup( unsigned id )
 {
   ui.tabs->setTabVisible( 0, false );
+  ui.tabs->setTabVisible( 1, true );
+  ui.tabs->setTabVisible( 2, true );
 
   if ( id == Instances::Group::AllGroupId ) {
     ui.tabs->setCurrentIndex( 1 );

--- a/src/ui/editdictionaries.cc
+++ b/src/ui/editdictionaries.cc
@@ -73,6 +73,9 @@ EditDictionaries::EditDictionaries( QWidget * parent,
 
 void EditDictionaries::editGroup( unsigned id )
 {
+  ui.tabs->setTabVisible( 0, false );
+  ui.tabs->setTabVisible( 1, true );
+  ui.tabs->setTabVisible( 2, true );
   if ( id == Instances::Group::AllGroupId ) {
     ui.tabs->setCurrentIndex( 1 );
   }

--- a/src/ui/editdictionaries.cc
+++ b/src/ui/editdictionaries.cc
@@ -73,10 +73,6 @@ EditDictionaries::EditDictionaries( QWidget * parent,
 
 void EditDictionaries::editGroup( unsigned id )
 {
-  ui.tabs->setTabVisible( 0, false );
-  ui.tabs->setTabVisible( 1, true );
-  ui.tabs->setTabVisible( 2, true );
-
   if ( id == Instances::Group::AllGroupId ) {
     ui.tabs->setCurrentIndex( 1 );
   }

--- a/src/ui/editdictionaries.hh
+++ b/src/ui/editdictionaries.hh
@@ -31,6 +31,7 @@ public:
 
   /// Instructs the dialog to position itself on editing the given group.
   void editGroup( unsigned id );
+  void showSource( bool show );
 
   /// Returns true if any changes to the 'dictionaries' vector passed were done.
   bool areDictionariesChanged() const

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -2210,12 +2210,18 @@ void MainWindow::editDictionaries( unsigned editDictionaryGroup, bool showSource
     connect( &dicts, &EditDictionaries::showDictionaryHeadwords, this, &MainWindow::showDictionaryHeadwords );
 
     if ( !showSourceOnly ) {
+      ui.tabs->setTabVisible( 0, false );
+
+      ui.tabs->setTabVisible( 1, true );
+      ui.tabs->setTabVisible( 2, true );
       if ( editDictionaryGroup != Instances::Group::NoGroupId ) {
         dicts.editGroup( editDictionaryGroup );
       }
     }
     else {
       ui.tabs->setTabVisible( 0, true );
+      ui.tabs->setTabVisible( 1, false );
+      ui.tabs->setTabVisible( 2, false );
       ui.tabs->setCurrentIndex( 0 );
     }
 

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -649,7 +649,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   connect( ui.quit, &QAction::triggered, this, &MainWindow::quitApp );
 
-  connect( ui.dictionaries, &QAction::triggered, this, [ this ](bool checked) {
+  connect( ui.dictionaries, &QAction::triggered, this, [ this ]( bool checked ) {
     editDictionaries( Instances::Group::NoGroupId, false );
   } );
   connect( ui.sourcesAction, &QAction::triggered, this, [ this ]( bool checked ) {

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -650,7 +650,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   connect( ui.quit, &QAction::triggered, this, &MainWindow::quitApp );
 
   connect( ui.dictionaries, &QAction::triggered, this, &MainWindow::editDictionaries );
-  connect( ui.sourcesAction, &QAction::triggered, this, []() {
+  connect( ui.sourcesAction, &QAction::triggered, this, [ this ]() {
     editDictionaries( Instances::Group::NoGroupId, true );
   } );
 

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -650,6 +650,9 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   connect( ui.quit, &QAction::triggered, this, &MainWindow::quitApp );
 
   connect( ui.dictionaries, &QAction::triggered, this, &MainWindow::editDictionaries );
+  connect( ui.sourcesAction, &QAction::triggered, this, []() {
+    editDictionaries( Instances::Group::NoGroupId, true );
+  } );
 
   connect( ui.preferences, &QAction::triggered, this, &MainWindow::editPreferences );
 
@@ -2188,7 +2191,7 @@ void MainWindow::updatePronounceAvailability()
   }
 }
 
-void MainWindow::editDictionaries( unsigned editDictionaryGroup )
+void MainWindow::editDictionaries( unsigned editDictionaryGroup, bool showSourceOnly )
 {
   hotkeyWrapper.reset(); // No hotkeys while we're editing dictionaries
   closeHeadwordsDialog();
@@ -2206,8 +2209,14 @@ void MainWindow::editDictionaries( unsigned editDictionaryGroup )
 
     connect( &dicts, &EditDictionaries::showDictionaryHeadwords, this, &MainWindow::showDictionaryHeadwords );
 
-    if ( editDictionaryGroup != Instances::Group::NoGroupId ) {
-      dicts.editGroup( editDictionaryGroup );
+    if ( !showSourceOnly ) {
+      if ( editDictionaryGroup != Instances::Group::NoGroupId ) {
+        dicts.editGroup( editDictionaryGroup );
+      }
+    }
+    else {
+      ui.tabs->setTabVisible( 0, true );
+      ui.tabs->setCurrentIndex( 0 );
     }
 
     dicts.restoreGeometry( cfg.dictionariesDialogGeometry );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -2209,20 +2209,12 @@ void MainWindow::editDictionaries( unsigned editDictionaryGroup, bool showSource
 
     connect( &dicts, &EditDictionaries::showDictionaryHeadwords, this, &MainWindow::showDictionaryHeadwords );
 
-    if ( !showSourceOnly ) {
-      ui.tabs->setTabVisible( 0, false );
+    dicts.showSource( showSourceOnly );
 
-      ui.tabs->setTabVisible( 1, true );
-      ui.tabs->setTabVisible( 2, true );
+    if ( !showSourceOnly ) {
       if ( editDictionaryGroup != Instances::Group::NoGroupId ) {
         dicts.editGroup( editDictionaryGroup );
       }
-    }
-    else {
-      ui.tabs->setTabVisible( 0, true );
-      ui.tabs->setTabVisible( 1, false );
-      ui.tabs->setTabVisible( 2, false );
-      ui.tabs->setCurrentIndex( 0 );
     }
 
     dicts.restoreGeometry( cfg.dictionariesDialogGeometry );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -649,10 +649,10 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   connect( ui.quit, &QAction::triggered, this, &MainWindow::quitApp );
 
-  connect( ui.dictionaries, &QAction::triggered, this, [ this ]() {
+  connect( ui.dictionaries, &QAction::triggered, this, [ this ](bool checked) {
     editDictionaries( Instances::Group::NoGroupId, false );
   } );
-  connect( ui.sourcesAction, &QAction::triggered, this, [ this ]() {
+  connect( ui.sourcesAction, &QAction::triggered, this, [ this ]( bool checked ) {
     editDictionaries( Instances::Group::NoGroupId, true );
   } );
 

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -650,7 +650,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   connect( ui.quit, &QAction::triggered, this, &MainWindow::quitApp );
 
   connect( ui.dictionaries, &QAction::triggered, this, [ this ]( bool checked ) {
-    editDictionaries( Instances::Group::NoGroupId, false );
+    editDictionaries();
   } );
   connect( ui.sourcesAction, &QAction::triggered, this, [ this ]( bool checked ) {
     editDictionaries( Instances::Group::NoGroupId, true );
@@ -805,7 +805,14 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   scanPopup->setStyleSheet( styleSheet() );
 
-  connect( scanPopup, &ScanPopup::editGroupRequest, this, &MainWindow::editDictionaries, Qt::QueuedConnection );
+  connect(
+    scanPopup,
+    &ScanPopup::editGroupRequest,
+    this,
+    [ this ]( bool check ) {
+      editDictionaries();
+    },
+    Qt::QueuedConnection );
 
   connect( scanPopup, &ScanPopup::sendPhraseToMainWindow, this, [ this ]( QString const & word ) {
     wordReceived( word );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -649,7 +649,9 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   connect( ui.quit, &QAction::triggered, this, &MainWindow::quitApp );
 
-  connect( ui.dictionaries, &QAction::triggered, this, &MainWindow::editDictionaries );
+  connect( ui.dictionaries, &QAction::triggered, this, [ this ]() {
+    editDictionaries( Instances::Group::NoGroupId, false );
+  } );
   connect( ui.sourcesAction, &QAction::triggered, this, [ this ]() {
     editDictionaries( Instances::Group::NoGroupId, true );
   } );

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -341,7 +341,7 @@ private slots:
 
   /// If editDictionaryGroup is specified, the dialog positions on that group
   /// initially.
-  void editDictionaries( unsigned editDictionaryGroup = Instances::Group::NoGroupId, bool showSourceOnly=false );
+  void editDictionaries( unsigned editDictionaryGroup = Instances::Group::NoGroupId, bool showSourceOnly = false );
   /// Edits current group when triggered from the dictionary bar.
   void editCurrentGroup();
   void editPreferences();

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -341,7 +341,7 @@ private slots:
 
   /// If editDictionaryGroup is specified, the dialog positions on that group
   /// initially.
-  void editDictionaries( unsigned editDictionaryGroup = Instances::Group::NoGroupId );
+  void editDictionaries( unsigned editDictionaryGroup = Instances::Group::NoGroupId, bool showSourceOnly=false );
   /// Edits current group when triggered from the dictionary bar.
   void editCurrentGroup();
   void editPreferences();

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -94,6 +94,7 @@
     <property name="title">
      <string>&amp;Edit</string>
     </property>
+    <addaction name="sourcesAction"/>
     <addaction name="dictionaries"/>
     <addaction name="preferences"/>
    </widget>
@@ -281,6 +282,18 @@
     </layout>
    </widget>
   </widget>
+  <action name="sourcesAction">
+   <property name="icon">
+    <iconset resource="../../resources.qrc">
+     <normaloff>:/icons/sources.png</normaloff>:/icons/sources.png</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Sources...</string>
+   </property>
+   <property name="menuRole">
+    <enum>QAction::NoRole</enum>
+   </property>
+  </action>
   <action name="dictionaries">
    <property name="icon">
     <iconset resource="../../resources.qrc">


### PR DESCRIPTION
fix #1873

The main purpose about this PR is that I want to get rid of this piece of code

https://github.com/xiaoyifang/goldendict-ng/blob/19bcd94834739213bb0e83f0a339ff03f733a0f3/src/ui/editdictionaries.cc#L239-L240

The tabs have been removed and recreated, causing the dialog to freeze when switching tabs.