### PR TITLE
Windows: use Fusion only when dark mode applied

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -368,7 +368,7 @@ int main( int argc, char ** argv )
 
 #ifdef Q_OS_WIN
   // TODO: Force fusion because Qt6.7's "ModernStyle"'s dark theme have problems, need to test / reconsider in future
-  QHotkeyApplication::setStyle( QStyleFactory::create( "Fusion" ) );
+  QHotkeyApplication::setStyle( QStyleFactory::create( "WindowsVista" ) );
 #endif
 
 

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1356,8 +1356,14 @@ void MainWindow::updateAppearances( QString const & addonStyle,
     darkPalette.setColor( QPalette::Disabled, QPalette::HighlightedText, disabledColor );
 
     qApp->setPalette( darkPalette );
+    #if defined( Q_OS_WIN )
+      qApp->setStyle("Fusion");
+    #endif
   }
   else {
+    #if defined( Q_OS_WIN )
+      qApp->setStyle("WindowsVista");
+    #endif
     qApp->setPalette( QPalette() );
   }
 #endif


### PR DESCRIPTION
It's better than just keep Fusion style used. 

https://github.com/user-attachments/assets/fa0d153d-9840-4a31-8788-417fba133871

