### PR TITLE
clean: apply clang-tidy's `modernize-use-using` (replace most `typedef`)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,3 +12,6 @@ b5349478cfb0dc2dd0de8c8e8aeebdd24cf7ac6b
 
 # mass apply clang-tidy's readability-braces-around-statements
 a11c9e3aeca4329e1982d8fe26bacbb21ab50ddf
+
+# mass apply clang-tidy's modernize-use-using
+d15081e723756eef053550dc9e06e31d7828dec3

--- a/src/article_maker.hh
+++ b/src/article_maker.hh
@@ -101,8 +101,8 @@ class ArticleRequest: public Dictionary::DataRequest
 
   /// A sequence of words and spacings between them, including the initial
   /// spacing before the first word and the final spacing after the last word.
-  typedef QList< QString > Words;
-  typedef QList< QString > Spacings;
+  using Words    = QList< QString >;
+  using Spacings = QList< QString >;
 
   /// Splits the given string into words and spacings between them.
   std::pair< Words, Spacings > splitIntoWords( QString const & );

--- a/src/audioplayerinterface.hh
+++ b/src/audioplayerinterface.hh
@@ -26,6 +26,6 @@ signals:
   void error( QString message );
 };
 
-typedef QScopedPointer< AudioPlayerInterface > AudioPlayerPtr;
+using AudioPlayerPtr = QScopedPointer< AudioPlayerInterface >;
 
 #endif // AUDIOPLAYERINTERFACE_HH_INCLUDED

--- a/src/common/base_type.hh
+++ b/src/common/base_type.hh
@@ -3,5 +3,5 @@
 
 #include <QString>
 
-typedef QMap< QString, QString > Contexts;
+using Contexts = QMap< QString, QString >;
 #endif // BASE_TYPE_H

--- a/src/common/wstring.hh
+++ b/src/common/wstring.hh
@@ -12,6 +12,6 @@
 ///
 
 namespace gd {
-typedef char32_t wchar;
-typedef std::u32string wstring;
+using wchar   = char32_t;
+using wstring = std::u32string;
 } // namespace gd

--- a/src/config.hh
+++ b/src/config.hh
@@ -36,7 +36,7 @@ enum class Dark : std::uint8_t {
 };
 
 /// Dictionaries which are temporarily disabled via the dictionary bar.
-typedef QSet< QString > MutedDictionaries;
+using MutedDictionaries = QSet< QString >;
 
 /// A path where to search for the dictionaries
 struct Path
@@ -61,7 +61,7 @@ struct Path
 };
 
 /// A list of paths where to search for the dictionaries
-typedef QList< Path > Paths;
+using Paths = QList< Path >;
 
 /// A directory holding bunches of audiofiles, which is indexed into a separate
 /// dictionary.
@@ -86,7 +86,7 @@ struct SoundDir
 };
 
 /// A list of SoundDirs
-typedef QList< SoundDir > SoundDirs;
+using SoundDirs = QList< SoundDir >;
 
 struct DictionaryRef
 {
@@ -518,7 +518,7 @@ struct WebSite
 };
 
 /// All the WebSites
-typedef QList< WebSite > WebSites;
+using WebSites = QList< WebSite >;
 
 /// Any DICT server
 struct DictServer
@@ -559,14 +559,14 @@ struct DictServer
 };
 
 /// All the DictServers
-typedef QList< DictServer > DictServers;
+using DictServers = QList< DictServer >;
 
 /// Hunspell configuration
 struct Hunspell
 {
   QString dictionariesPath;
 
-  typedef QList< QString > Dictionaries;
+  using Dictionaries = QList< QString >;
 
   Dictionaries enabledDictionaries;
 
@@ -582,7 +582,7 @@ struct Hunspell
 };
 
 /// All the MediaWikis
-typedef QList< MediaWiki > MediaWikis;
+using MediaWikis = QList< MediaWiki >;
 
 
 /// Chinese transliteration configuration
@@ -775,7 +775,7 @@ struct Program
   }
 };
 
-typedef QList< Program > Programs;
+using Programs = QList< Program >;
 
 #ifndef NO_TTS_SUPPORT
 struct VoiceEngine
@@ -821,7 +821,7 @@ struct VoiceEngine
   }
 };
 
-typedef QList< VoiceEngine > VoiceEngines;
+using VoiceEngines = QList< VoiceEngine >;
 #endif
 
 struct HeadwordsDialog

--- a/src/dict/bgl_babylon.hh
+++ b/src/dict/bgl_babylon.hh
@@ -115,20 +115,20 @@ const std::vector< std::string > bgl_charset = { "WINDOWS-1252", /*Default*/
 const std::array< std::string, 11 > partOfSpeech = {
   "n.", "adj.", "v.", "adv.", "interj.", "pron.", "prep.", "conj.", "suff.", "pref.", "art." };
 
-typedef struct
+struct bgl_block
 {
   unsigned type;
   unsigned length;
   char * data;
-} bgl_block;
+};
 
-typedef struct
+struct bgl_entry
 {
   std::string headword;
   std::string definition;
   std::string displayedHeadword;
   std::vector< std::string > alternates;
-} bgl_entry;
+};
 
 class Babylon
 {

--- a/src/dict/epwing_book.hh
+++ b/src/dict/epwing_book.hh
@@ -58,7 +58,7 @@ struct EpwingHeadword
 
 class EpwingBook
 {
-  typedef std::pair< int, int > EWPos;
+  using EWPos = std::pair< int, int >;
 
   void setErrorString( QString const & func, EB_Error_Code code );
 

--- a/src/dict/forvo.cc
+++ b/src/dict/forvo.cc
@@ -93,7 +93,7 @@ class ForvoArticleRequest: public Dictionary::DataRequest
     }
   };
 
