### PR TITLE
opt: mdx -> avoid duplicated Adler-32 checksum in zlib decompression

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,6 +26,7 @@ Checks: >
   -google-default-arguments,
   -google-readability-casting,
   -hicpp-deprecated-headers,
+  -hicpp-no-array-decay,
   -misc-const-correctness,
   -misc-include-cleaner,
   -misc-non-private-member-variables-in-classes,

--- a/src/dict/mdictparser.cc
+++ b/src/dict/mdictparser.cc
@@ -264,14 +264,12 @@ bool MdictParser::parseCompressedBlock( qint64 compressedBlockSize,
 
     case 0x02000000:
       // zlib compression
-      decompressedBlock = zlibDecompress( buf, size );
-
-      if ( !checkAdler32( decompressedBlock.constData(), decompressedBlock.size(), checksum ) ) {
-        gdWarning( "MDict: parseCompressedBlock: zlib: checksum does not match" );
+      decompressedBlock = zlibDecompress( buf, size, checksum );
+      if ( decompressedBlock.isEmpty() ) {
+        gdWarning( "MDict: parseCompressedBlock: zlib: failed to decompress or checksum does not match" );
         return false;
       }
       break;
-
     default:
       gdWarning( "MDict: parseCompressedBlock: unknown type" );
       return false;

--- a/src/dict/utils/decompress.hh
+++ b/src/dict/utils/decompress.hh
@@ -3,12 +3,11 @@
 #include <QByteArray>
 #include <string>
 
-using std::string;
+/// @param adler32_checksum  0 to skip checksum
+QByteArray zlibDecompress( const char * bufptr, unsigned length, unsigned long adler32_checksum );
 
-QByteArray zlibDecompress( const char * bufptr, unsigned length );
+std::string decompressZlib( const char * bufptr, unsigned length );
 
-string decompressZlib( const char * bufptr, unsigned length );
+std::string decompressBzip2( const char * bufptr, unsigned length );
 
-string decompressBzip2( const char * bufptr, unsigned length );
-
-string decompressLzma2( const char * bufptr, unsigned length, bool raw_decoder = false );
+std::string decompressLzma2( const char * bufptr, unsigned length, bool raw_decoder = false );


### PR DESCRIPTION
close https://github.com/xiaoyifang/goldendict-ng/issues/1775

Micro optimization, remove one extra data traversing to calculate the hash.

Adler-32 is a rolling hash calculated together with the inflating process.

Fix various small issues

* move `using` out of the header (it propagates into all headers that include it)
* create buf only when it will be used (`inflateInit == Z_OK`)
* check `inflateEnd`'s return value