### PR TITLE
clean: simplify macOS hotkey mapping code

### DIFF
--- a/src/macos/machotkeywrapper.mm
+++ b/src/macos/machotkeywrapper.mm
@@ -51,15 +51,15 @@ void createMapping()
             return;
         }
 
-        CFDataRef dataRef = (CFDataRef)TISGetInputSourceProperty(inputSourceRef, kTISPropertyUnicodeKeyLayoutData);
+        CFDataRef uchrDataRef = (CFDataRef)TISGetInputSourceProperty(inputSourceRef, kTISPropertyUnicodeKeyLayoutData);
 
-        const UCKeyboardLayout* keyboardLayoutPtr;
+        const UCKeyboardLayout* UCkeyboardLayoutPtr;
 
-        if (dataRef) {
-            keyboardLayoutPtr = (const UCKeyboardLayout*)CFDataGetBytePtr(dataRef);
+        if (uchrDataRef) {
+            UCkeyboardLayoutPtr = (const UCKeyboardLayout*)CFDataGetBytePtr(uchrDataRef);
         }
 
-        if (!keyboardLayoutPtr) {
+        if (!UCkeyboardLayoutPtr) {
             return;
         }
 
@@ -67,16 +67,17 @@ void createMapping()
             UInt32 theDeadKeyState = 0;
             UniCharCount theLength = 0;
             UniChar temp_char_buf;
-            if (UCKeyTranslate(keyboardLayoutPtr, i, kUCKeyActionDown, 0, LMGetKbdType(),
+            if (UCKeyTranslate(UCkeyboardLayoutPtr, i, kUCKeyActionDown, 0, LMGetKbdType(),
                     kUCKeyTranslateNoDeadKeysBit, &theDeadKeyState, 1, &theLength,
                     &temp_char_buf)
                     == noErr
                 && theLength > 0) {
                 if (isprint(temp_char_buf)) {
-                    mapping.emplace_back(ReverseMapEntry { temp_char, i });
+                    mapping.emplace_back(ReverseMapEntry { temp_char_buf, i });
                 }
             }
         }
+        mapping.shrink_to_fit();
     }
 }
 

--- a/src/macos/machotkeywrapper.mm
+++ b/src/macos/machotkeywrapper.mm
@@ -39,8 +39,7 @@ std::vector<ReverseMapEntry> mapping;
 /// * https://github.com/libsdl-org/SDL/blob/fc12cc6dfd859a4e01376162a58f12208e539ac6/src/video/cocoa/SDL_cocoakeyboard.m#L345
 /// * https://github.com/qt/qtbase/blob/922369844fcb75386237bca3eef59edd5093f58d/src/gui/platform/darwin/qapplekeymapper.mm#L449
 ///
-///  Known flaw:
-///  * UCKeyTranslate doesn't handle modifiers at all.
+///  Known possible flaws 1) UCKeyTranslate doesn't handle modifiers at all 2) Handling keyboard switching
 void createMapping()
 {
     if (mapping.empty()) {

--- a/src/macos/machotkeywrapper.mm
+++ b/src/macos/machotkeywrapper.mm
@@ -7,8 +7,8 @@
 #include <QPushButton>
 #include <QTimer>
 
-#include <vector>
 #include <memory>
+#include <vector>
 
 #import <Appkit/Appkit.h>
 
@@ -45,21 +45,21 @@ void createMapping()
 {
     if (mapping.empty()) {
         mapping.reserve(128);
-        
+
         TISInputSourceRef inputSourceRef = TISCopyCurrentKeyboardLayoutInputSource();
         if (!inputSourceRef) {
             return;
         }
 
         CFDataRef dataRef = (CFDataRef)TISGetInputSourceProperty(inputSourceRef, kTISPropertyUnicodeKeyLayoutData);
-        
+
         const UCKeyboardLayout* keyboardLayoutPtr;
-        
-        if(dataRef){
+
+        if (dataRef) {
             keyboardLayoutPtr = (const UCKeyboardLayout*)CFDataGetBytePtr(dataRef);
         }
-        
-        if(!keyboardLayoutPtr){
+
+        if (!keyboardLayoutPtr) {
             return;
         }
 
@@ -69,11 +69,11 @@ void createMapping()
             UniChar temp_char_buf;
             if (UCKeyTranslate(keyboardLayoutPtr, i, kUCKeyActionDown, 0, LMGetKbdType(),
                     kUCKeyTranslateNoDeadKeysBit, &theDeadKeyState, 1, &theLength,
-                               &temp_char_buf)
+                    &temp_char_buf)
                     == noErr
                 && theLength > 0) {
                 if (isprint(temp_char_buf)) {
-                    mapping.emplace_back(ReverseMapEntry{temp_char,i});
+                    mapping.emplace_back(ReverseMapEntry { temp_char, i });
                 }
             }
         }
@@ -87,7 +87,7 @@ quint32 qtKeyToNativeKey(quint32 key)
         return 0;
     }
 
-    for (auto& m:mapping) {
+    for (auto& m : mapping) {
         if (m.character == key) {
             return m.keyCode;
         }

--- a/src/macos/machotkeywrapper.mm
+++ b/src/macos/machotkeywrapper.mm
@@ -33,7 +33,7 @@ struct ReverseMapEntry {
     UInt16 keyCode;
 };
 
-std::vector<ReverseMapEntry> mapping;
+static std::vector<ReverseMapEntry> mapping;
 
 /// References:
 /// * https://github.com/libsdl-org/SDL/blob/fc12cc6dfd859a4e01376162a58f12208e539ac6/src/video/cocoa/SDL_cocoakeyboard.m#L345
@@ -52,13 +52,13 @@ void createMapping()
 
         CFDataRef uchrDataRef = (CFDataRef)TISGetInputSourceProperty(inputSourceRef, kTISPropertyUnicodeKeyLayoutData);
 
-        const UCKeyboardLayout* UCkeyboardLayoutPtr;
+        const UCKeyboardLayout* UCKeyboardLayoutPtr;
 
         if (uchrDataRef) {
-            UCkeyboardLayoutPtr = (const UCKeyboardLayout*)CFDataGetBytePtr(uchrDataRef);
+            UCKeyboardLayoutPtr = (const UCKeyboardLayout*)CFDataGetBytePtr(uchrDataRef);
         }
 
-        if (!UCkeyboardLayoutPtr) {
+        if (!UCKeyboardLayoutPtr) {
             return;
         }
 
@@ -66,7 +66,7 @@ void createMapping()
             UInt32 theDeadKeyState = 0;
             UniCharCount theLength = 0;
             UniChar temp_char_buf;
-            if (UCKeyTranslate(UCkeyboardLayoutPtr, i, kUCKeyActionDown, 0, LMGetKbdType(),
+            if (UCKeyTranslate(UCKeyboardLayoutPtr, i, kUCKeyActionDown, 0, LMGetKbdType(),
                     kUCKeyTranslateNoDeadKeysBit, &theDeadKeyState, 1, &theLength,
                     &temp_char_buf)
                     == noErr

--- a/src/macos/machotkeywrapper.mm
+++ b/src/macos/machotkeywrapper.mm
@@ -81,7 +81,7 @@ void createMapping()
     }
 }
 
-quint32 qtKeyToNativeKey(quint32 key)
+quint32 qtKeyToNativeKey(UniChar key)
 {
     createMapping();
     if (mapping.empty()) {
@@ -341,7 +341,7 @@ quint32 HotkeyWrapper::nativeKey(int key)
         return 0x72;
     default:;
     }
-    return MacKeyMapping::qtKeyToNativeKey(QChar(key).toLower().toLatin1());
+    return MacKeyMapping::qtKeyToNativeKey(QChar(key).toLower().unicode());
 }
 
 void HotkeyWrapper::sendCmdC()


### PR DESCRIPTION
Let's merge this in another day,

Chop related code to half.

---

This region of code looked scary because the first line assumes everyone uses English keyboard.
```
TISInputSourceRef inputSourceRef = TISCopyInputSourceForLanguage(CFSTR("en"));
```

So, the next line patches it to copy current input source -> TISCopyCurrentKeyboardInputSource

But japanese keyboard is slightly different, so it got patched again TISCopyCurrentKeyboardLayoutInputSource

Just uses the last one `TISCopyCurrentKeyboardLayoutInputSource`, all code are no longer needed.

---

Also change mappping to a vector instead of `calloc`.
