### PR TITLE
clean: delete most Qt5 & <=6.3 conditional compiled code (`QT_VERSION_CHECK` macro)

### DIFF
--- a/src/audio/audiooutput.cc
+++ b/src/audio/audiooutput.cc
@@ -6,11 +6,7 @@
 #include <QWaitCondition>
 #include <QCoreApplication>
 #include <QThreadPool>
-#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
-  #include <QAudioOutput>
-#else
-  #include <QAudioSink>
-#endif
+#include <QAudioSink>
 #include <QtGlobal>
 #include <QBuffer>
 
@@ -23,18 +19,7 @@ static QAudioFormat format( int sampleRate, int channelCount )
 
   out.setSampleRate( sampleRate );
   out.setChannelCount( channelCount );
-#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
-  out.setByteOrder( QAudioFormat::LittleEndian );
-  out.setCodec( QLatin1String( "audio/pcm" ) );
-#endif
-
-#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
-  out.setSampleSize( 16 );
-  out.setSampleType( QAudioFormat::SignedInt );
-#else
   out.setSampleFormat( QAudioFormat::Int16 );
-#endif
-
 
   return out;
 }
@@ -50,11 +35,8 @@ public:
 
   QFuture< void > audioPlayFuture;
 
-#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
-  using AudioOutput = QAudioOutput;
-#else
   using AudioOutput = QAudioSink;
-#endif
+
   AudioOutput * audioOutput = nullptr;
   QByteArray buffer;
   qint64 offset = 0;
@@ -185,11 +167,7 @@ AudioOutput::AudioOutput( QObject * parent ):
   QObject( parent ),
   d_ptr( new AudioOutputPrivate )
 {
-#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
-  d_ptr->audioPlayFuture = QtConcurrent::run( &d_ptr->threadPool, d_ptr.data(), &AudioOutputPrivate::doPlayAudio );
-#else
   d_ptr->audioPlayFuture = QtConcurrent::run( &d_ptr->threadPool, &AudioOutputPrivate::doPlayAudio, d_ptr.data() );
-#endif
 }
 
 void AudioOutput::setAudioFormat( int sampleRate, int channels )

--- a/src/audio/ffmpegaudio.cc
+++ b/src/audio/ffmpegaudio.cc
@@ -2,27 +2,14 @@
 
   #include "audiooutput.hh"
   #include "ffmpegaudio.hh"
-
-  #include <errno.h>
-
-extern "C" {
-  #include <libavcodec/avcodec.h>
-  #include <libavformat/avformat.h>
-  #include <libavutil/avutil.h>
-  #include "libswresample/swresample.h"
-}
-
-  #include <QString>
-  #include <QDataStream>
-
-  #include <vector>
-  #if ( QT_VERSION >= QT_VERSION_CHECK( 6, 2, 0 ) )
-    #include <QMediaDevices>
-
-    #include <QAudioDevice>
-  #endif
   #include "gddebug.hh"
   #include "utils.hh"
+  #include <QAudioDevice>
+  #include <QDataStream>
+  #include <QMediaDevices>
+  #include <QString>
+  #include <errno.h>
+  #include <vector>
 
 using std::vector;
 
