### PR TITLE
update brew before running macOS workflows

### DIFF
--- a/.github/workflows/PR-check-cmake.yml
+++ b/.github/workflows/PR-check-cmake.yml
@@ -51,6 +51,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: false
+      - name: Update brew
+        run: |
+          brew update
       - name: Install dependencies
         run: |
           brew install \
@@ -66,11 +69,11 @@ jobs:
           xapian \
           libzim \
           qt
-
+      - name: Install eb
+        run: |
           wget ftp://ftp.sra.co.jp/pub/misc/eb/eb-4.4.3.tar.bz2
           tar xvjf eb-4.4.3.tar.bz2
           cd eb-4.4.3 && ./configure && make -j 8 && sudo make install && cd ..
-
       - name: Run build
         run: |
           mkdir build_dir

--- a/.github/workflows/Release-all.yml
+++ b/.github/workflows/Release-all.yml
@@ -26,6 +26,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Update brew
+        run: |
+          brew update
       - name: Install dependencies
         run: |
           brew install \
@@ -40,7 +43,8 @@ jobs:
             ninja \
             opencc \
             xapian
-          
+      - name: Install eb
+        run: |
           git clone https://github.com/xiaoyifang/eb.git
           cd eb && ./configure && make -j 8 && sudo make install && cd ..         
       - uses: jurplel/install-qt-action@v4


### PR DESCRIPTION
This is exactly the same as: https://github.com/xiaoyifang/goldendict-ng/blob/808d8576027641da897c43dd607f89f26619beab/.github/workflows/PR-check-cmake.yml#L20

Whatever in the GitHub's runner image is outdated compared to whatever in the remote registry.