### PR TITLE
fix: manually deploy icu4c dylibs for macOS

### DIFF
--- a/.github/workflows/Release-all.yml
+++ b/.github/workflows/Release-all.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Package
         run: |
           cmake --install build_dir/
+      - name: Print package content
+        run: |
+          ls -Rl ./build_dir/redist
       - uses: actions/upload-artifact@v4
         with:
           name: macOS-${{ matrix.os }}-Qt${{ matrix.qt_ver }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,6 +284,7 @@ if (APPLE)
             set(QT_DEPLOY_TRANSLATIONS_DIR \"Contents/Resources/translations\")
             qt_deploy_runtime_dependencies(
                         EXECUTABLE \"${Redistributable_APP}\"
+                        ADDITIONAL_LIBRARIES \"${BREW_ICU_NEEDED_LIBS}\"
                         GENERATE_QT_CONF
                         NO_APP_STORE_COMPLIANCE)
             qt_deploy_translations()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,7 +284,7 @@ if (APPLE)
             set(QT_DEPLOY_TRANSLATIONS_DIR \"Contents/Resources/translations\")
             qt_deploy_runtime_dependencies(
                         EXECUTABLE \"${Redistributable_APP}\"
-                        ADDITIONAL_LIBRARIES \"${BREW_ICU_NEEDED_LIBS}\"
+                        ADDITIONAL_LIBRARIES ${BREW_ICU_NEEDED_LIBS}
                         GENERATE_QT_CONF
                         NO_APP_STORE_COMPLIANCE)
             qt_deploy_translations()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,7 +284,7 @@ if (APPLE)
             set(QT_DEPLOY_TRANSLATIONS_DIR \"Contents/Resources/translations\")
             qt_deploy_runtime_dependencies(
                         EXECUTABLE \"${Redistributable_APP}\"
-                        ADDITIONAL_LIBRARIES ${BREW_ICU_NEEDED_LIBS}
+                        ADDITIONAL_LIBRARIES ${BREW_ICU_ADDITIONAL_DYLIBS}
                         GENERATE_QT_CONF
                         NO_APP_STORE_COMPLIANCE)
             qt_deploy_translations()

--- a/cmake/Deps_Unix.cmake
+++ b/cmake/Deps_Unix.cmake
@@ -98,10 +98,6 @@ if (WITH_ZIM)
 
     pkg_check_modules(ZIM REQUIRED IMPORTED_TARGET libzim)
     target_link_libraries(${GOLDENDICT} PRIVATE PkgConfig::ZIM)
-
-    if (APPLE)
-
-    endif ()
 endif ()
 
 if (USE_SYSTEM_FMT)

--- a/cmake/Deps_Unix.cmake
+++ b/cmake/Deps_Unix.cmake
@@ -95,6 +95,7 @@ if (WITH_ZIM)
             message(FATAL_ERROR "!!! ZIM <-> icu error -> check `brew info libzim` to know what libzim is depending.")
         endif ()
         set(BREW_ICU_NEEDED_LIBS "${BREW_ICU_LIBRARY_DIRS}/libicudata.dylib ${BREW_ICU_LIBRARY_DIRS}/libicui18n.dylib ${BREW_ICU_LIBRARY_DIRS}/libicuuc.dylib")
+        message(STATUS "Additional Libs -> ${BREW_ICU_NEEDED_LIBS}")
     endif ()
 endif ()
 

--- a/cmake/Deps_Unix.cmake
+++ b/cmake/Deps_Unix.cmake
@@ -88,18 +88,19 @@ if (WITH_ZIM)
                 COMMAND_ERROR_IS_FATAL ANY)
         message(STATUS "Found correct homebrew icu path -> ${ICU_REQUIRED_BY_ZIM_PREFIX}")
         set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:${ICU_REQUIRED_BY_ZIM_PREFIX}/lib/pkgconfig")
-        message(STATUS "$ENV{PKG_CONFIG_PATH}:${ICU_REQUIRED_BY_ZIM_PREFIX}/lib/pkgconfig")
+        message(STATUS "Updated pkg_config_path -> $ENV{PKG_CONFIG_PATH}:${ICU_REQUIRED_BY_ZIM_PREFIX}/lib/pkgconfig")
+
+        # icu4c as transitive dependency of libzim may not be automatically copied into app bundle
+        # so we manually discover the icu4c from homebrew, then find the relevent dylibs
+        set(BREW_ICU_ADDITIONAL_DYLIBS "${ICU_REQUIRED_BY_ZIM_PREFIX}/lib/libicudata.dylib ${BREW_ICU_LIBRARY_DIRS}/lib/libicui18n.dylib ${BREW_ICU_LIBRARY_DIRS}/lib/libicuuc.dylib")
+        message(STATUS "Additional ICU `.dylib`s -> ${BREW_ICU_NEEDED_LIBS}")
     endif ()
 
     pkg_check_modules(ZIM REQUIRED IMPORTED_TARGET libzim)
     target_link_libraries(${GOLDENDICT} PRIVATE PkgConfig::ZIM)
 
     if (APPLE)
-        # icu4c as transitive dependency of libzim may not be automatically copied into app bundle
-        # so we manually discover the icu4c from homebrew, then find the relevent dylibs
-        pkg_check_modules(BREW_ICU REQUIRED IMPORTED_TARGET icu-i18n icu-uc)
-        set(BREW_ICU_NEEDED_LIBS "${BREW_ICU_LIBRARY_DIRS}/libicudata.dylib ${BREW_ICU_LIBRARY_DIRS}/libicui18n.dylib ${BREW_ICU_LIBRARY_DIRS}/libicuuc.dylib")
-        message(STATUS "Additional Libs -> ${BREW_ICU_NEEDED_LIBS}")
+
     endif ()
 endif ()
 

--- a/cmake/Deps_Unix.cmake
+++ b/cmake/Deps_Unix.cmake
@@ -84,9 +84,11 @@ if (WITH_ZIM)
         execute_process(
                 COMMAND sh -c [=[brew --prefix $(brew deps libzim | grep icu4c)]=]
                 OUTPUT_VARIABLE ICU_REQUIRED_BY_ZIM_PREFIX
+                OUTPUT_STRIP_TRAILING_WHITESPACE
                 COMMAND_ERROR_IS_FATAL ANY)
         message(STATUS "Found correct homebrew icu path -> ${ICU_REQUIRED_BY_ZIM_PREFIX}")
         set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:${ICU_REQUIRED_BY_ZIM_PREFIX}/lib/pkgconfig")
+        message(STATUS "$ENV{PKG_CONFIG_PATH}:${ICU_REQUIRED_BY_ZIM_PREFIX}/lib/pkgconfig")
     endif ()
 
     pkg_check_modules(ZIM REQUIRED IMPORTED_TARGET libzim)

--- a/cmake/Deps_Unix.cmake
+++ b/cmake/Deps_Unix.cmake
@@ -92,8 +92,8 @@ if (WITH_ZIM)
 
         # icu4c as transitive dependency of libzim may not be automatically copied into app bundle
         # so we manually discover the icu4c from homebrew, then find the relevent dylibs
-        set(BREW_ICU_ADDITIONAL_DYLIBS "${ICU_REQUIRED_BY_ZIM_PREFIX}/lib/libicudata.dylib ${BREW_ICU_LIBRARY_DIRS}/lib/libicui18n.dylib ${BREW_ICU_LIBRARY_DIRS}/lib/libicuuc.dylib")
-        message(STATUS "Additional ICU `.dylib`s -> ${BREW_ICU_NEEDED_LIBS}")
+        set(BREW_ICU_ADDITIONAL_DYLIBS "${ICU_REQUIRED_BY_ZIM_PREFIX}/lib/libicudata.dylib ${ICU_REQUIRED_BY_ZIM_PREFIX}/lib/libicui18n.dylib ${ICU_REQUIRED_BY_ZIM_PREFIX}/lib/libicuuc.dylib")
+        message(STATUS "Additional ICU `.dylib`s -> ${BREW_ICU_ADDITIONAL_DYLIBS}")
     endif ()
 
     pkg_check_modules(ZIM REQUIRED IMPORTED_TARGET libzim)

--- a/cmake/Deps_Unix.cmake
+++ b/cmake/Deps_Unix.cmake
@@ -86,22 +86,15 @@ if (WITH_ZIM)
     target_link_libraries(${GOLDENDICT} PRIVATE PkgConfig::ZIM)
 
     if (APPLE)
-        # icu4c as transitive dependency of libzim may not be copied into app bundle, so we directly depends on it to assist macdeployqt
-        # Why such complexities: 1) System or XCode SDKS's icu exists 2) icu itself is depended by various stuffs and homebrew may need multiple versions of it
+        # icu4c as transitive dependency of libzim may not be automatically copied into app bundle
+        # so we manually discover the icu4c from homebrew, then find the relevent dylibs
         pkg_check_modules(BREW_ICU REQUIRED IMPORTED_TARGET icu-i18n icu-uc)
-        target_link_libraries(${GOLDENDICT} PUBLIC PkgConfig::BREW_ICU)
-
-        # Verify icu <-> zim matches
-        message("Zim include dirs -> ${ZIM_INCLUDE_DIRS}")
-        message("Homebrew icu include dirs-> ${BREW_ICU_INCLUDE_DIRS}")
-
-        list(GET BREW_ICU_INCLUDE_DIRS 0 ONE_OF_BREW_ICU_INCLUDE_DIR)
-        if (ONE_OF_BREW_ICU_INCLUDE_DIR IN_LIST ZIM_INCLUDE_DIRS)
-            message("ZIM OK!")
+        if (BREW_ICU_INCLUDE_DIRS IN_LIST ZIM_INCLUDE_DIRS)
+            message(STATUS "ZIM OK!")
         else ()
-            message(FATAL_ERROR "!!!! ZIM <-> icu error -> check `brew info libzim` and `brew list libzim`")
+            message(FATAL_ERROR "!!! ZIM <-> icu error -> check `brew info libzim` to know what libzim is depending.")
         endif ()
-        # TODO: get rid of these 💩, how?
+        set(BREW_ICU_NEEDED_LIBS "${BREW_ICU_LIBRARY_DIRS}/libicudata.dylib ${BREW_ICU_LIBRARY_DIRS}/libicui18n.dylib ${BREW_ICU_LIBRARY_DIRS}/libicuuc.dylib")
     endif ()
 endif ()
 


### PR DESCRIPTION
Stop using the trick of linking goldendict to icu4c-i18n/uc to bring the related dylibs to the app bundle.

(For whatever reason, icudata is not copied.)

Instead, change the strategy into:

Find out the icu4c's dylibs then explicitly pass them to qt_deploy_runtime_dependencies (which pass the arguments to underlying `macdeplogyqt -executable="path_to_some_dylib"`)

Actually fix https://github.com/xiaoyifang/goldendict-ng/issues/1954