@@ -284,14 +271,11 @@ void DecoderContext::closeCodec()
 
 bool DecoderContext::openOutputDevice( QString & errorString )
 {
-  // only check device when qt version is greater than 6.2
-  #if ( QT_VERSION >= QT_VERSION_CHECK( 6, 2, 0 ) )
   QAudioDevice m_outputDevice = QMediaDevices::defaultAudioOutput();
   if ( m_outputDevice.isNull() ) {
     errorString += QString( "Can not found default audio output device" );
     return false;
   }
-  #endif
 
   if ( audioOutput == nullptr ) {
     errorString += QStringLiteral( "Failed to create audioOutput." );

--- a/src/audio/ffmpegaudio.hh
+++ b/src/audio/ffmpegaudio.hh
@@ -1,27 +1,24 @@
 #pragma once
 
 #ifdef MAKE_FFMPEG_PLAYER
-  #include "audiooutput.hh"
-  #include <QObject>
-  #include <QMutex>
-  #include <QByteArray>
-  #include <QThread>
+
 extern "C" {
   #include <libavcodec/avcodec.h>
   #include <libavformat/avformat.h>
   #include <libavutil/avutil.h>
   #include "libswresample/swresample.h"
 }
-
-  #include <QString>
+  #include "audiooutput.hh"
+  #include <QObject>
+  #include <QMutex>
+  #include <QByteArray>
+  #include <QThread>
+  #include <QAudioDevice>
   #include <QDataStream>
-
+  #include <QMediaDevices>
+  #include <QString>
   #include <vector>
-  #if ( QT_VERSION >= QT_VERSION_CHECK( 6, 2, 0 ) )
-    #include <QMediaDevices>
 
-    #include <QAudioDevice>
-  #endif
 using std::vector;
 namespace Ffmpeg {
 class DecoderThread;

--- a/src/audio/multimediaaudioplayer.cc
+++ b/src/audio/multimediaaudioplayer.cc
@@ -4,29 +4,18 @@
 #ifdef MAKE_QTMULTIMEDIA_PLAYER
 
   #include <QByteArray>
-  #if ( QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 ) )
-    #include <QMediaContent>
-  #endif
-  #if ( QT_VERSION > QT_VERSION_CHECK( 6, 2, 0 ) )
-    #include <QAudioDevice>
-  #endif
+  #include <QAudioDevice>
   #include "multimediaaudioplayer.hh"
 
   #include <QDebug>
 
 MultimediaAudioPlayer::MultimediaAudioPlayer()
-  #if ( QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 ) )
-  :
-  player( 0, QMediaPlayer::StreamPlayback )
-  #endif
 {
   player.setAudioOutput( &audioOutput );
 
   connect( &player, &QMediaPlayer::errorChanged, this, &MultimediaAudioPlayer::onMediaPlayerError );
 
-  #if ( QT_VERSION > QT_VERSION_CHECK( 6, 2, 0 ) )
   connect( &mediaDevices, &QMediaDevices::audioOutputsChanged, this, &MultimediaAudioPlayer::audioOutputChange );
-  #endif
 }
 
 void MultimediaAudioPlayer::audioOutputChange()
@@ -42,15 +31,11 @@ QString MultimediaAudioPlayer::play( const char * data, int size )
   if ( !audioBuffer->open( QIODevice::ReadOnly ) ) {
     return tr( "Couldn't open audio buffer for reading." );
   }
-  #if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
   player.setSourceDevice( audioBuffer );
-    #if ( QT_VERSION > QT_VERSION_CHECK( 6, 2, 0 ) )
+
   audioOutput.setDevice( QMediaDevices::defaultAudioOutput() );
   player.setAudioOutput( &audioOutput );
-    #endif
-  #else
-  player.setMedia( QMediaContent(), audioBuffer );
-  #endif
+
   player.play();
   return {};
 }
@@ -58,9 +43,7 @@ QString MultimediaAudioPlayer::play( const char * data, int size )
 void MultimediaAudioPlayer::stop()
 {
   player.stop();
-  #if ( QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 ) )
-  player.setMedia( QMediaContent() ); // Forget about audioBuffer.
-  #endif
+
   if ( audioBuffer ) {
     audioBuffer->close();
     audioBuffer->setData( QByteArray() ); // Free memory.

--- a/src/audio/multimediaaudioplayer.hh
+++ b/src/audio/multimediaaudioplayer.hh
@@ -5,15 +5,11 @@
 
 #ifdef MAKE_QTMULTIMEDIA_PLAYER
 
-  #include <QBuffer>
-  #include <QMediaPlayer>
   #include "audioplayerinterface.hh"
-  #if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
-    #include <QAudioOutput>
-  #endif
-  #if ( QT_VERSION >= QT_VERSION_CHECK( 6, 2, 0 ) )
-    #include <QMediaDevices>
-  #endif
+  #include <QAudioOutput>
+  #include <QBuffer>
+  #include <QMediaDevices>
+  #include <QMediaPlayer>
   #include <QPointer>
 
 class MultimediaAudioPlayer: public AudioPlayerInterface
@@ -34,12 +30,8 @@ private slots:
 private:
   QPointer< QBuffer > audioBuffer;
   QMediaPlayer player; ///< Depends on audioBuffer.
-  #if ( QT_VERSION >= QT_VERSION_CHECK( 6, 2, 0 ) )
   QAudioOutput audioOutput;
-  #endif
-  #if ( QT_VERSION >= QT_VERSION_CHECK( 6, 2, 0 ) )
   QMediaDevices mediaDevices;
-  #endif
 };
 
 #endif // MAKE_QTMULTIMEDIA_PLAYER

--- a/src/common/gddebug.cc
+++ b/src/common/gddebug.cc
@@ -1,14 +1,10 @@
 /* This file is (c) 2013 Abs62
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
-#include <QString>
 #include "gddebug.hh"
 #include <QDebug>
-#if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
-  #include <QtCore5Compat/QTextCodec>
-#else
-  #include <QTextCodec>
-#endif
+#include <QString>
+#include <QtCore5Compat/QTextCodec>
 
 QFile * logFilePtr;
 

--- a/src/common/wildcard.cc
+++ b/src/common/wildcard.cc
@@ -9,11 +9,6 @@
 
 QString wildcardsToRegexp( const QString & wc_str )
 {
-#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
-  //qt 5.X does not offer an unanchored version. the default output is enclosed between \A   \z.
-  auto anchorPattern = QRegularExpression::wildcardToRegularExpression( wc_str );
-  return anchorPattern.mid( 2, anchorPattern.length() - 4 );
-#else
+  // The "anchored" version will enclose the output with \A...\z.
   return QRegularExpression::wildcardToRegularExpression( wc_str, QRegularExpression::UnanchoredWildcardConversion );
-#endif
 }

--- a/src/dict/dsl_details.hh
+++ b/src/dict/dsl_details.hh
@@ -9,11 +9,7 @@
 #include <zlib.h>
 #include "dictionary.hh"
 #include "iconv.hh"
-#if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
-  #include <QtCore5Compat/QTextCodec>
-#else
-  #include <QTextCodec>
-#endif
+#include <QtCore5Compat/QTextCodec>
 #include <QByteArray>
 #include "utf8.hh"
 

--- a/src/dict/epwing_book.cc
+++ b/src/dict/epwing_book.cc
@@ -541,11 +541,7 @@ bool EpwingBook::setSubBook( int book_nom )
   QFile f( fileName );
   if ( f.open( QFile::ReadOnly | QFile::Text ) ) {
     QTextStream ts( &f );
-  #if ( QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 ) )
-    ts.setCodec( "UTF-8" );
-  #else
     ts.setEncoding( QStringConverter::Utf8 );
-  #endif
 
     QString line = ts.readLine();
     while ( !line.isEmpty() ) {

--- a/src/dict/epwing_book.hh
+++ b/src/dict/epwing_book.hh
@@ -16,12 +16,7 @@
 #endif
 
 #include <QString>
-#if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
-  #include <QtCore5Compat/QTextCodec>
-#else
-  #include <QTextCodec>
-#endif
-
+#include <QtCore5Compat/QTextCodec>
 
 #ifdef _MSC_VER
   #include <stub_msvc.h>

--- a/src/dict/gls.cc
+++ b/src/dict/gls.cc
@@ -32,11 +32,8 @@
 #include <QBuffer>
 
 #include <QRegularExpression>
-#if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
-  #include <QtCore5Compat/QTextCodec>
-#else
-  #include <QTextCodec>
-#endif
+#include <QtCore5Compat/QTextCodec>
+
 #include <string>
 #include <list>
 #include <map>

--- a/src/dict/mdictparser.cc
+++ b/src/dict/mdictparser.cc
@@ -32,11 +32,8 @@
 #include <QDomDocument>
 #include <QTextDocumentFragment>
 #include <QDataStream>
-#if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
-  #include <QtCore5Compat/QTextCodec>
-#else
-  #include <QTextCodec>
-#endif
+#include <QtCore5Compat/QTextCodec>
+
 #include "decompress.hh"
 #include "gddebug.hh"
 #include "ripemd.hh"

--- a/src/dict/sdict.cc
+++ b/src/dict/sdict.cc
@@ -1,35 +1,30 @@
 /* This file is (c) 2008-2012 Konstantin Isakov <ikm@goldendict.org>
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
-#include "sdict.hh"
 #include "btreeidx.hh"
-#include "folding.hh"
-#include "utf8.hh"
 #include "chunkedstorage.hh"
-#include "langcoder.hh"
-#include "gddebug.hh"
-
 #include "decompress.hh"
-#include "htmlescape.hh"
+#include "folding.hh"
 #include "ftshelpers.hh"
-
+#include "gddebug.hh"
+#include "htmlescape.hh"
+#include "langcoder.hh"
+#include "sdict.hh"
+#include "utf8.hh"
 #include <map>
+#include <QAtomicInt>
+#include <QRegularExpression>
+#include <QSemaphore>
+#include <QString>
 #include <set>
 #include <string>
+
+#include "utils.hh"
+
 
 #ifdef _MSC_VER
   #include <stub_msvc.h>
 #endif
-
-#include <QString>
-#include <QSemaphore>
-#include <QAtomicInt>
-#if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
-  #include <QtCore5Compat>
-#endif
-#include <QRegularExpression>
-
-#include "utils.hh"
 
 namespace Sdict {
 

--- a/src/dict/utils/indexedzip.cc
+++ b/src/dict/utils/indexedzip.cc
@@ -8,11 +8,8 @@
 #include "utf8.hh"
 #include "iconv.hh"
 #include "wstring_qt.hh"
-#if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
-  #include <QtCore5Compat/QTextCodec>
-#else
-  #include <QTextCodec>
-#endif
+#include <QtCore5Compat/QTextCodec>
+
 #include <QMutexLocker>
 
 using namespace BtreeIndexing;

--- a/src/iframeschemehandler.cc
+++ b/src/iframeschemehandler.cc
@@ -105,15 +105,8 @@ void IframeSchemeHandler::requestStarted( QWebEngineUrlRequestJob * requestJob )
 
     buffer->setData( articleString.toUtf8() );
 
-#if QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 )
     requestJob->reply( "text/html; charset=utf-8", buffer );
-#else
-  #if defined( Q_OS_WIN32 ) || defined( Q_OS_MAC )
-    requestJob->reply( contentType, buffer );
-  #else
-    requestJob->reply( "text/html", buffer );
-  #endif
-#endif
+
   };
   connect( reply, &QNetworkReply::finished, requestJob, finishAction );
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -307,15 +307,7 @@ void processCommandLine( QCoreApplication * app, GDOptions * result )
     // Handle cases where we get encoded URL
     if ( result->word.startsWith( QStringLiteral( "xn--" ) ) ) {
       // For `kde-open` or `gio` or others, URL are encoded into ACE or Punycode
-  #if QT_VERSION >= QT_VERSION_CHECK( 6, 3, 0 )
       result->word = QUrl::fromAce( result->word.toLatin1(), QUrl::IgnoreIDNWhitelist );
-  #else
-      // Old Qt's fromAce only applies to whitelisted domains, so we add .com to bypass this restriction :)
-      // https://bugreports.qt.io/browse/QTBUG-29080
-      result->word.append( QStringLiteral( ".com" ) );
-      result->word = QUrl::fromAce( result->word.toLatin1() );
-      result->word.chop( 4 );
-  #endif
     }
     else if ( result->word.startsWith( QStringLiteral( "%" ) ) ) {
       // For Firefox or other browsers where URL are percent encoded
@@ -359,10 +351,6 @@ int main( int argc, char ** argv )
 
 
   //high dpi screen support
-#if ( QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 ) )
-  QApplication::setAttribute( Qt::AA_EnableHighDpiScaling );
-  QApplication::setAttribute( Qt::AA_UseHighDpiPixmaps );
-#endif
   qputenv( "QT_ENABLE_HIGHDPI_SCALING", "1" );
   QApplication::setHighDpiScaleFactorRoundingPolicy( Qt::HighDpiScaleFactorRoundingPolicy::PassThrough );
 

--- a/src/ui/article_inspect.cc
+++ b/src/ui/article_inspect.cc
@@ -1,8 +1,6 @@
 #include "article_inspect.hh"
 #include <QCloseEvent>
-#if ( QT_VERSION > QT_VERSION_CHECK( 6, 0, 0 ) )
-  #include <QWebEngineContextMenuRequest>
-#endif
+#include <QWebEngineContextMenuRequest>
 ArticleInspector::ArticleInspector( QWidget * parent ):
   QWidget( parent, Qt::WindowType::Window )
 {
@@ -39,9 +37,7 @@ void ArticleInspector::triggerAction( QWebEnginePage * page )
     return;
   }
 
-#if ( QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 ) || QT_VERSION > QT_VERSION_CHECK( 6, 3, 0 ) )
   page->triggerAction( QWebEnginePage::InspectElement );
-#endif
 }
 
 void ArticleInspector::closeEvent( QCloseEvent * )

--- a/src/ui/dictheadwords.cc
+++ b/src/ui/dictheadwords.cc
@@ -420,10 +420,6 @@ void DictHeadwords::saveHeadersToFile()
   // Write UTF-8 BOM
   QTextStream out( &file );
   out.setGenerateByteOrderMark( true );
-//qt 6 will use utf-8 default.
-#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
-  out.setCodec( "UTF-8" );
-#endif
 
   exportAllWords( progress, out );
 

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -760,11 +760,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
 
 #if defined( Q_OS_LINUX )
-  #if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
   defaultInterfaceStyle = QApplication::style()->name();
-  #else
-  defaultInterfaceStyle = QApplication::style()->objectName();
-  #endif
 #elif defined( Q_OS_MAC )
   defaultInterfaceStyle = "Fusion";
 #endif

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -8,11 +8,6 @@
 #include <QBitmap>
 #include <QMenu>
 #include <QMouseEvent>
-#if ( QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 ) )
-  #include <QDesktopWidget>
-  #include <QScreen>
-  #include <QStringList>
-#endif
 #include "gddebug.hh"
 #include "gestures.hh"
 
@@ -846,11 +841,7 @@ void ScanPopup::leaveEvent( QEvent * event )
   }
 }
 
-#if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
 void ScanPopup::enterEvent( QEnterEvent * event )
-#else
-void ScanPopup::enterEvent( QEvent * event )
-#endif
 {
   QMainWindow::enterEvent( event );
 

--- a/src/ui/scanpopup.hh
+++ b/src/ui/scanpopup.hh
@@ -174,11 +174,7 @@ private:
   virtual void mouseMoveEvent( QMouseEvent * );
   virtual void mouseReleaseEvent( QMouseEvent * );
   virtual void leaveEvent( QEvent * event );
-#if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )
   virtual void enterEvent( QEnterEvent * event );
-#else
-  virtual void enterEvent( QEvent * event );
-#endif
   virtual void showEvent( QShowEvent * );
   virtual void closeEvent( QCloseEvent * );
   virtual void moveEvent( QMoveEvent * );


### PR DESCRIPTION
I was just wanted to delete Qt5 branch code, but found Qt6≤3 branches aren't really useful either.

The `hotkeywarpper.cc/hh` aren't touched because I am not on windows/Linux as of now.

Plus minor `#include` cleanup.