### PR TITLE
fix: local audio files without extension are not added to dictAudioMap

### DIFF
--- a/src/common/utils.hh
+++ b/src/common/utils.hh
@@ -257,9 +257,14 @@ inline bool isAudioUrl( QUrl const & url )
 {
   if ( !url.isValid() )
     return false;
-  // Note: we check for forvo sound links explicitly, as they don't have extensions
 
-  return ( url.scheme() == "http" || url.scheme() == "https" || url.scheme() == "gdau" )
+  // gdau links are known to be audios, (sometimes they may not have file extension).
+  if ( url.scheme() == "gdau" ) {
+    return true;
+  }
+
+  // Note: we check for forvo sound links explicitly, as they don't have extensions
+  return ( url.scheme() == "http" || url.scheme() == "https" )
     && ( Filetype::isNameOfSound( url.path().toUtf8().data() ) || url.host() == "apifree.forvo.com" );
 }
 

--- a/src/pronounceengine.cc
+++ b/src/pronounceengine.cc
@@ -17,7 +17,7 @@ void PronounceEngine::reset()
 }
 
 
-void PronounceEngine::sendAudio( std::string dictId, QString audioLink )
+void PronounceEngine::sendAudio( const std::string & dictId, const QString& audioLink )
 {
   if ( state == PronounceState::OCCUPIED ) {
     return;
@@ -29,7 +29,7 @@ void PronounceEngine::sendAudio( std::string dictId, QString audioLink )
 
   QMutexLocker _( &mutex );
 
-  dictAudioMap.operator[]( dictId ).push_back( audioLink );
+  dictAudioMap[ dictId ].append( audioLink );
 }
 
 void PronounceEngine::finishDictionary( std::string dictId )

--- a/src/pronounceengine.cc
+++ b/src/pronounceengine.cc
@@ -17,7 +17,7 @@ void PronounceEngine::reset()
 }
 
 
-void PronounceEngine::sendAudio( const std::string & dictId, const QString& audioLink )
+void PronounceEngine::sendAudio( const std::string & dictId, const QString & audioLink )
 {
   if ( state == PronounceState::OCCUPIED ) {
     return;

--- a/src/pronounceengine.hh
+++ b/src/pronounceengine.hh
@@ -21,7 +21,7 @@ class PronounceEngine: public QObject
 public:
   explicit PronounceEngine( QObject * parent = nullptr );
   void reset();
-  void sendAudio( const std::string & dictId, const QString& audioLink );
+  void sendAudio( const std::string & dictId, const QString & audioLink );
   void finishDictionary( std::string dictId );
 signals:
   void emitAudio( QString audioLink );

--- a/src/pronounceengine.hh
+++ b/src/pronounceengine.hh
@@ -21,7 +21,7 @@ class PronounceEngine: public QObject
 public:
   explicit PronounceEngine( QObject * parent = nullptr );
   void reset();
-  void sendAudio( std::string dictId, QString audioLink );
+  void sendAudio( const std::string & dictId, const QString& audioLink );
   void finishDictionary( std::string dictId );
 signals:
   void emitAudio( QString audioLink );


### PR DESCRIPTION
close https://github.com/xiaoyifang/goldendict-ng/issues/1962

`gdau://` are written by GD itself, and the files are known to be audio files.

There were probably some bug reports related to this. 