-  typedef std::list< NetReply > NetReplies;
+  using NetReplies = std::list< NetReply >;
   NetReplies netReplies;
   QString apiKey, languageCode;
   string dictionaryId;

--- a/src/dict/lingualibre.cc
+++ b/src/dict/lingualibre.cc
@@ -33,7 +33,7 @@ class LinguaArticleRequest: public Dictionary::DataRequest
     }
   };
 
-  typedef std::list< NetReply > NetReplies;
+  using NetReplies = std::list< NetReply >;
   NetReplies netReplies;
   QString languageCode, langWikipediaID;
   string dictionaryId;

--- a/src/dict/mdictparser.hh
+++ b/src/dict/mdictparser.hh
@@ -112,9 +112,9 @@ public:
     virtual void handleRecord( QString const & name, RecordInfo const & recordInfo ) = 0;
   };
 
-  typedef vector< pair< qint64, qint64 > > BlockInfoVector;
-  typedef vector< pair< qint64, QString > > HeadWordIndex;
-  typedef map< qint32, pair< QString, QString > > StyleSheets;
+  using BlockInfoVector = vector< pair< qint64, qint64 > >;
+  using HeadWordIndex   = vector< pair< qint64, QString > >;
+  using StyleSheets     = map< qint32, pair< QString, QString > >;
 
   inline QString const & title() const
   {

--- a/src/dict/mediawiki.cc
+++ b/src/dict/mediawiki.cc
@@ -389,7 +389,7 @@ void MediaWikiSectionsParser::closeListTags( int currentLevel )
 
 class MediaWikiArticleRequest: public MediaWikiDataRequestSlots
 {
-  typedef std::list< std::pair< QNetworkReply *, bool > > NetReplies;
+  using NetReplies = std::list< std::pair< QNetworkReply *, bool > >;
   NetReplies netReplies;
   QString url;
   QString lang;

--- a/src/dict/slob.cc
+++ b/src/dict/slob.cc
@@ -109,8 +109,8 @@ bool indexIsOldOrBad( string const & indexFile )
 class SlobFile
 {
 public:
-  typedef std::pair< quint64, quint32 > RefEntryOffsetItem;
-  typedef QList< RefEntryOffsetItem > RefOffsetsVector;
+  using RefEntryOffsetItem = std::pair< quint64, quint32 >;
+  using RefOffsetsVector   = QList< RefEntryOffsetItem >;
 
 private:
   enum Compressions {

--- a/src/hotkeywrapper.cc
+++ b/src/hotkeywrapper.cc
@@ -698,7 +698,7 @@ bool HotkeyWrapper::isKeyGrabbed( quint32 keyCode, quint32 modifiers ) const
 
 namespace {
 
-typedef int ( *X11ErrorHandler )( Display * display, XErrorEvent * event );
+using X11ErrorHandler = int ( * )( Display * display, XErrorEvent * event );
 
 class X11GrabUngrabErrorHandler
 {

--- a/src/hotkeywrapper.hh
+++ b/src/hotkeywrapper.hh
@@ -142,7 +142,7 @@ private:
 
   /// Holds all the keys currently grabbed.
   /// The first value is keycode, the second is modifiers
-  typedef std::set< std::pair< quint32, quint32 > > GrabbedKeys;
+  using GrabbedKeys = std::set< std::pair< quint32, quint32 > >;
   GrabbedKeys grabbedKeys;
 
   GrabbedKeys::iterator keyToUngrab; // Used for second stage grabs

--- a/src/language.hh
+++ b/src/language.hh
@@ -11,7 +11,7 @@ namespace Language {
 
 /// This identifies any language uniquely within the program. It also has
 /// two special meanings - Unknown and Any.
-typedef quint32 Id;
+using Id = quint32;
 
 enum {
   /// Value for Id which signifies that the language is unknown or unspecified.

--- a/src/multimediaaudioplayer.cc
+++ b/src/multimediaaudioplayer.cc
@@ -20,17 +20,9 @@ MultimediaAudioPlayer::MultimediaAudioPlayer()
   player( 0, QMediaPlayer::StreamPlayback )
   #endif
 {
-  typedef void ( QMediaPlayer::*ErrorSignal )( QMediaPlayer::Error );
-  #if ( QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 ) )
-  connect( &player,
-           static_cast< ErrorSignal >( &QMediaPlayer::error ),
-           this,
-           &MultimediaAudioPlayer::onMediaPlayerError );
-  #else
   player.setAudioOutput( &audioOutput );
 
   connect( &player, &QMediaPlayer::errorChanged, this, &MultimediaAudioPlayer::onMediaPlayerError );
-  #endif
 
   #if ( QT_VERSION > QT_VERSION_CHECK( 6, 2, 0 ) )
   connect( &mediaDevices, &QMediaDevices::audioOutputsChanged, this, &MultimediaAudioPlayer::audioOutputChange );

--- a/src/wordfinder.hh
+++ b/src/wordfinder.hh
@@ -60,8 +60,8 @@ private:
 
   // Maps lowercased string to the original one. This catches all duplicates
   // without case sensitivity. Made as an array and a map indexing that array.
-  typedef std::list< OneResult > ResultsArray;
-  typedef std::map< gd::wstring, ResultsArray::iterator > ResultsIndex;
+  using ResultsArray = std::list< OneResult >;
+  using ResultsIndex = std::map< gd::wstring, ResultsArray::iterator >;
   ResultsArray resultsArray;
   ResultsIndex resultsIndex;
 


### PR DESCRIPTION
I feel `using` is a straight upgrade of `typedef` especially for long type names.


There is only 2 `typedef` left because that file is currently compiled as C.