### PR TITLE
fix: windows global hotkey Win/Meta and 1-9 doesn't work

### DIFF
--- a/src/hotkeywrapper.cc
+++ b/src/hotkeywrapper.cc
@@ -1,8 +1,3 @@
-#ifdef __WIN32 // Q_OS_WIN32 isn't available at this point
-  #define _WIN32_WINNT 0x0430
-  #include <windows.h>
-#endif
-
 #include "hotkeywrapper.hh"
 #include "gddebug.hh"
 
@@ -12,6 +7,7 @@
 
 #ifdef Q_OS_WIN
   #include "mainwindow.hh"
+  #include <windows.h>
 #endif
 
 //////////////////////////////////////////////////////////////////////////
@@ -332,12 +328,11 @@ bool HotkeyWrapper::winEvent( MSG * message, qintptr * result )
   return false;
 }
 
+/// Ref: https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
 quint32 HotkeyWrapper::nativeKey( int key )
 {
-  if ( key >= Qt::Key_0 && key <= Qt::Key_9 )
-    return VK_NUMPAD0 + ( key - Qt::Key_0 );
-
-  if ( key >= Qt::Key_A && key <= Qt::Key_Z )
+  // Qt's 0-1 & A-Z overlaps with Windows's VK
+  if ( key >= Qt::Key_0 && key <= Qt::Key_9 || key >= Qt::Key_A && key <= Qt::Key_Z )
     return key;
 
   switch ( key ) {

--- a/src/hotkeywrapper.cc
+++ b/src/hotkeywrapper.cc
@@ -331,7 +331,7 @@ bool HotkeyWrapper::winEvent( MSG * message, qintptr * result )
 /// Ref: https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
 quint32 HotkeyWrapper::nativeKey( int key )
 {
-  // Qt's 0-1 & A-Z overlaps with Windows's VK
+  // Qt's 0-9 & A-Z overlaps with Windows's VK
   if ( key >= Qt::Key_0 && key <= Qt::Key_9 || key >= Qt::Key_A && key <= Qt::Key_Z )
     return key;
 

--- a/src/hotkeywrapper.cc
+++ b/src/hotkeywrapper.cc
@@ -332,8 +332,9 @@ bool HotkeyWrapper::winEvent( MSG * message, qintptr * result )
 quint32 HotkeyWrapper::nativeKey( int key )
 {
   // Qt's 0-9 & A-Z overlaps with Windows's VK
-  if ( key >= Qt::Key_0 && key <= Qt::Key_9 || key >= Qt::Key_A && key <= Qt::Key_Z )
+  if ( key >= Qt::Key_0 && key <= Qt::Key_9 || key >= Qt::Key_A && key <= Qt::Key_Z ) {
     return key;
+  }
 
   switch ( key ) {
     case Qt::Key_Space:

--- a/src/hotkeywrapper.cc
+++ b/src/hotkeywrapper.cc
@@ -480,6 +480,8 @@ quint32 HotkeyWrapper::nativeKey( int key )
       return 0x39;
     case Qt::Key_Underscore:
       return VK_OEM_MINUS;
+    case Qt::Key_Meta:
+      return VK_LWIN;
     default:;
   }
 


### PR DESCRIPTION
fix https://github.com/xiaoyifang/goldendict-ng/issues/1938

Fix these Win/Meta related issues from the original GD.

fix https://github.com/goldendict/goldendict/issues/1185
fix https://github.com/goldendict/goldendict/issues/1211

Not sure how things used to work, but as today:

* Qt uses `Qt::KeypadModifier` to know if pressed numbers belongs to Numpad.
* The original code from 2009 for some reason maps them to `VK_NUMPAD`

For Win/Meta, only the left one --> LWIN is supported.


