### PR TITLE
clean: add `override` to satisfy clang's `Winconsistent-missing-override`

### DIFF
--- a/src/article_netmgr.hh
+++ b/src/article_netmgr.hh
@@ -42,38 +42,38 @@ public:
     delete baseReply;
   }
 
-  void close()
+  void close() override
   {
     baseReply->close();
   }
 
   // QIODevice virtual functions
-  qint64 bytesAvailable() const;
+  qint64 bytesAvailable() const override;
   bool atEnd() const override
   {
     return baseReply->atEnd();
   }
-  qint64 bytesToWrite() const
+  qint64 bytesToWrite() const override
   {
     return baseReply->bytesToWrite();
   }
-  bool canReadLine() const
+  bool canReadLine() const override
   {
     return baseReply->canReadLine();
   }
-  bool isSequential() const
+  bool isSequential() const override
   {
     return baseReply->isSequential();
   }
-  bool waitForReadyRead( int msecs )
+  bool waitForReadyRead( int msecs ) override
   {
     return baseReply->waitForReadyRead( msecs );
   }
-  bool waitForBytesWritten( int msecs )
+  bool waitForBytesWritten( int msecs ) override
   {
     return baseReply->waitForBytesWritten( msecs );
   }
-  bool reset()
+  bool reset() override
   {
     return baseReply->reset();
   }
@@ -82,37 +82,37 @@ public slots:
   void applyError( QNetworkReply::NetworkError code );
 
   // Redirect QNetworkReply slots
-  virtual void abort()
+  void abort() override
   {
     baseReply->abort();
   }
-  virtual void ignoreSslErrors()
+  void ignoreSslErrors() override
   {
     baseReply->ignoreSslErrors();
   }
 
 protected:
   // QNetworkReply virtual functions
-  void ignoreSslErrorsImplementation( const QList< QSslError > & errors )
+  void ignoreSslErrorsImplementation( const QList< QSslError > & errors ) override
   {
     baseReply->ignoreSslErrors( errors );
   }
-  void setSslConfigurationImplementation( const QSslConfiguration & configuration )
+  void setSslConfigurationImplementation( const QSslConfiguration & configuration ) override
   {
     baseReply->setSslConfiguration( configuration );
   }
-  void sslConfigurationImplementation( QSslConfiguration & configuration ) const
+  void sslConfigurationImplementation( QSslConfiguration & configuration ) const override
   {
     configuration = baseReply->sslConfiguration();
   }
 
   // QIODevice virtual functions
-  qint64 readData( char * data, qint64 maxSize );
-  qint64 readLineData( char * data, qint64 maxSize )
+  qint64 readData( char * data, qint64 maxSize ) override;
+  qint64 readLineData( char * data, qint64 maxSize ) override
   {
     return baseReply->readLine( data, maxSize );
   }
-  qint64 writeData( const char * data, qint64 maxSize )
+  qint64 writeData( const char * data, qint64 maxSize ) override
   {
     return baseReply->write( data, maxSize );
   }
@@ -178,10 +178,10 @@ public:
 
 protected:
 
-  virtual qint64 bytesAvailable() const;
+  virtual qint64 bytesAvailable() const override;
   bool atEnd() const override;
-  virtual void abort() {}
-  virtual qint64 readData( char * data, qint64 maxSize );
+  virtual void abort() override {}
+  virtual qint64 readData( char * data, qint64 maxSize ) override;
 
   // We use the hackery below to work around the fact that we need to emit
   // ready/finish signals after we've been constructed.

--- a/src/dict/forvo.cc
+++ b/src/dict/forvo.cc
@@ -107,7 +107,7 @@ public:
                        string const & dictionaryId_,
                        QNetworkAccessManager & mgr );
 
-  virtual void cancel();
+  void cancel() override;
 
 private:
 

--- a/src/dict/lingualibre.cc
+++ b/src/dict/lingualibre.cc
@@ -47,7 +47,7 @@ public:
                         string const & dictionaryId_,
                         QNetworkAccessManager & mgr );
 
-  virtual void cancel();
+  void cancel() override;
 
 private:
 

--- a/src/ui/articleview.hh
+++ b/src/ui/articleview.hh
@@ -104,7 +104,7 @@ public:
   void setAudioLink( QString audioLink );
   QString getAudioLink() const;
 
-  virtual QSize minimumSizeHint() const;
+  QSize minimumSizeHint() const override;
   void clearContent();
 
   ~ArticleView();


### PR DESCRIPTION
It seems newer version of clang has this warning enabled by default and the build log full of this thing.

https://github.com/xiaoyifang/goldendict-ng/actions/runs/11622770897/job/32368748936

clang-tidy doesn't appear to be able to catch all cases https://github.com/xiaoyifang/goldendict-ng/pull/293