### PR TITLE
fix: remove some tabText() in groupWidget when rename group

### DIFF
--- a/src/ui/groups_widgets.cc
+++ b/src/ui/groups_widgets.cc
@@ -915,7 +915,7 @@ QString DictGroupsWidget::getCurrentGroupName() const
   const int current = currentIndex();
 
   if ( current >= 0 ) {
-    auto * w = dynamic_cast< DictGroupWidget * >( widget( current ) );
+    auto * w = qobject_cast< DictGroupWidget * >( widget( current ) );
     return w->name();
   }
 

--- a/src/ui/groups_widgets.cc
+++ b/src/ui/groups_widgets.cc
@@ -915,9 +915,9 @@ QString DictGroupsWidget::getCurrentGroupName() const
   const int current = currentIndex();
 
   if ( current >= 0 ) {
-    auto widget = dynamic_cast< DictGroupWidget & >( *widget( x ) );
+    auto w = dynamic_cast< DictGroupWidget & >( *widget( x ) );
 
-    return widget.name();
+    return w.name();
   }
 
   return {};
@@ -928,8 +928,8 @@ void DictGroupsWidget::renameCurrentGroup( QString const & name )
   const int current = currentIndex();
 
   if ( current >= 0 ) {
-    auto widget = dynamic_cast< DictGroupWidget & >( *widget( x ) );
-    widget->setName( name );
+    auto w = dynamic_cast< DictGroupWidget & >( *widget( x ) );
+    w->setName( name );
     setTabText( current, Utils::escapeAmps( name ) );
   }
 }

--- a/src/ui/groups_widgets.cc
+++ b/src/ui/groups_widgets.cc
@@ -648,6 +648,7 @@ int DictGroupsWidget::addNewGroup( QString const & name )
   Config::Group newGroup;
 
   newGroup.id = nextId++;
+  newGroup.name = name;
 
   const auto gr = new DictGroupWidget( this, *allDicts, newGroup );
   const int idx = insertTab( currentIndex() + 1, gr, Utils::escapeAmps( name ) );
@@ -909,15 +910,13 @@ void DictGroupsWidget::groupsByMetadata()
   addGroupBasedOnMap( groupToDicts );
 }
 
-
 QString DictGroupsWidget::getCurrentGroupName() const
 {
   const int current = currentIndex();
 
   if ( current >= 0 ) {
-    auto w = dynamic_cast< DictGroupWidget & >( *widget( current ) );
-
-    return w.name();
+    auto * w = dynamic_cast< DictGroupWidget * >( widget( current ) );
+    return w->name();
   }
 
   return {};
@@ -928,7 +927,7 @@ void DictGroupsWidget::renameCurrentGroup( QString const & name )
   const int current = currentIndex();
 
   if ( current >= 0 ) {
-    auto w = dynamic_cast< DictGroupWidget & >( *widget( current ) );
+    auto * w = dynamic_cast< DictGroupWidget * >( widget( current ) );
     w->setName( name );
     setTabText( current, Utils::escapeAmps( name ) );
   }

--- a/src/ui/groups_widgets.cc
+++ b/src/ui/groups_widgets.cc
@@ -916,7 +916,7 @@ QString DictGroupsWidget::getCurrentGroupName() const
 
   if ( current >= 0 ) {
     auto widget = dynamic_cast< DictGroupWidget & >( *widget( x ) );
-   
+
     return widget.name();
   }
 
@@ -974,8 +974,7 @@ void DictGroupsWidget::combineGroups( int source, int target )
 
   connect( model, &DictListModel::contentChanged, this, &DictGroupsWidget::tabDataChanged );
 
-  const QString toolTipStr = tr( "Dictionaries: " )
-    + QString::number( model->getCurrentDictionaries().size() );
+  const QString toolTipStr = tr( "Dictionaries: " ) + QString::number( model->getCurrentDictionaries().size() );
   setTabToolTip( target, toolTipStr );
 }
 
@@ -1127,8 +1126,8 @@ void DictGroupsWidget::contextMenu( QPoint const & pos )
 
 void DictGroupsWidget::tabDataChanged()
 {
-  const QString toolTipStr = tr( "Dictionaries: " )
-    + QString::number( getCurrentModel()->getCurrentDictionaries().size() );
+  const QString toolTipStr =
+    tr( "Dictionaries: " ) + QString::number( getCurrentModel()->getCurrentDictionaries().size() );
   setTabToolTip( currentIndex(), toolTipStr );
 }
 

--- a/src/ui/groups_widgets.cc
+++ b/src/ui/groups_widgets.cc
@@ -915,7 +915,7 @@ QString DictGroupsWidget::getCurrentGroupName() const
   const int current = currentIndex();
 
   if ( current >= 0 ) {
-    auto w = dynamic_cast< DictGroupWidget & >( *widget( x ) );
+    auto w = dynamic_cast< DictGroupWidget & >( *widget( current ) );
 
     return w.name();
   }
@@ -928,7 +928,7 @@ void DictGroupsWidget::renameCurrentGroup( QString const & name )
   const int current = currentIndex();
 
   if ( current >= 0 ) {
-    auto w = dynamic_cast< DictGroupWidget & >( *widget( x ) );
+    auto w = dynamic_cast< DictGroupWidget & >( *widget( current ) );
     w->setName( name );
     setTabText( current, Utils::escapeAmps( name ) );
   }

--- a/src/ui/groups_widgets.hh
+++ b/src/ui/groups_widgets.hh
@@ -121,9 +121,6 @@ class DictGroupWidget: public QWidget
 public:
   DictGroupWidget( QWidget * parent, std::vector< sptr< Dictionary::Class > > const &, Config::Group const & );
 
-  /// Makes the group's configuration out of the data currently held.
-  /// Since the group's name is not part of the widget by design right now
-  /// (it is known by the containing tab widget only), it is returned as empty.
   Config::Group makeGroup() const;
 
   DictListModel * getModel() const

--- a/src/ui/groups_widgets.hh
+++ b/src/ui/groups_widgets.hh
@@ -136,6 +136,14 @@ public:
     return ui.dictionaries->selectionModel();
   }
 
+  QString name(){
+    return groupName;
+  }
+
+  void setName( const QString & name ){
+    groupName = name;
+  }
+
 private slots:
 
   void groupIconActivated( int );
@@ -145,6 +153,7 @@ private slots:
 private:
   Ui::DictGroupWidget ui;
   unsigned groupId;
+  QString groupName;
 
 signals:
   void showDictionaryInfo( QString const & id );

--- a/src/ui/groups_widgets.hh
+++ b/src/ui/groups_widgets.hh
@@ -136,11 +136,13 @@ public:
     return ui.dictionaries->selectionModel();
   }
 
-  QString name(){
+  QString name()
+  {
     return groupName;
   }
 
-  void setName( const QString & name ){
+  void setName( const QString & name )
+  {
     groupName = name;
   }
 


### PR DESCRIPTION
relate #1484 