### PR TITLE
opt: don't focus on the main window if word comes from headword dialog

### DIFF
--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -402,10 +402,9 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   connect( wordsZoomBase, &QAction::triggered, this, &MainWindow::doWordsZoomBase );
 
   // tray icon
-  connect( trayIconMenu.addAction( tr( "Show &Main Window" ) ),
-           &QAction::triggered,
-           this,
-           &MainWindow::showMainWindow );
+  connect( trayIconMenu.addAction( tr( "Show &Main Window" ) ), &QAction::triggered, this, [ this ] {
+    this->toggleMainWindow( true );
+  } );
   trayIconMenu.addAction( enableScanningAction );
 
   trayIconMenu.addSeparator();
@@ -2532,7 +2531,7 @@ void MainWindow::handleEsc()
   }
 
   if ( cfg.preferences.escKeyHidesMainWindow ) {
-    toggleMainWindow();
+    toggleMainWindow( false );
   }
   else {
     focusTranslateLine();
@@ -2873,7 +2872,7 @@ void MainWindow::showTranslationForDicts( QString const & inWord,
                         ignoreDiacritics );
 }
 
-void MainWindow::toggleMainWindow( bool onlyShow )
+void MainWindow::toggleMainWindow( bool ensureShow )
 {
   bool shown = false;
 
@@ -2906,7 +2905,7 @@ void MainWindow::toggleMainWindow( bool onlyShow )
     }
     shown = true;
   }
-  else if ( !onlyShow ) {
+  else if ( !ensureShow ) {
 
     // On Windows and Linux, a hidden window won't show a task bar icon
     // When trayicon is enabled, the duplication is unneeded
@@ -2990,7 +2989,7 @@ void MainWindow::installHotKeys()
 void MainWindow::hotKeyActivated( int hk )
 {
   if ( !hk ) {
-    toggleMainWindow();
+    toggleMainWindow( false );
   }
   else if ( scanPopup ) {
 #ifdef HAVE_X11
@@ -3075,7 +3074,7 @@ void MainWindow::trayIconActivated( QSystemTrayIcon::ActivationReason r )
   switch ( r ) {
     case QSystemTrayIcon::Trigger:
       // Left click toggles the visibility of main window
-      toggleMainWindow();
+      toggleMainWindow( false );
       break;
 
     case QSystemTrayIcon::MiddleClick:
@@ -3088,10 +3087,6 @@ void MainWindow::trayIconActivated( QSystemTrayIcon::ActivationReason r )
   }
 }
 
-void MainWindow::showMainWindow()
-{
-  toggleMainWindow( true );
-}
 
 void MainWindow::visitHomepage()
 {

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -3730,13 +3730,6 @@ void MainWindow::wordReceived( const QString & word )
   respondToTranslationRequest( word, false );
 }
 
-void MainWindow::headwordReceived( const QString & word, const QString & ID )
-{
-  toggleMainWindow( true );
-  setInputLineText( word, WildcardPolicy::EscapeWildcards, NoPopupChange );
-  respondToTranslationRequest( word, false, ArticleView::scrollToFromDictionaryId( ID ), false );
-}
-
 void MainWindow::updateFavoritesMenu()
 {
   if ( ui.favoritesPane->isVisible() ) {
@@ -4141,7 +4134,13 @@ void MainWindow::showDictionaryHeadwords( Dictionary::Class * dict )
       headwordsDlg = new DictHeadwords( this, cfg, dict );
       addGlobalActionsToDialog( headwordsDlg );
       addGroupComboBoxActionsToDialog( headwordsDlg, groupList );
-      connect( headwordsDlg, &DictHeadwords::headwordSelected, this, &MainWindow::headwordReceived );
+      connect( headwordsDlg,
+               &DictHeadwords::headwordSelected,
+               this,
+               [ this ]( QString const & headword, QString const & dictID ) {
+                 setInputLineText( headword, WildcardPolicy::EscapeWildcards, NoPopupChange );
+                 respondToTranslationRequest( headword, false, ArticleView::scrollToFromDictionaryId( dictID ), false );
+               } );
       connect( headwordsDlg,
                &DictHeadwords::closeDialog,
                this,

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -225,9 +225,8 @@ private:
   /// group, or to all dictionaries if there are no groups.
   vector< sptr< Dictionary::Class > > const & getActiveDicts();
 
-  /// Brings the main window to front if it's not currently, or hides it
-  /// otherwise. The hiding part is omitted if onlyShow is true.
-  void toggleMainWindow( bool onlyShow = false );
+  /// @param ensureShow only ensure the window will be shown and no "toggling"
+  void toggleMainWindow( bool ensureShow );
 
   /// Creates hotkeyWrapper and hooks the currently set keys for it
   void installHotKeys();
@@ -396,8 +395,6 @@ private slots:
   void trayIconActivated( QSystemTrayIcon::ActivationReason );
 
   void setAutostart( bool );
-
-  void showMainWindow();
 
   void visitHomepage();
   void visitForum();

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -67,7 +67,6 @@ public slots:
   void messageFromAnotherInstanceReceived( QString const & );
   void showStatusBarMessage( QString const &, int, QPixmap const & );
   void wordReceived( QString const & );
-  void headwordReceived( QString const &, QString const & );
   void headwordFromFavorites( QString const &, QString const & );
   void quitApp();
 


### PR DESCRIPTION
fix https://github.com/xiaoyifang/goldendict-ng/issues/1323

Note that this focus stealing exists for a decade. Honestly cannot tell if it is a feature or misdesign 😅 

As of now, I think it is a misdesign, because the dialog is a tall narrow window, it don't cover the article display area (probably only because today's computer monitor is larger than a decade ago).

https://github.com/xiaoyifang/goldendict-ng/commit/46298a842cead991e271535105db546f80f88eba#diff-5672b26c3952a17c577362e80c313b2d937da7cdf2d4e4a91bba90e68ed855ccR3513

Related change

* Move `headwordReceived` into lambda, because it only serves the head word dialog.
* Stop the confusing `toggle****` and `showOnly` thing