### PR TITLE
opt: dictionary tab switch will show blank widget when source changing.

### DIFF
--- a/src/ui/editdictionaries.cc
+++ b/src/ui/editdictionaries.cc
@@ -200,7 +200,7 @@ void EditDictionaries::acceptChangedSources( bool rebuildGroups )
 #ifndef NO_TTS_SUPPORT
   cfg.voiceEngines = sources.getVoiceEngines();
 #endif
-  ui.tabs->setUpdatesEnabled( false );
+  setUpdatesEnabled( false );
   // Those hold pointers to dictionaries, we need to free them.
   groupInstances.clear();
 
@@ -225,7 +225,7 @@ void EditDictionaries::acceptChangedSources( bool rebuildGroups )
     connect( groups, &Groups::showDictionaryInfo, this, &EditDictionaries::showDictionaryInfo );
     connect( orderAndProps, &OrderAndProps::showDictionaryHeadwords, this, &EditDictionaries::showDictionaryHeadwords );
   }
-  ui.tabs->setUpdatesEnabled( true );
+  setUpdatesEnabled( true );
 }
 EditDictionaries::~EditDictionaries()
 {


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/065040f3-ad20-4cc9-8b01-1774220a599c)
after:
![image](https://github.com/user-attachments/assets/1bab5f81-7dab-4e38-b94d-5b34e952279b)
