### PR TITLE
opt: disable Qt≤6.7 deprecated features and disable Qt deprecation warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,12 @@ endif ()
 
 #### Compile definitions
 
+# Disable deprecated staffs for Qt<=6.5 (Bump this if ever consider bump Qt version)
+target_compile_definitions(${GOLDENDICT} PRIVATE
+        QT_DISABLE_DEPRECATED_UP_TO=0x060500
+        QT_NO_DEPRECATED_WARNINGS
+)
+
 target_compile_definitions(${GOLDENDICT} PUBLIC
         CMAKE_USED_HACK  # temporal hack to avoid breaking qmake build
         MAKE_QTMULTIMEDIA_PLAYER

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,9 +192,9 @@ endif ()
 
 #### Compile definitions
 
-# Disable deprecated staffs for Qt<=6.5 (Bump this if ever consider bump Qt version)
+# Disable deprecated staffs for Qt<=6.7 (Bump this if ever consider bump Qt version)
 target_compile_definitions(${GOLDENDICT} PRIVATE
-        QT_DISABLE_DEPRECATED_UP_TO=0x060500
+        QT_DISABLE_DEPRECATED_UP_TO=0x060700
         QT_NO_DEPRECATED_WARNINGS
 )
 

--- a/src/macos/macmouseover.mm
+++ b/src/macos/macmouseover.mm
@@ -88,8 +88,8 @@ QString MacMouseOver::CFStringRefToQString( CFStringRef str )
 
   UniChar *chars = new UniChar[ length ];
   CFStringGetCharacters( str, CFRangeMake( 0, length ), chars );
-
-  QString result = QString::fromUtf16( chars, length );
+  
+  QString result = QString::fromUtf16( (char16_t*)chars, length );
 
   delete[] chars;
   return result;

--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -31,7 +31,7 @@ Requires Windows 10 (1809 or later).
 * For ArchLinux, pre-built binary is available from [archlinuxcn's repo](https://github.com/archlinuxcn/repo/tree/master/archlinuxcn/goldendict-ng-git).
 * [Gentoo package from PG_Overlay](https://gitlab.com/Perfect_Gentleman/PG_Overlay/-/tree/master/app-text/goldendict-ng)
 
-Minimum supported "Linux" versions is supposedly the current Ubuntu LTS or Debian's old stable or Qt6.4.
+Minimum supported "Linux" version is supposedly the current Ubuntu LTS and Debian's oldstable.
 
 ## macOS
 


### PR DESCRIPTION
Depends on https://github.com/xiaoyifang/goldendict-ng/pull/1920

The remaining ones aren't really fixable --> some are Qt6.7/6.8 features.

And, we need to support Qt6.4.

---

So, let's disable ~~Qt≤6.5~~ Qt≤6.7 deprecated features.

Using them will cause build error.

Sample failure --> https://github.com/xiaoyifang/goldendict-ng/actions/runs/11718114232/job/32638882331?pr=1921#step:6:300

Then disable warnings from Qt's side.
