### PR TITLE
benchmark + opt: make Folding::apply slightly faster

### DIFF
--- a/.github/workflows/PR-check-cmake.yml
+++ b/.github/workflows/PR-check-cmake.yml
@@ -141,7 +141,8 @@ jobs:
           qt6-tools \
           qt6-webengine \
           tomlplusplus \
-          xapian-core
+          xapian-core \
+          benchmark
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/PR-check-cmake.yml
+++ b/.github/workflows/PR-check-cmake.yml
@@ -158,7 +158,8 @@ jobs:
             -DWITH_FFMPEG_PLAYER=ON \
             -DWITH_TTS=ON \
             -DUSE_SYSTEM_FMT=ON \
-            -DUSE_SYSTEM_TOML=ON
+            -DUSE_SYSTEM_TOML=ON \
+            -DWITH_DEV_GOOGLE_BENCH=ON
 
           cmake --build ./build_dir
 

--- a/.github/workflows/PR-check-cmake.yml
+++ b/.github/workflows/PR-check-cmake.yml
@@ -160,3 +160,7 @@ jobs:
             -DUSE_SYSTEM_TOML=ON
 
           cmake --build ./build_dir
+
+      - name: Run benchmark
+        run: |
+          ./build_dir/bcf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ option(USE_SYSTEM_TOML "use system toml++ instead of bundled one" OFF)
 
 option(WITH_VCPKG_BREAKPAD "build with Breakpad support for VCPKG build only" OFF)
 
+# dev purpose options
+option(WITH_DEV_GOOGLE_BENCH "Add google benchmark to the tree" OFF)
+
 ## Change binary & resources folder to parallel install with original GD.
 ## This flag should be avoided because it leads to small regressions:
 ## 1. There are personal scripts assuming the binary name to be "goldendict" -> require everyone to change the name in their script
@@ -49,7 +52,7 @@ include(FeatureSummary)
 project(goldendict-ng
         VERSION 24.11.0
         LANGUAGES CXX C)
-        
+
 if (APPLE)
     enable_language(OBJCXX)
     set(CMAKE_OBJCXX_STANDARD 17)
@@ -60,12 +63,12 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(GOLDENDICT "goldendict") # binary/executable name
-if (USE_ALTERNATIVE_NAME )
+if (USE_ALTERNATIVE_NAME)
     set(GOLDENDICT "goldendict-ng")
 endif ()
 if (APPLE)
     set(GOLDENDICT "GoldenDict-ng")
-endif()
+endif ()
 
 
 #### Qt
@@ -163,7 +166,7 @@ target_link_libraries(${GOLDENDICT} PRIVATE
         Qt6::WebEngineWidgets
         Qt6::Widgets
         Qt6::Svg
-        )
+)
 
 if (WITH_TTS)
     target_link_libraries(${GOLDENDICT} PRIVATE Qt6::TextToSpeech)
@@ -176,7 +179,7 @@ target_include_directories(${GOLDENDICT} PRIVATE
         ${PROJECT_SOURCE_DIR}/src/dict
         ${PROJECT_SOURCE_DIR}/src/dict/utils
         ${PROJECT_SOURCE_DIR}/src/ui
-        )
+)
 
 if (WIN32)
     target_include_directories(${GOLDENDICT} PRIVATE ${PROJECT_SOURCE_DIR}/src/windows)
