### PR TITLE
fix a mistake of #1912

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -111,7 +111,7 @@ HotKey::HotKey( QKeySequence const & seq ):
 
 QKeySequence HotKey::toKeySequence() const
 {
-  if ( key2 != 0 || key2 != Qt::Key::Key_unknown ) {
+  if ( key2 != 0 && key2 != Qt::Key::Key_unknown ) {
     return { QKeyCombination( modifiers, static_cast< Qt::Key >( key1 ) ),
              QKeyCombination( modifiers, static_cast< Qt::Key >( key2 ) ) };
   }


### PR DESCRIPTION
https://github.com/xiaoyifang/goldendict-ng/pull/1912

key2 have to be not equal to both to be valid.