### PR TITLE
clean: remove redundant gd::toWString

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -15,3 +15,6 @@ a11c9e3aeca4329e1982d8fe26bacbb21ab50ddf
 
 # mass apply clang-tidy's modernize-use-using
 d15081e723756eef053550dc9e06e31d7828dec3
+
+# remove gd::toWString
+c8af0450f1f7f8188004db96e3f53e7e33e2ccad

--- a/src/article_maker.cc
+++ b/src/article_maker.cc
@@ -521,7 +521,7 @@ void ArticleRequest::altSearchFinished()
 
     vector< wstring > altsVector( alts.begin(), alts.end() );
 
-    wstring wordStd = gd::toWString( word );
+    wstring wordStd = word.toStdU32String();
 
     if ( activeDicts.size() <= 1 ) {
       articleSizeLimit = -1; // Don't collapse article if only one dictionary presented

--- a/src/common/iconv.cc
+++ b/src/common/iconv.cc
@@ -93,7 +93,7 @@ gd::wstring Iconv::toWstring( char const * fromEncoding, void const * fromData, 
   Iconv ic( fromEncoding );
 
   QString outStr = ic.convert( fromData, dataSize );
-  return gd::toWString( outStr );
+  return outStr.toStdU32String();
 }
 
 std::string Iconv::toUtf8( char const * fromEncoding, void const * fromData, size_t dataSize )

--- a/src/common/wstring_qt.cc
+++ b/src/common/wstring_qt.cc
@@ -2,10 +2,6 @@
 #include <QList>
 
 namespace gd {
-wstring toWString( QString const & in )
-{
-  return in.toStdU32String();
-}
 
 // When convert non-BMP characters to wstring,the ending char maybe \0 .This method remove the tailing \0 from the wstring
 // as \0 is sensitive in the index.  This method will be only used with index related operations like store/query.
@@ -35,7 +31,7 @@ wstring removeTrailingZero( QString const & in )
 
 wstring normalize( const wstring & str )
 {
-  return toWString( QString::fromStdU32String( str ).normalized( QString::NormalizationForm_C ) );
+  return QString::fromStdU32String( str ).normalized( QString::NormalizationForm_C ).toStdU32String();
 }
 
 

--- a/src/common/wstring_qt.hh
+++ b/src/common/wstring_qt.hh
@@ -10,7 +10,6 @@
 #include <QString>
 
 namespace gd {
-wstring toWString( QString const & );
 wstring removeTrailingZero( wstring const & v );
 wstring removeTrailingZero( QString const & in );
 wstring normalize( wstring const & );

--- a/src/dict/dictserver.cc
+++ b/src/dict/dictserver.cc
@@ -424,7 +424,7 @@ public:
       if ( countn ) {
         QMutexLocker _( &dataMutex );
         for ( int x = 0; x < countn; x++ ) {
-          matches.emplace_back( gd::toWString( matchesList.at( x ) ) );
+          matches.emplace_back( matchesList.at( x ).toStdU32String() );
         }
       }
       finish();

--- a/src/dict/dsl.cc
+++ b/src/dict/dsl.cc
@@ -540,7 +540,7 @@ void DslDictionary::loadArticle( uint32_t address,
 
     if ( !articleBody ) {
       //      throw exCantReadFile( getDictionaryFilenames()[ 0 ] );
-      articleData = U"\n\r\t" + gd::toWString( QString( "DICTZIP error: " ) + dict_error_str( dz ) );
+      articleData = U"\n\r\tDICTZIP error: " + QString( dict_error_str( dz ) ).toStdU32String();
     }
     else {
       try {
@@ -966,7 +966,7 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
         if ( n >= 0 ) {
           int n2 = attr.indexOf( '\"', n + 6 );
           if ( n2 > 0 ) {
-            quint32 id = dslLanguageToId( gd::toWString( attr.mid( n + 6, n2 - n - 6 ) ) );
+            quint32 id = dslLanguageToId( attr.mid( n + 6, n2 - n - 6 ).toStdU32String() );
             langcode   = LangCoder::intToCode2( id ).toStdString();
           }
         }
@@ -1089,7 +1089,7 @@ QString const & DslDictionary::getDescription()
       for ( ;; ) {
         data.clear();
         langStr = str.mid( 10 ).replace( '\"', ' ' ).trimmed();
-        annLang = LangCoder::findIdForLanguage( gd::toWString( langStr ) );
+        annLang = LangCoder::findIdForLanguage( langStr.toStdU32String() );
         do {
           str = annStream.readLine();
           if ( str.left( 10 ).compare( "#LANGUAGE " ) == 0 ) {
@@ -1391,7 +1391,7 @@ void DslDictionary::getArticleText( uint32_t articleAddress, QString & headword,
 
     if ( haveInsidedCards ) {
       // Use base DSL parser for articles with insided cards
-      ArticleDom dom( gd::toWString( text ), getName(), articleHeadword );
+      ArticleDom dom( text.toStdU32String(), getName(), articleHeadword );
       text = QString::fromStdU32String( dom.root.renderAsText( true ) );
     }
     else {

--- a/src/dict/epwing.cc
+++ b/src/dict/epwing.cc
@@ -994,7 +994,7 @@ void EpwingWordSearchRequest::findMatches()
     QMutexLocker _( &dataMutex );
 
     for ( const auto & headword : headwords )
-      addMatch( gd::toWString( headword ) );
+      addMatch( headword.toStdU32String() );
 
     break;
   }
@@ -1047,7 +1047,7 @@ void addWordToChunks( Epwing::Book::EpwingHeadword & head,
     chunks.addToBlock( &head.page, sizeof( head.page ) );
     chunks.addToBlock( &head.offset, sizeof( head.offset ) );
 
-    wstring hw = gd::toWString( head.headword );
+    wstring hw = head.headword.toStdU32String();
 
     indexedWords.addWord( hw, offset );
     wordCount++;

--- a/src/dict/epwing_book.cc
+++ b/src/dict/epwing_book.cc
@@ -1141,7 +1141,7 @@ void EpwingBook::fixHeadword( QString & headword )
   //  return;
   //}
 
-  gd::wstring folded = Folding::applyPunctOnly( gd::toWString( fixed ) );
+  gd::wstring folded = Folding::applyPunctOnly( fixed.toStdU32String() );
   //fixed = QString::fromStdU32String( folded );
 
   //if( isHeadwordCorrect( fixed ) )

--- a/src/dict/hunspell.cc
+++ b/src/dict/hunspell.cc
@@ -413,7 +413,7 @@ QList< wstring > suggest( wstring & word, QMutex & hunspellMutex, Hunspell & hun
 
         auto match = cutStem.match( suggestion.trimmed() );
         if ( match.hasMatch() ) {
-          wstring alt = gd::toWString( match.captured( 1 ) );
+          wstring alt = match.captured( 1 ).toStdU32String();
 
           if ( Folding::applySimpleCaseOnly( alt ) != lowercasedWord ) // No point in providing same word
           {
@@ -643,7 +643,7 @@ wstring decodeFromHunspell( Hunspell & hunspell, char const * str )
   size_t outLeft = result.size() * sizeof( wchar );
 
   QString convStr = conv.convert( in, inLeft );
-  return gd::toWString( convStr );
+  return convStr.toStdU32String();
 }
 } // namespace
 

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -785,7 +785,7 @@ void MddResourceRequest::run()
         data.push_back( '\0' );
         QString target =
           MdictParser::toUtf16( "UTF-16LE", &data.front() + sizeof( pattern ), data.size() - sizeof( pattern ) );
-        resourceName = gd::toWString( target.trimmed() );
+        resourceName = target.trimmed().toStdU32String();
         continue;
       }
     }
@@ -1200,7 +1200,7 @@ QString MdxDictionary::getCachedFileName( QString filename )
       data.push_back( '\0' );
       QString target =
         MdictParser::toUtf16( "UTF-16LE", &data.front() + sizeof( pattern ), data.size() - sizeof( pattern ) );
-      resourceName = gd::toWString( target.trimmed() );
+      resourceName = target.trimmed().toStdU32String();
       continue;
     }
     break;
@@ -1249,14 +1249,14 @@ static void addEntryToIndex( QString const & word, uint32_t offset, IndexedWords
 {
   // Strip any leading or trailing whitespaces
   QString wordTrimmed = word.trimmed();
-  indexedWords.addWord( gd::toWString( wordTrimmed ), offset );
+  indexedWords.addWord( wordTrimmed.toStdU32String(), offset );
 }
 
 static void addEntryToIndexSingle( QString const & word, uint32_t offset, IndexedWords & indexedWords )
 {
   // Strip any leading or trailing whitespaces
   QString wordTrimmed = word.trimmed();
-  indexedWords.addSingleWord( gd::toWString( wordTrimmed ), offset );
+  indexedWords.addSingleWord( wordTrimmed.toStdU32String(), offset );
 }
 
 class ArticleHandler: public MdictParser::RecordHandler

--- a/src/dict/mediawiki.cc
+++ b/src/dict/mediawiki.cc
@@ -223,7 +223,7 @@ void MediaWikiWordSearchRequest::downloadFinished()
 
         qDebug() << "matches" << matches.size();
         for ( int x = 0; x < nl.length(); ++x ) {
-          matches.emplace_back( gd::toWString( nl.item( x ).toElement().attribute( "title" ) ) );
+          matches.emplace_back( nl.item( x ).toElement().attribute( "title" ).toStdU32String() );
         }
       }
     }

--- a/src/dict/programs.cc
+++ b/src/dict/programs.cc
@@ -334,7 +334,7 @@ void ProgramWordSearchRequest::instanceFinished( QByteArray output, QString erro
     QStringList result = QString::fromUtf8( output ).split( "\n", Qt::SkipEmptyParts );
 
     for ( const auto & x : result ) {
-      matches.push_back( Dictionary::WordMatch( gd::toWString( x ) ) );
+      matches.push_back( Dictionary::WordMatch( x.toStdU32String() ) );
     }
 
     if ( !error.isEmpty() ) {

--- a/src/dict/slob.cc
+++ b/src/dict/slob.cc
@@ -1315,10 +1315,10 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
                || contentType.startsWith( "text/plain", Qt::CaseInsensitive ) ) {
             //Article
             if ( maxHeadwordsToExpand && entries > maxHeadwordsToExpand ) {
-              indexedWords.addSingleWord( gd::toWString( refEntry.key ), offsets[ i ].second );
+              indexedWords.addSingleWord( refEntry.key.toStdU32String(), offsets[ i ].second );
             }
             else {
-              indexedWords.addWord( gd::toWString( refEntry.key ), offsets[ i ].second );
+              indexedWords.addWord( refEntry.key.toStdU32String(), offsets[ i ].second );
             }
 
             wordCount += 1;
@@ -1330,7 +1330,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
             }
           }
           else {
-            indexedResources.addSingleWord( gd::toWString( refEntry.key ), offsets[ i ].second );
+            indexedResources.addSingleWord( refEntry.key.toStdU32String(), offsets[ i ].second );
           }
         }
         sf.clearRefOffsets();

--- a/src/dict/sounddir.cc
+++ b/src/dict/sounddir.cc
@@ -409,7 +409,7 @@ void addDir( QDir const & baseDir,
       const uint32_t articleOffset = chunks.startNewBlock();
       chunks.addToBlock( fileName.c_str(), fileName.size() + 1 );
 
-      wstring name = gd::toWString( i->fileName() );
+      wstring name = i->fileName().toStdU32String();
 
       const wstring::size_type pos = name.rfind( L'.' );
 

--- a/src/dict/utils/indexedzip.cc
+++ b/src/dict/utils/indexedzip.cc
@@ -214,7 +214,7 @@ bool IndexedZip::indexFile( BtreeIndexing::IndexedWords & zipFileNames, quint32 
         // System locale
         if ( localeCodec ) {
           QString name       = localeCodec->toUnicode( entry.fileName.constData(), entry.fileName.size() );
-          nameInSystemLocale = gd::toWString( name );
+          nameInSystemLocale = name.toStdU32String();
           if ( !nameInSystemLocale.empty() ) {
             zipFileNames.addSingleWord( nameInSystemLocale, entry.localHeaderOffset );
 

--- a/src/dict/xdxf.cc
+++ b/src/dict/xdxf.cc
@@ -903,7 +903,7 @@ void indexArticle( GzippedFile & gzFile,
         // Add words to index
 
         for ( const auto & word : words ) {
-          indexedWords.addWord( gd::toWString( word ), offset );
+          indexedWords.addWord( word.toStdU32String(), offset );
         }
 
         ++articleCount;
@@ -1226,7 +1226,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
                         while ( !( stream.isEndElement() && stream.name() == u"abbr_def" ) || !stream.atEnd() ) {
                           if ( stream.isStartElement() && stream.name() == u"abbr_k" ) {
                             s = readElementText( stream );
-                            keys.push_back( gd::toWString( s ) );
+                            keys.push_back( s.toStdU32String() );
                           }
                           else if ( stream.isStartElement() && stream.name() == u"abbr_v" ) {
                             s     = readElementText( stream );
@@ -1246,7 +1246,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
                         while ( !( stream.isEndElement() && stream.name() == u"abr_def" ) || !stream.atEnd() ) {
                           if ( stream.isStartElement() && stream.name() == u"k" ) {
                             s = readElementText( stream );
-                            keys.push_back( gd::toWString( s ) );
+                            keys.push_back( s.toStdU32String() );
                           }
                           else if ( stream.isStartElement() && stream.name() == u"v" ) {
                             s     = readElementText( stream );

--- a/src/dict/xdxf2html.cc
+++ b/src/dict/xdxf2html.cc
@@ -630,7 +630,7 @@ string convert( string const & in,
 
     //    if( type == XDXF && dictPtr != NULL && !el.hasAttribute( "start" ) )
     if ( dictPtr != NULL && !el.hasAttribute( "start" ) ) {
-      string filename = Utf8::encode( gd::toWString( el.text() ) );
+      string filename = Utf8::encode( el.text().toStdU32String() );
 
       if ( Filetype::isNameOfPicture( filename ) ) {
         QUrl url;

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -1905,7 +1905,7 @@ void ArticleView::doubleClicked( QPoint pos )
 
     emit sendWordToInputLine( selectedText );
     // Do some checks to make sure there's a sensible selection indeed
-    if ( Folding::applyWhitespaceOnly( gd::toWString( selectedText ) ).size() && selectedText.size() < 60 ) {
+    if ( Folding::applyWhitespaceOnly( selectedText.toStdU32String() ).size() && selectedText.size() < 60 ) {
       // Initiate translation
       Qt::KeyboardModifiers kmod = QApplication::keyboardModifiers();
       if ( kmod & ( Qt::ControlModifier | Qt::ShiftModifier ) ) { // open in new tab

--- a/src/wordfinder.cc
+++ b/src/wordfinder.cc
@@ -131,7 +131,7 @@ void WordFinder::startSearch()
     allWordWritings.resize( 1 );
   }
 
-  allWordWritings[ 0 ] = gd::toWString( inputWord );
+  allWordWritings[ 0 ] = inputWord.toStdU32String();
 
   for ( const auto & inputDict : *inputDicts ) {
     vector< wstring > writings = inputDict->getAlternateWritings( allWordWritings[ 0 ] );


### PR DESCRIPTION
The reason there is such function was because the Windows version of gd::wstring is whatever we don't care anymore.

https://github.com/timonwong/goldendict/commit/babde3d53d21f8ba2a13c41d0cf2f391e6839094#diff-426cee2bb29733a476f42c3ba97c2ebc90647d51f30d6feb74b5fee3d15976b4R4-R32

Let's just use the real thing.


