### PR TITLE
fix: macOS -> replace the tray icon with a dock menu

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -199,7 +199,6 @@ Preferences::Preferences():
   hideMenubar( false ),
   enableTrayIcon( true ),
   startToTray( false ),
-  closeToTray( true ),
   autoStart( false ),
   doubleClickTranslates( true ),
   selectWordBySingleClick( false ),
@@ -906,7 +905,9 @@ Class load()
 
     c.preferences.enableTrayIcon = ( preferences.namedItem( "enableTrayIcon" ).toElement().text() == "1" );
     c.preferences.startToTray    = ( preferences.namedItem( "startToTray" ).toElement().text() == "1" );
-    c.preferences.closeToTray    = ( preferences.namedItem( "closeToTray" ).toElement().text() == "1" );
+#ifndef Q_OS_MACOS // // macOS uses the dock menu instead of the tray icon
+    c.preferences.closeToTray = ( preferences.namedItem( "closeToTray" ).toElement().text() == "1" );
+#endif
     c.preferences.autoStart      = ( preferences.namedItem( "autoStart" ).toElement().text() == "1" );
     c.preferences.alwaysOnTop    = ( preferences.namedItem( "alwaysOnTop" ).toElement().text() == "1" );
     c.preferences.searchInDock   = ( preferences.namedItem( "searchInDock" ).toElement().text() == "1" );

--- a/src/config.hh
+++ b/src/config.hh
@@ -343,7 +343,12 @@ struct Preferences
   bool hideMenubar;
   bool enableTrayIcon;
   bool startToTray;
-  bool closeToTray;
+#ifdef Q_OS_MACOS // macOS uses the dock menu instead of the tray icon
+  bool closeToTray = false;
+#else
+  bool closeToTray = true;
+#endif
+
   bool autoStart;
   bool doubleClickTranslates;
   bool selectWordBySingleClick;

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -401,14 +401,18 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   connect( wordsZoomOut, &QAction::triggered, this, &MainWindow::doWordsZoomOut );
   connect( wordsZoomBase, &QAction::triggered, this, &MainWindow::doWordsZoomBase );
 
-  // tray icon
+// tray icon
+#ifndef Q_OS_MACOS // macOS uses the dock menu instead of the tray icon
   connect( trayIconMenu.addAction( tr( "Show &Main Window" ) ), &QAction::triggered, this, [ this ] {
     this->toggleMainWindow( true );
   } );
+#endif
   trayIconMenu.addAction( enableScanningAction );
 
+#ifndef Q_OS_MACOS // macOS uses the dock menu instead of the tray icon
   trayIconMenu.addSeparator();
   connect( trayIconMenu.addAction( tr( "&Quit" ) ), &QAction::triggered, this, &MainWindow::quitApp );
+#endif
 
   addGlobalAction( &escAction, [ this ]() {
     handleEsc();
@@ -1420,6 +1424,10 @@ void MainWindow::updateAppearances( QString const & addonStyle,
 
 void MainWindow::trayIconUpdateOrInit()
 {
+#ifdef Q_OS_MACOS
+  trayIconMenu.setAsDockMenu();
+#else
+
   if ( !cfg.preferences.enableTrayIcon ) {
     if ( trayIcon ) {
       delete trayIcon;
@@ -1443,6 +1451,7 @@ void MainWindow::trayIconUpdateOrInit()
   // The 'Close to tray' action is associated with the tray icon, so we hide
   // or show it here.
   ui.actionCloseToTray->setVisible( cfg.preferences.enableTrayIcon );
+#endif
 }
 
 void MainWindow::wheelEvent( QWheelEvent * ev )

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -174,6 +174,11 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   ui.hideSingleTab->setChecked( p.hideSingleTab );
   ui.mruTabOrder->setChecked( p.mruTabOrder );
   ui.enableTrayIcon->setChecked( p.enableTrayIcon );
+
+#ifdef Q_OS_MACOS // macOS uses the dock menu instead of the tray icon
+  ui.enableTrayIcon->hide();
+#endif
+
   ui.startToTray->setChecked( p.startToTray );
   ui.closeToTray->setChecked( p.closeToTray );
   ui.cbAutostart->setChecked( p.autoStart );


### PR DESCRIPTION
* implement https://github.com/goldendict/goldendict/issues/1356#issuecomment-1362735547
* close https://github.com/xiaoyifang/goldendict-ng/issues/857
* close https://github.com/xiaoyifang/goldendict-ng/issues/583
* related https://github.com/xiaoyifang/goldendict-ng/issues/1731
* fix a bug that clicking the tray icon on macOS will bring up both "the tray menu" and the "main window" up (The tray menu showing up is macOS's intrinsic behavior? We don't have any code touches it).

---

After this change:

The toggle clipboard monitoring is moved to the dock menu.

<img width="339" src="https://github.com/user-attachments/assets/b98df0fa-5f13-49a0-803d-113591eb3e41">

To toggling visibility using dock icon: "Click" to bring up and "Option+Click" to hide. Note that "Option+click" may also hide other staffs, a weird shortcut.

---

Pretty sure this will break someone's habit, however

* The tray icon has little value on macOS because macOS's dock has the capability of having custom menu items
* Bugs, as in the issues mentioned. They all require macOS specific code that may lock related code in place for future because nobody knows Qt and macOS programming at the same time.

Is there fixes? Yes, but actually no.


(Apple don't use the terminology "tray icons", it is "Menu Extra" BTW. -> from Apple's HIG https://developer.apple.com/design/human-interface-guidelines/the-menu-bar#Menu-bar-extras).


* One fix is `TransformProcessType` -> `kProcessTransformToUIElementApplication` & `kProcessTransformToForegroundApplication`
  * `UIElementApplication` is app with "MenuExtra" but no "Dock Icon"
  * Apple don't even document it at all https://developer.apple.com/documentation/applicationservices/1462420-transformprocesstype?language=objc
* Another fix is having an extra binary that lives in its own process with type `LSUIElement = true`.
  * This is the method provided in Apple's sample codes, but that requires reprogram the tray menu that's wildly different from Windows & Linux's code https://developer.apple.com/documentation/swiftui/menubarextra
  * This is probably doable by just invoking the `goldendict` binary though.



I think this is the best way forward with only downside of breaks some existing users, hopefully they can adapt and hopefully using dock menu isn't hard.

