### PR TITLE
clean: fix some issues found by the code analysis of Visual Studio

### DIFF
--- a/src/config.hh
+++ b/src/config.hh
@@ -492,7 +492,7 @@ struct WebSite
   QString id, name, url;
   bool enabled;
   QString iconFilename;
-  bool inside_iframe;
+  bool inside_iframe = false;
 
   WebSite():
     enabled( false )
@@ -698,7 +698,7 @@ struct Transliteration
 
 struct Lingua
 {
-  bool enable;
+  bool enable = false;
   QString languageCodes;
 
   bool operator==( Lingua const & other ) const
@@ -737,13 +737,15 @@ struct Forvo
 struct Program
 {
   bool enabled;
+  // NOTE: the value of this enum is used for config
   enum Type {
-    Audio,
-    PlainText,
-    Html,
-    PrefixMatch,
-    MaxTypeValue
-  } type;
+    Unknown      = -1,
+    Audio        = 0,
+    PlainText    = 1,
+    Html         = 2,
+    PrefixMatch  = 3,
+    MaxTypeValue = 4
+  } type = Unknown;
   QString id, name, commandLine;
   QString iconFilename;
 
@@ -892,7 +894,7 @@ struct Class
   QString articleSavePath;   // Path to save articles
 
   bool pinPopupWindow;         // Last pin status
-  bool popupWindowAlwaysOnTop; // Last status of pinned popup window
+  bool popupWindowAlwaysOnTop = false; // Last status of pinned popup window
 
   QByteArray mainWindowState;    // Binary state saved by QMainWindow
   QByteArray mainWindowGeometry; // Geometry saved by QMainWindow
@@ -929,7 +931,7 @@ struct Class
   Group const * getGroup( unsigned id ) const;
   //disable tts dictionary. does not need to save to persistent file
   bool notts = false;
-  bool resetState;
+  bool resetState = false;
 };
 
 /// Configuration-specific events. Some parts of the program need to react

--- a/src/config.hh
+++ b/src/config.hh
@@ -739,13 +739,14 @@ struct Program
   bool enabled;
   // NOTE: the value of this enum is used for config
   enum Type {
-    Unknown      = -1,
+    Invalid      = -1, // Init value
     Audio        = 0,
     PlainText    = 1,
     Html         = 2,
     PrefixMatch  = 3,
     MaxTypeValue = 4
-  } type = Unknown;
+  };
+  Type type = Invalid;
   QString id, name, commandLine;
   QString iconFilename;
 

--- a/src/dict/btreeidx.hh
+++ b/src/dict/btreeidx.hh
@@ -45,9 +45,9 @@ DEF_EX( exCorruptedChainData, "Corrupted chain data in the leaf of a btree encou
 struct WordArticleLink
 {
   string word, prefix; // in utf8
-  uint32_t articleOffset;
+  uint32_t articleOffset = 0;
 
-  WordArticleLink() {}
+  WordArticleLink() = default;
 
   WordArticleLink( string const & word_, uint32_t articleOffset_, string const & prefix_ = string() ):
     word( word_ ),

--- a/src/dict/xdxf2html.cc
+++ b/src/dict/xdxf2html.cc
@@ -102,8 +102,7 @@ string convert( string const & in,
           }
           break;
         }
-        // Fall-through
-
+      [[fallthrough]]
       default:
         inConverted.push_back( i );
         afterEol = false;

--- a/src/dict/xdxf2html.cc
+++ b/src/dict/xdxf2html.cc
@@ -102,7 +102,7 @@ string convert( string const & in,
           }
           break;
         }
-      [[fallthrough]]
+      [[fallthrough]];
       default:
         inConverted.push_back( i );
         afterEol = false;

--- a/src/hotkeywrapper.hh
+++ b/src/hotkeywrapper.hh
@@ -47,10 +47,11 @@ struct HotkeyStruct
   HotkeyStruct() = default;
   HotkeyStruct( quint32 key, quint32 key2, quint32 modifier, int handle, int id );
 
-  quint32 key, key2;
-  quint32 modifier;
-  int handle;
-  int id;
+  quint32 key      = 0;
+  quint32 key2     = 0;
+  quint32 modifier = 0;
+  int handle       = 0;
+  int id           = 0;
 #ifdef Q_OS_MAC
   EventHotKeyRef hkRef  = 0;
   EventHotKeyRef hkRef2 = 0;

--- a/src/main.cc
+++ b/src/main.cc
@@ -341,8 +341,11 @@ int main( int argc, char ** argv )
   // attach the new console to this application's process
   if ( AttachConsole( ATTACH_PARENT_PROCESS ) ) {
     // reopen the std I/O streams to redirect I/O to the new console
-    freopen( "CON", "w", stdout );
-    freopen( "CON", "w", stderr );
+    auto ret1 = freopen( "CON", "w", stdout );
+    auto ret2 = freopen( "CON", "w", stderr );
+    if ( ret1 == nullptr || ret2 == nullptr ) {
+      qDebug() << "Attaching console stdout or stderr failed";
+    }
   }
 
   qputenv( "QT_QPA_PLATFORM", "windows:darkmode=1" );

--- a/src/ui/favoritespanewidget.hh
+++ b/src/ui/favoritespanewidget.hh
@@ -84,13 +84,13 @@ private slots:
 private:
   virtual bool eventFilter( QObject *, QEvent * );
 
-  Config::Class * m_cfg;
-  QTreeView * m_favoritesTree;
-  QMenu * m_favoritesMenu;
-  QAction * m_deleteSelectedAction;
-  QAction * m_separator;
-  QAction * m_copySelectedToClipboard;
-  QAction * m_addFolder;
+  Config::Class * m_cfg               = nullptr;
+  QTreeView * m_favoritesTree         = nullptr;
+  QMenu * m_favoritesMenu             = nullptr;
+  QAction * m_deleteSelectedAction    = nullptr;
+  QAction * m_separator               = nullptr;
+  QAction * m_copySelectedToClipboard = nullptr;
+  QAction * m_addFolder               = nullptr;
 
   QWidget favoritesPaneTitleBar;
   QHBoxLayout favoritesPaneTitleBarLayout;

--- a/src/ui/historypanewidget.hh
+++ b/src/ui/historypanewidget.hh
@@ -53,13 +53,13 @@ private slots:
 private:
   virtual bool eventFilter( QObject *, QEvent * );
 
-  Config::Class * m_cfg;
-  History * m_history;
-  QListView * m_historyList;
-  QMenu * m_historyMenu;
-  QAction * m_deleteSelectedAction;
-  QAction * m_separator;
-  QAction * m_copySelectedToClipboard;
+  Config::Class * m_cfg               = nullptr;
+  History * m_history                 = nullptr;
+  QListView * m_historyList           = nullptr;
+  QMenu * m_historyMenu               = nullptr;
+  QAction * m_deleteSelectedAction    = nullptr;
+  QAction * m_separator               = nullptr;
+  QAction * m_copySelectedToClipboard = nullptr;
 
   QWidget historyPaneTitleBar;
   QHBoxLayout historyPaneTitleBarLayout;


### PR DESCRIPTION
It appears that the Visual Studio's Analyze → Run code analyze button is just rebuilding the project, then collect warnings.

Edit: Actually, I don't know what's the rule it follows. It seems CMake (?) project cannot configure it as written in VS's doc. The panel is blank for me.
https://learn.microsoft.com/en-us/cpp/code-quality/quick-start-code-analysis-for-c-cpp?view=msvc-170

This fixes all the default warnings.

Mostly uninitialized variables. Initialize everything religiously.