### PR TITLE
clean: deprecated `QKeySequence[]->int`; answer ikm's question from 2009

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -105,15 +105,18 @@ AnkiConnectServer::AnkiConnectServer():
 HotKey::HotKey( QKeySequence const & seq ):
   modifiers( seq[ 0 ].keyboardModifiers() ),
   key1( seq[ 0 ].key() ),
-  key2( seq[ 1 ].key() ) {}
+  key2( seq[ 1 ].key() )
+{
+}
 
 QKeySequence HotKey::toKeySequence() const
 {
   if ( key2 != 0 || key2 != Qt::Key::Key_unknown ) {
-    return {QKeyCombination( modifiers, static_cast< Qt::Key >(key1) ),
-            QKeyCombination( modifiers, static_cast< Qt::Key >(key2) )};
+    return { QKeyCombination( modifiers, static_cast< Qt::Key >( key1 ) ),
+             QKeyCombination( modifiers, static_cast< Qt::Key >( key2 ) ) };
   }
-  return {QKeyCombination( modifiers, static_cast< Qt::Key >(key1) )};;
+  return { QKeyCombination( modifiers, static_cast< Qt::Key >( key1 ) ) };
+  ;
 }
 
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -102,31 +102,20 @@ AnkiConnectServer::AnkiConnectServer():
 {
 }
 
-HotKey::HotKey():
-  modifiers( 0 ),
-  key1( 0 ),
-  key2( 0 )
-{
-}
-
-// Does anyone know how to separate modifiers from the keycode? We'll
-// use our own mask.
-
-uint32_t const keyMask = 0x01FFFFFF;
-
 HotKey::HotKey( QKeySequence const & seq ):
-  modifiers( seq[ 0 ] & ~keyMask ),
-  key1( seq[ 0 ] & keyMask ),
-  key2( seq[ 1 ] & keyMask )
-{
-}
+  modifiers( seq[ 0 ].keyboardModifiers() ),
+  key1( seq[ 0 ].key() ),
+  key2( seq[ 1 ].key() ) {}
 
 QKeySequence HotKey::toKeySequence() const
 {
-  int v2 = key2 ? ( key2 | modifiers ) : 0;
-
-  return QKeySequence( key1 | modifiers, v2 );
+  if ( key2 != 0 || key2 != Qt::Key::Key_unknown ) {
+    return {QKeyCombination( modifiers, static_cast< Qt::Key >(key1) ),
+            QKeyCombination( modifiers, static_cast< Qt::Key >(key2) )};
+  }
+  return {QKeyCombination( modifiers, static_cast< Qt::Key >(key1) )};;
 }
+
 
 bool InternalPlayerBackend::anyAvailable()
 {

--- a/src/config.hh
+++ b/src/config.hh
@@ -192,14 +192,11 @@ struct HotKey
   Qt::KeyboardModifiers modifiers;
   int key1, key2;
 
-  HotKey();
-
   /// Hotkey's constructor, take a QKeySequence's first two keys
   /// 1st key's modifier will be the `modifiers` above
   /// 1st key without modifier will becomes `key1`
   /// 2nd key without modifier will becomes `key2`
   /// The relation between the int and qt's KeyCode should consult qt's doc
-
   HotKey( QKeySequence const & );
 
   QKeySequence toKeySequence() const;


### PR DESCRIPTION
A very interesting deprecation from Qt's side.

In Qt5 
```
QKeySequence[]-> int`
```

In Qt6
```
QKeySequence[]-> QKeyCombination::operator int() -> int`
                                            ^ deprecated
```

---

Anyway, the original GD's author's question finally got an answer in Qt6 :sweat_smile: 