### PR TITLE
clean: fix all `globalPosition` deprecations to stop related warnings

### DIFF
--- a/src/gestures.cc
+++ b/src/gestures.cc
@@ -81,16 +81,16 @@ QGestureRecognizer::Result GDPinchGestureRecognizer::recognize( QGesture * state
     case QEvent::TouchUpdate: {
       gest->scaleChanged           = false;
       const QTouchEvent * const ev = static_cast< const QTouchEvent * >( event );
-      fewTouchPointsPresented      = ( ev->touchPoints().size() > 1 );
-      if ( ev->touchPoints().size() == 2 ) {
-        QTouchEvent::TouchPoint p1 = ev->touchPoints().at( 0 );
-        QTouchEvent::TouchPoint p2 = ev->touchPoints().at( 1 );
+      fewTouchPointsPresented      = ( ev->points().size() > 1 );
+      if ( ev->points().size() == 2 ) {
+        QTouchEvent::TouchPoint p1 = ev->points().at( 0 );
+        QTouchEvent::TouchPoint p2 = ev->points().at( 1 );
 
-        QPointF centerPoint = ( p1.screenPos() + p2.screenPos() ) / 2.0;
+        QPointF centerPoint = ( p1.globalPosition() + p2.globalPosition() ) / 2.0;
         gest->setHotSpot( centerPoint );
         if ( gest->isNewSequence ) {
-          gest->startPosition[ 0 ] = p1.screenPos();
-          gest->startPosition[ 1 ] = p2.screenPos();
+          gest->startPosition[ 0 ] = p1.globalPosition();
+          gest->startPosition[ 1 ] = p2.globalPosition();
           gest->lastCenterPoint    = centerPoint;
         }
         else {
@@ -105,8 +105,8 @@ QGestureRecognizer::Result GDPinchGestureRecognizer::recognize( QGesture * state
         }
         else {
           gest->lastScaleFactor = gest->scaleFactor;
-          QLineF line( p1.screenPos(), p2.screenPos() );
-          QLineF lastLine( p1.lastScreenPos(), p2.lastScreenPos() );
+          QLineF line( p1.globalPosition(), p2.globalPosition() );
+          QLineF lastLine( p1.globalLastPosition(), p2.globalLastPosition() );
           gest->scaleFactor = line.length() / lastLine.length();
         }
 
@@ -210,28 +210,28 @@ QGestureRecognizer::Result GDSwipeGestureRecognizer::recognize( QGesture * state
     }
     case QEvent::TouchUpdate: {
       const QTouchEvent * const ev = static_cast< const QTouchEvent * >( event );
-      fewTouchPointsPresented      = ( ev->touchPoints().size() > 1 );
+      fewTouchPointsPresented      = ( ev->points().size() > 1 );
       if ( !swipe->started )
         result = QGestureRecognizer::CancelGesture;
-      else if ( ev->touchPoints().size() == 2 ) {
+      else if ( ev->points().size() == 2 ) {
         //2-point gesture
 
-        QTouchEvent::TouchPoint p1 = ev->touchPoints().at( 0 );
-        QTouchEvent::TouchPoint p2 = ev->touchPoints().at( 1 );
+        QTouchEvent::TouchPoint p1 = ev->points().at( 0 );
+        QTouchEvent::TouchPoint p2 = ev->points().at( 1 );
 
         if ( swipe->lastPositions[ 0 ].isNull() ) {
-          swipe->lastPositions[ 0 ] = p1.startScreenPos().toPoint();
-          swipe->lastPositions[ 1 ] = p2.startScreenPos().toPoint();
+          swipe->lastPositions[ 0 ] = p1.globalPressPosition().toPoint();
+          swipe->lastPositions[ 1 ] = p2.globalPressPosition().toPoint();
         }
 
         if ( !swipe->hasHotSpot() ) {
-          swipe->setHotSpot( ( p1.startScreenPos() + p2.startScreenPos() ) / 2 );
+          swipe->setHotSpot( ( p1.globalPressPosition() + p2.globalPressPosition() ) / 2 );
         }
 
-        int dx1 = p1.screenPos().toPoint().x() - swipe->lastPositions[ 0 ].x();
-        int dx2 = p2.screenPos().toPoint().x() - swipe->lastPositions[ 1 ].x();
-        int dy1 = p1.screenPos().toPoint().y() - swipe->lastPositions[ 0 ].y();
-        int dy2 = p2.screenPos().toPoint().y() - swipe->lastPositions[ 1 ].y();
+        int dx1 = p1.globalPosition().toPoint().x() - swipe->lastPositions[ 0 ].x();
+        int dx2 = p2.globalPosition().toPoint().x() - swipe->lastPositions[ 1 ].x();
+        int dy1 = p1.globalPosition().toPoint().y() - swipe->lastPositions[ 0 ].y();
+        int dy2 = p2.globalPosition().toPoint().y() - swipe->lastPositions[ 1 ].y();
 
         if ( qAbs( ( dx1 + dx2 ) / 2.0 ) >= MOVE_X_TRESHOLD || qAbs( ( dy1 + dy2 ) / 2.0 ) >= MOVE_Y_TRESHOLD ) {
           qreal angle1                           = computeAngle( dx1, dy1 );
@@ -255,8 +255,8 @@ QGestureRecognizer::Result GDSwipeGestureRecognizer::recognize( QGesture * state
           swipe->vertDirection  = vertDir;
           swipe->horizDirection = horizDir;
 
-          swipe->lastPositions[ 0 ] = p1.screenPos().toPoint();
-          swipe->lastPositions[ 1 ] = p2.screenPos().toPoint();
+          swipe->lastPositions[ 0 ] = p1.globalPosition().toPoint();
+          swipe->lastPositions[ 1 ] = p2.globalPosition().toPoint();
 
           result = QGestureRecognizer::TriggerGesture;
         }

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -727,7 +727,7 @@ bool ScanPopup::eventFilter( QObject * watched, QEvent * event )
 
     if ( event->type() == QEvent::MouseMove ) {
       QMouseEvent * mouseEvent = (QMouseEvent *)event;
-      reactOnMouseMove( mouseEvent->globalPos() );
+      reactOnMouseMove( mouseEvent->globalPosition() );
     }
   }
 
@@ -751,9 +751,9 @@ bool ScanPopup::eventFilter( QObject * watched, QEvent * event )
   return QMainWindow::eventFilter( watched, event );
 }
 
-void ScanPopup::reactOnMouseMove( QPoint const & p )
+void ScanPopup::reactOnMouseMove(QPointF const& p)
 {
-  if ( geometry().contains( p ) ) {
+  if ( geometry().contains( p.toPoint() ) ) {
     //        GD_DPRINTF( "got inside\n" );
 
     hideTimer.stop();
@@ -773,7 +773,7 @@ void ScanPopup::reactOnMouseMove( QPoint const & p )
     // receiving this event, meaning there's basically nothing under the
     // cursor.
     if ( /*watched == this &&*/
-         !frameGeometry().adjusted( -proximity, -proximity, proximity, proximity ).contains( p ) ) {
+         !frameGeometry().adjusted( -proximity, -proximity, proximity, proximity ).contains( p.toPoint() ) ) {
       // We've way too far from the window -- hide the popup
 
       // If the mouse never entered the popup, hide the window instantly --
@@ -794,14 +794,14 @@ void ScanPopup::mousePressEvent( QMouseEvent * ev )
   // With mouse grabs, the press can occur anywhere on the screen, which
   // might mean hiding the window.
 
-  if ( !frameGeometry().contains( ev->globalPos() ) ) {
+  if ( !frameGeometry().contains( ev->globalPosition().toPoint() ) ) {
     hideWindow();
 
     return;
   }
 
   if ( ev->button() == Qt::LeftButton ) {
-    startPos = ev->globalPos();
+    startPos = ev->globalPosition();
     setCursor( Qt::ClosedHandCursor );
   }
 
@@ -811,15 +811,13 @@ void ScanPopup::mousePressEvent( QMouseEvent * ev )
 void ScanPopup::mouseMoveEvent( QMouseEvent * event )
 {
   if ( event->buttons() && cursor().shape() == Qt::ClosedHandCursor ) {
-    QPoint newPos = event->globalPos();
-
-    QPoint delta = newPos - startPos;
+    QPointF newPos = event->globalPosition();
+    QPointF delta = newPos - startPos;
 
     startPos = newPos;
 
     // Move the window
-
-    move( pos() + delta );
+    move( (pos() + delta).toPoint() );
   }
 
   QMainWindow::mouseMoveEvent( event );

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -751,7 +751,7 @@ bool ScanPopup::eventFilter( QObject * watched, QEvent * event )
   return QMainWindow::eventFilter( watched, event );
 }
 
-void ScanPopup::reactOnMouseMove(QPointF const& p)
+void ScanPopup::reactOnMouseMove( QPointF const & p )
 {
   if ( geometry().contains( p.toPoint() ) ) {
     //        GD_DPRINTF( "got inside\n" );
@@ -812,12 +812,12 @@ void ScanPopup::mouseMoveEvent( QMouseEvent * event )
 {
   if ( event->buttons() && cursor().shape() == Qt::ClosedHandCursor ) {
     QPointF newPos = event->globalPosition();
-    QPointF delta = newPos - startPos;
+    QPointF delta  = newPos - startPos;
 
     startPos = newPos;
 
     // Move the window
-    move( (pos() + delta).toPoint() );
+    move( ( pos() + delta ).toPoint() );
   }
 
   QMainWindow::mouseMoveEvent( event );

--- a/src/ui/scanpopup.hh
+++ b/src/ui/scanpopup.hh
@@ -148,7 +148,7 @@ private:
   bool mouseEnteredOnce = false;
   bool mouseIntercepted = false;
 
-  QPoint startPos; // For window moving
+  QPointF startPos; // For window moving
   QByteArray pinnedGeometry;
 
   QTimer hideTimer; // When mouse leaves the window, a grace period is
@@ -169,7 +169,7 @@ private:
 
   /// Called from event filter or from mouseGrabPoll to handle mouse event
   /// while it is being intercepted.
-  void reactOnMouseMove( QPoint const & p );
+  void reactOnMouseMove(QPointF const& p);
 
   virtual void mousePressEvent( QMouseEvent * );
   virtual void mouseMoveEvent( QMouseEvent * );

--- a/src/ui/scanpopup.hh
+++ b/src/ui/scanpopup.hh
@@ -169,7 +169,7 @@ private:
 
   /// Called from event filter or from mouseGrabPoll to handle mouse event
   /// while it is being intercepted.
-  void reactOnMouseMove(QPointF const& p);
+  void reactOnMouseMove( QPointF const & p );
 
   virtual void mousePressEvent( QMouseEvent * );
   virtual void mouseMoveEvent( QMouseEvent * );


### PR DESCRIPTION
Half of the remaining default compiler warnings are this thing.

Pretty much direct renames.