### PR TITLE
clean: remove unused `DEF_EX`

### DIFF
--- a/src/dict/aard.cc
+++ b/src/dict/aard.cc
@@ -46,10 +46,6 @@ using BtreeIndexing::IndexInfo;
 
 namespace {
 
-DEF_EX_STR( exNotAardFile, "Not an AARD file", Dictionary::Ex )
-DEF_EX_STR( exWordIsTooLarge, "Enountered a word that is too large:", Dictionary::Ex )
-DEF_EX_STR( exSuddenEndOfFile, "Sudden end of file", Dictionary::Ex )
-
 #pragma pack( push, 1 )
 
 /// AAR file header

--- a/src/dict/bgl.cc
+++ b/src/dict/bgl.cc
@@ -169,10 +169,6 @@ void addEntryToIndex( string & word,
   indexedWords.addWord( Utf8::decode( word ), articleOffset );
 }
 
-
-DEF_EX( exFailedToDecompressArticle, "Failed to decompress article's body", Dictionary::Ex )
-DEF_EX( exChunkIndexOutOfRange, "Chunk index is out of range", Dictionary::Ex )
-
 class BglDictionary: public BtreeIndexing::BtreeDictionary
 {
   QMutex idxMutex;

--- a/src/dict/gls.cc
+++ b/src/dict/gls.cc
@@ -301,7 +301,6 @@ namespace {
 ////////////////// GLS Dictionary
 
 using Dictionary::exCantReadFile;
-DEF_EX( exUserAbort, "User abort", Dictionary::Ex )
 DEF_EX_STR( exDictzipError, "DICTZIP error", Dictionary::Ex )
 
 enum {

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -64,14 +64,11 @@ DEF_EX( exNotAnIfoFile, "Not an .ifo file", Dictionary::Ex )
 DEF_EX_STR( exBadFieldInIfo, "Bad field in .ifo file encountered:", Dictionary::Ex )
 DEF_EX_STR( exNoIdxFile, "No corresponding .idx file was found for", Dictionary::Ex )
 DEF_EX_STR( exNoDictFile, "No corresponding .dict file was found for", Dictionary::Ex )
-DEF_EX_STR( exNoSynFile, "No corresponding .syn file was found for", Dictionary::Ex )
 
 DEF_EX( ex64BitsNotSupported, "64-bit indices are not presently supported, sorry", Dictionary::Ex )
 DEF_EX( exDicttypeNotSupported, "Dictionaries with dicttypes are not supported, sorry", Dictionary::Ex )
 
 using Dictionary::exCantReadFile;
-DEF_EX_STR( exWordIsTooLarge, "Enountered a word that is too large:", Dictionary::Ex )
-DEF_EX_STR( exSuddenEndOfFile, "Sudden end of file", Dictionary::Ex )
 DEF_EX_STR( exDictzipError, "DICTZIP error", Dictionary::Ex )
 
 DEF_EX_STR( exIncorrectOffset, "Incorrect offset encountered in file", Dictionary::Ex )

--- a/src/dict/xdxf.cc
+++ b/src/dict/xdxf.cc
@@ -81,7 +81,6 @@ namespace {
 
 using Dictionary::exCantReadFile;
 DEF_EX_STR( exNotXdxfFile, "The file is not an XDXF file:", Dictionary::Ex )
-DEF_EX( exCorruptedIndex, "The index file is corrupted", Dictionary::Ex )
 DEF_EX_STR( exDictzipError, "DICTZIP error", Dictionary::Ex )
 
 enum {


### PR DESCRIPTION
After https://github.com/xiaoyifang/goldendict-ng/pull/1939, unused warning will show up :)