@@ -202,7 +205,7 @@ target_compile_definitions(${GOLDENDICT} PUBLIC
         CMAKE_USED_HACK  # temporal hack to avoid breaking qmake build
         MAKE_QTMULTIMEDIA_PLAYER
         MAKE_CHINESE_CONVERSION_SUPPORT
-        )
+)
 
 if (WIN32)
     target_compile_definitions(${GOLDENDICT} PUBLIC
@@ -215,9 +218,9 @@ if (WITH_FFMPEG_PLAYER)
     target_compile_definitions(${GOLDENDICT} PUBLIC MAKE_FFMPEG_PLAYER)
 endif ()
 
-if(NOT WITH_TTS)
+if (NOT WITH_TTS)
     target_compile_definitions(${GOLDENDICT} PUBLIC NO_TTS_SUPPORT)
-endif()
+endif ()
 
 
 if (NOT WITH_EPWING_SUPPORT)
@@ -257,6 +260,11 @@ qt_add_translations(${GOLDENDICT} TS_FILES ${TRANS_FILES}
         LUPDATE_OPTIONS "-no-ui-lines -locations none -no-obsolete")
 
 add_dependencies(${GOLDENDICT} "release_translations")
+
+add_executable(bcf bench/bench-case-folding.cpp src/common/folding.cc src/common/utf8.cc )
+target_link_libraries(bcf PUBLIC benchmark::benchmark_main Qt6::Core fmt::fmt)
+target_include_directories(bcf PUBLIC src/common)
+
 
 #### installation or assemble redistribution
 

--- a/bench/bench-case-folding.cpp
+++ b/bench/bench-case-folding.cpp
@@ -1,0 +1,19 @@
+#include "folding.hh"
+#include <benchmark/benchmark.h>
+
+static std::u32string a = U"HOMEBREW_NO_AUTO_UPDATE. Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).";
+
+static void applyFolding(benchmark::State& state){
+  for (auto _ : state){
+    Folding::apply(a);
+  }
+}
+BENCHMARK(applyFolding);
+
+
+static void applyFolding2(benchmark::State& state){
+  for (auto _ : state){
+    Folding::apply2(a);
+  }
+}
+BENCHMARK(applyFolding2);

--- a/bench/bench-case-folding.cpp
+++ b/bench/bench-case-folding.cpp
@@ -3,17 +3,19 @@
 
 static std::u32string a = U"HOMEBREW_NO_AUTO_UPDATE. Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).";
 
-static void applyFolding(benchmark::State& state){
-  for (auto _ : state){
-    Folding::apply(a);
+static void applyFolding( benchmark::State & state )
+{
+  for ( auto _ : state ) {
+    Folding::apply( a );
   }
 }
-BENCHMARK(applyFolding);
+BENCHMARK( applyFolding );
 
 
-static void applyFolding2(benchmark::State& state){
-  for (auto _ : state){
-    Folding::apply2(a);
+static void applyFolding2( benchmark::State & state )
+{
+  for ( auto _ : state ) {
+    Folding::apply2( a );
   }
 }
-BENCHMARK(applyFolding2);
+BENCHMARK( applyFolding2 );

--- a/cmake/Deps_Unix.cmake
+++ b/cmake/Deps_Unix.cmake
@@ -101,3 +101,7 @@ if (USE_SYSTEM_TOML)
     find_package(tomlplusplus)
     target_link_libraries(${GOLDENDICT} PRIVATE tomlplusplus::tomlplusplus)
 endif ()
+
+if (WITH_DEV_GOOGLE_BENCH)
+    find_package(benchmark REQUIRED)
+endif ()

--- a/src/common/folding.cc
+++ b/src/common/folding.cc
@@ -58,6 +58,19 @@ wstring apply( wstring const & in, bool preserveWildcards )
   return caseFolded;
 }
 
+wstring apply2( wstring const & in, bool preserveWildcards )
+{
+  return QString::fromStdU32String( in )
+    .toCaseFolded()
+    .normalized( QString::NormalizationForm_KD )
+    .remove( RX::markSpace )
+    .removeIf( [ preserveWildcards ]( const QChar & ch ) -> bool {
+      return ch.isPunct()
+        || ( preserveWildcards && ( ch == '\\' || ch == '?' || ch == '*' || ch == '[' || ch == ']' ) );
+    } )
+    .toStdU32String();
+}
+
 wstring applySimpleCaseOnly( wstring const & in )
 {
   wchar const * nextChar = in.data();

--- a/src/common/folding.hh
+++ b/src/common/folding.hh
@@ -28,6 +28,7 @@ enum {
 /// Applies the folding algorithm to each character in the given string,
 /// making another one as a result.
 wstring apply( wstring const &, bool preserveWildcards = false );
+wstring apply2( wstring const &, bool preserveWildcards = false );
 
 /// Applies only simple case folding algorithm. Since many dictionaries have
 /// different case style, we interpret words differing only by case as synonyms.


### PR DESCRIPTION
related https://github.com/xiaoyifang/goldendict-ng/issues/1943

The original code reallocates memory for string multiple times, just reuse Qt's case folding and do everything with QString, only returns std::u32string.

It is simply 10x faster.

New version is `apply2`

In debug build, the speed up is 10x

```
/Users/slbtty/src/goldendict-ng/cmake-build-debug/bcf
Unable to determine clock rate from sysctl: hw.cpufrequency: No such file or directory
This does not affect benchmark measurements, only the metadata output.
***WARNING*** Failed to set thread affinity. Estimated CPU frequency may be incorrect.
2024-11-12T17:56:24-05:00
Running /Users/slbtty/src/goldendict-ng/cmake-build-debug/bcf
Run on (8 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x8)
Load Average: 3.55, 3.72, 3.48
--------------------------------------------------------
Benchmark              Time             CPU   Iterations
--------------------------------------------------------
applyFolding       45889 ns        45767 ns        15304
applyFolding2       3609 ns         3602 ns       194045
```

For -O2 or similar, the factor is less than 2 https://github.com/xiaoyifang/goldendict-ng/actions/runs/11807278152/job/32893638497#step:7:15
