### PR TITLE
fix: a DICT crash caused by string out of bound access

### DIFF
--- a/src/dict/dictserver.cc
+++ b/src/dict/dictserver.cc
@@ -538,11 +538,13 @@ void DictServerWordSearchRequest::readMatchData( QByteArray & reply )
       if ( word.endsWith( '\"' ) ) {
         word.chop( 1 );
       }
-      if ( word[ 0 ] == '\"' ) {
-        word = word.mid( 1 );
+      if ( word.startsWith( '\"' ) ) {
+        word = word.remove( 0, 1 );
       }
 
-      this->addMatchedWord( word );
+      if ( !word.isEmpty() ) {
+        this->addMatchedWord( word );
+      }
     }
 
     reply = this->dictImpl->socket.readLine();


### PR DESCRIPTION
Crash site:

<img width="400" src="https://github.com/user-attachments/assets/9ea5d014-8035-4e36-9c26-ff12094e51cf">

`reply` is `wn "`.

A combination of 2 factors:

Original GD's code assumes `"` `"`  is a pair, and access the string by index.

New code doesn't wait for response to ready.

---

It for some reason reliably crash for me when searching "get" and always end with a incomplete `wn "`. I thought it is just out of bound access, but looking into the website reveals that three are a few more words aren't arrived. It always reaches `gettable`. (Does this mean dict.org is hosted on a single machine and my latency to this machine is a constant and thus it always crash at that point 😅 )

<img width="400"  src="https://github.com/user-attachments/assets/0e59da62-2ad8-4dde-abcc-db1ec21812a5">
