### PR TITLE
clean: delete useless fopen style mode char* API from File::Index

### DIFF
--- a/src/dict/aard.cc
+++ b/src/dict/aard.cc
@@ -103,7 +103,7 @@ static_assert( alignof( IdxHeader ) == 1 );
 
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Index idx( indexFile, "rb" );
+  File::Index idx( indexFile, QIODevice::ReadOnly );
 
   IdxHeader header;
 
@@ -287,10 +287,10 @@ private:
 
 AardDictionary::AardDictionary( string const & id, string const & indexFile, vector< string > const & dictionaryFiles ):
   BtreeDictionary( id, dictionaryFiles ),
-  idx( indexFile, "rb" ),
+  idx( indexFile, QIODevice::ReadOnly ),
   idxHeader( idx.read< IdxHeader >() ),
   chunks( idx, idxHeader.chunksOffset ),
-  df( dictionaryFiles[ 0 ], "rb" )
+  df( dictionaryFiles[ 0 ], QIODevice::ReadOnly )
 {
   // Read dictionary name
 
@@ -802,7 +802,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
           }
         }
 
-        File::Index df( fileName, "rb" );
+        File::Index df( fileName, QIODevice::ReadOnly );
 
         AAR_header dictHeader;
 
@@ -871,7 +871,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         initializing.indexingDictionary( dictName );
 
-        File::Index idx( indexFile, "wb" );
+        File::Index idx( indexFile, QIODevice::WriteOnly );
         IdxHeader idxHeader;
         memset( &idxHeader, 0, sizeof( idxHeader ) );
 

--- a/src/dict/bgl.cc
+++ b/src/dict/bgl.cc
@@ -85,7 +85,7 @@ static_assert( alignof( IdxHeader ) == 1 );
 
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Index idx( indexFile, "rb" );
+  File::Index idx( indexFile, QIODevice::ReadOnly );
 
   IdxHeader header;
 
@@ -250,7 +250,7 @@ private:
 
 BglDictionary::BglDictionary( string const & id, string const & indexFile, string const & dictionaryFile ):
   BtreeDictionary( id, vector< string >( 1, dictionaryFile ) ),
-  idx( indexFile, "rb" ),
+  idx( indexFile, QIODevice::ReadOnly ),
   idxHeader( idx.read< IdxHeader >() ),
   chunks( idx, idxHeader.chunksOffset )
 {
@@ -1083,7 +1083,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         initializing.indexingDictionary( b.title() );
 
-        File::Index idx( indexFile, "wb" );
+        File::Index idx( indexFile, QIODevice::WriteOnly );
 
         IdxHeader idxHeader;
 

--- a/src/dict/dictdfiles.cc
+++ b/src/dict/dictdfiles.cc
@@ -74,7 +74,7 @@ static_assert( alignof( IdxHeader ) == 1 );
 
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Index idx( indexFile, "rb" );
+  File::Index idx( indexFile, QIODevice::ReadOnly );
 
   IdxHeader header;
 
@@ -155,8 +155,8 @@ DictdDictionary::DictdDictionary( string const & id,
                                   string const & indexFile,
                                   vector< string > const & dictionaryFiles ):
   BtreeDictionary( id, dictionaryFiles ),
-  idx( indexFile, "rb" ),
-  indexFile( dictionaryFiles[ 0 ], "rb" ),
+  idx( indexFile, QIODevice::ReadOnly ),
+  indexFile( dictionaryFiles[ 0 ], QIODevice::ReadOnly ),
   idxHeader( idx.read< IdxHeader >() )
 {
 
@@ -606,7 +606,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         initializing.indexingDictionary( dictionaryName );
 
-        File::Index idx( indexFile, "wb" );
+        File::Index idx( indexFile, QIODevice::WriteOnly );
 
         IdxHeader idxHeader;
 
@@ -619,7 +619,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         IndexedWords indexedWords;
 
-        File::Index indexFile( dictFiles[ 0 ], "rb" );
+        File::Index indexFile( dictFiles[ 0 ], QIODevice::ReadOnly );
 
         // Read words from index until none's left.
 

--- a/src/dict/dsl.cc
+++ b/src/dict/dsl.cc
@@ -132,7 +132,7 @@ struct InsidedCard
 
 bool indexIsOldOrBad( string const & indexFile, bool hasZipFile )
 {
-  File::Index idx( indexFile, "rb" );
+  File::Index idx( indexFile, QIODevice::ReadOnly );
 
   IdxHeader header;
 
@@ -289,7 +289,7 @@ private:
 
 DslDictionary::DslDictionary( string const & id, string const & indexFile, vector< string > const & dictionaryFiles ):
   BtreeDictionary( id, dictionaryFiles ),
-  idx( indexFile, "rb" ),
+  idx( indexFile, QIODevice::ReadOnly ),
   idxHeader( idx.read< IdxHeader >() ),
   dz( 0 ),
   deferredInitRunnableStarted( false ),
@@ -1807,7 +1807,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
           gdDebug( "Dsl: Building the index for dictionary: %s\n",
                    QString::fromStdU32String( scanner.getDictionaryName() ).toUtf8().data() );
 
-          File::Index idx( indexFile, "wb" );
+          File::Index idx( indexFile, QIODevice::WriteOnly );
 
           IdxHeader idxHeader;
 

--- a/src/dict/epwing.cc
+++ b/src/dict/epwing.cc
@@ -66,7 +66,7 @@ static_assert( alignof( IdxHeader ) == 1 );
 
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Index idx( indexFile, "rb" );
+  File::Index idx( indexFile, QIODevice::ReadOnly );
 
   IdxHeader header;
 
@@ -219,7 +219,7 @@ EpwingDictionary::EpwingDictionary( string const & id,
                                     vector< string > const & dictionaryFiles,
                                     int subBook ):
   BtreeDictionary( id, dictionaryFiles ),
-  idx( indexFile, "rb" ),
+  idx( indexFile, QIODevice::ReadOnly ),
   idxHeader( idx.read< IdxHeader >() ),
   chunks( idx, idxHeader.chunksOffset )
 {
@@ -1197,7 +1197,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
           QByteArray nameData = str.toUtf8();
           initializing.indexingDictionary( nameData.data() );
 
-          File::Index idx( indexFile, "wb" );
+          File::Index idx( indexFile, QIODevice::WriteOnly );
 
           IdxHeader idxHeader{};
 

--- a/src/dict/gls.cc
+++ b/src/dict/gls.cc
@@ -335,7 +335,7 @@ static_assert( alignof( IdxHeader ) == 1 );
 
 bool indexIsOldOrBad( string const & indexFile, bool hasZipFile )
 {
-  File::Index idx( indexFile, "rb" );
+  File::Index idx( indexFile, QIODevice::ReadOnly );
 
   IdxHeader header;
 
@@ -443,7 +443,7 @@ private:
 
 GlsDictionary::GlsDictionary( string const & id, string const & indexFile, vector< string > const & dictionaryFiles ):
   BtreeDictionary( id, dictionaryFiles ),
-  idx( indexFile, "rb" ),
+  idx( indexFile, QIODevice::ReadOnly ),
   idxHeader( idx.read< IdxHeader >() ),
   dz( 0 ),
   chunks( idx, idxHeader.chunksOffset )
@@ -1270,7 +1270,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
           gdDebug( "Gls: Building the index for dictionary: %s\n",
                    QString::fromStdU32String( scanner.getDictionaryName() ).toUtf8().data() );
 
-          File::Index idx( indexFile, "wb" );
+          File::Index idx( indexFile, QIODevice::WriteOnly );
 
           IdxHeader idxHeader;
 

--- a/src/dict/lsa.cc
+++ b/src/dict/lsa.cc
@@ -65,7 +65,7 @@ static_assert( alignof( IdxHeader ) == 1 );
 
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Index idx( indexFile, "rb" );
+  File::Index idx( indexFile, QIODevice::ReadOnly );
 
   IdxHeader header;
 
@@ -201,7 +201,7 @@ string LsaDictionary::getName() noexcept
 
 LsaDictionary::LsaDictionary( string const & id, string const & indexFile, vector< string > const & dictionaryFiles ):
   BtreeDictionary( id, dictionaryFiles ),
-  idx( indexFile, "rb" ),
+  idx( indexFile, QIODevice::ReadOnly ),
   idxHeader( idx.read< IdxHeader >() )
 {
   // Initialize the index
@@ -405,7 +405,7 @@ sptr< Dictionary::DataRequest > LsaDictionary::getResource( string const & name 
     return std::make_shared< Dictionary::DataRequestInstant >( false ); // No such resource
   }
 
-  File::Index f( getDictionaryFilenames()[ 0 ], "rb" );
+  File::Index f( getDictionaryFilenames()[ 0 ], QIODevice::ReadOnly );
 
   f.seek( chain[ 0 ].articleOffset );
   Entry e( f );
@@ -522,7 +522,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
     }
 
     try {
-      File::Index f( *i, "rb" );
+      File::Index f( *i, QIODevice::ReadOnly );
 
       /// Check the signature
 
@@ -547,7 +547,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         initializing.indexingDictionary( Utils::Fs::basename( *i ) );
 
-        File::Index idx( indexFile, "wb" );
+        File::Index idx( indexFile, QIODevice::WriteOnly );
 
         IdxHeader idxHeader;
 

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -302,7 +302,7 @@ private:
 
 MdxDictionary::MdxDictionary( string const & id, string const & indexFile, vector< string > const & dictionaryFiles ):
   BtreeDictionary( id, dictionaryFiles ),
-  idx( indexFile, "rb" ),
+  idx( indexFile, QIODevice::ReadOnly ),
   idxFileName( indexFile ),
   idxHeader( idx.read< IdxHeader >() ),
   chunks( idx, idxHeader.chunksOffset ),
@@ -1307,7 +1307,7 @@ private:
 
 static bool indexIsOldOrBad( vector< string > const & dictFiles, string const & indexFile )
 {
-  File::Index idx( indexFile, "rb" );
+  File::Index idx( indexFile, QIODevice::ReadOnly );
   IdxHeader header;
 
   return idx.readRecords( &header, sizeof( header ), 1 ) != 1 || header.signature != kSignature
@@ -1385,7 +1385,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
         }
       }
 
-      File::Index idx( indexFile, "wb" );
+      File::Index idx( indexFile, QIODevice::WriteOnly );
       IdxHeader idxHeader;
       memset( &idxHeader, 0, sizeof( idxHeader ) );
       // We write a dummy header first. At the end of the process the header

--- a/src/dict/sdict.cc
+++ b/src/dict/sdict.cc
@@ -97,7 +97,7 @@ static_assert( alignof( IdxHeader ) == 1 );
 
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Index idx( indexFile, "rb" );
+  File::Index idx( indexFile, QIODevice::ReadOnly );
 
   IdxHeader header;
 
@@ -188,10 +188,10 @@ SdictDictionary::SdictDictionary( string const & id,
                                   string const & indexFile,
                                   vector< string > const & dictionaryFiles ):
   BtreeDictionary( id, dictionaryFiles ),
-  idx( indexFile, "rb" ),
+  idx( indexFile, QIODevice::ReadOnly ),
   idxHeader( idx.read< IdxHeader >() ),
   chunks( idx, idxHeader.chunksOffset ),
-  df( dictionaryFiles[ 0 ], "rb" )
+  df( dictionaryFiles[ 0 ], QIODevice::ReadOnly )
 {
   // Read dictionary name
 
@@ -689,7 +689,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
       try {
         gdDebug( "SDict: Building the index for dictionary: %s\n", fileName.c_str() );
 
-        File::Index df( fileName, "rb" );
+        File::Index df( fileName, QIODevice::ReadOnly );
 
         DCT_header dictHeader;
 
@@ -722,7 +722,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         initializing.indexingDictionary( dictName );
 
-        File::Index idx( indexFile, "wb" );
+        File::Index idx( indexFile, QIODevice::WriteOnly );
         IdxHeader idxHeader;
         memset( &idxHeader, 0, sizeof( idxHeader ) );
 

--- a/src/dict/slob.cc
+++ b/src/dict/slob.cc
@@ -97,7 +97,7 @@ struct RefEntry
 
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Index idx( indexFile, "rb" );
+  File::Index idx( indexFile, QIODevice::ReadOnly );
 
   IdxHeader header;
 
@@ -702,7 +702,7 @@ private:
 SlobDictionary::SlobDictionary( string const & id, string const & indexFile, vector< string > const & dictionaryFiles ):
   BtreeDictionary( id, dictionaryFiles ),
   idxFileName( indexFile ),
-  idx( indexFile, "rb" ),
+  idx( indexFile, QIODevice::ReadOnly ),
   idxHeader( idx.read< IdxHeader >() )
 {
   // Open data file
@@ -1285,7 +1285,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         initializing.indexingDictionary( sf.getDictionaryName().toUtf8().constData() );
 
-        File::Index idx( indexFile, "wb" );
+        File::Index idx( indexFile, QIODevice::WriteOnly );
         IdxHeader idxHeader;
         memset( &idxHeader, 0, sizeof( idxHeader ) );
 

--- a/src/dict/sounddir.cc
+++ b/src/dict/sounddir.cc
@@ -51,7 +51,7 @@ static_assert( alignof( IdxHeader ) == 1 );
 
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Index idx( indexFile, "rb" );
+  File::Index idx( indexFile, QIODevice::ReadOnly );
 
   IdxHeader header;
 
@@ -114,7 +114,7 @@ SoundDirDictionary::SoundDirDictionary( string const & id,
                                         QString const & iconFilename_ ):
   BtreeDictionary( id, dictionaryFiles ),
   name( name_ ),
-  idx( indexFile, "rb" ),
+  idx( indexFile, QIODevice::ReadOnly ),
   idxHeader( idx.read< IdxHeader >() ),
   chunks( idx, idxHeader.chunksOffset ),
   iconFilename( iconFilename_ )
@@ -370,7 +370,7 @@ sptr< Dictionary::DataRequest > SoundDirDictionary::getResource( string const & 
   // Now try loading that file
 
   try {
-    File::Index f( fileName.toStdString(), "rb" );
+    File::Index f( fileName.toStdString(), QIODevice::ReadOnly );
 
     sptr< Dictionary::DataRequestInstant > dr = std::make_shared< Dictionary::DataRequestInstant >( true );
 
@@ -479,7 +479,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( Config::SoundDirs const & 
 
       initializing.indexingDictionary( soundDir.name.toUtf8().data() );
 
-      File::Index idx( indexFile, "wb" );
+      File::Index idx( indexFile, QIODevice::WriteOnly );
 
       IdxHeader idxHeader;
 

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -118,7 +118,7 @@ static_assert( alignof( IdxHeader ) == 1 );
 
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Index idx( indexFile, "rb" );
+  File::Index idx( indexFile, QIODevice::ReadOnly );
 
   IdxHeader header;
 
@@ -237,7 +237,7 @@ StardictDictionary::StardictDictionary( string const & id,
                                         string const & indexFile,
                                         vector< string > const & dictionaryFiles ):
   BtreeDictionary( id, dictionaryFiles ),
-  idx( indexFile, "rb" ),
+  idx( indexFile, QIODevice::ReadOnly ),
   idxHeader( idx.read< IdxHeader >() ),
   bookName( loadString( idxHeader.bookNameSize ) ),
   sameTypeSequence( loadString( idxHeader.sameTypeSequenceSize ) ),
@@ -1918,7 +1918,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         initializing.indexingDictionary( ifo.bookname );
 
-        File::Index idx( indexFile, "wb" );
+        File::Index idx( indexFile, QIODevice::WriteOnly );
 
         IdxHeader idxHeader;
 

--- a/src/dict/utils/dictfile.cc
+++ b/src/dict/utils/dictfile.cc
@@ -37,50 +37,18 @@ bool tryPossibleZipName( std::string const & name, std::string & copyTo )
 
 void loadFromFile( std::string const & filename, std::vector< char > & data )
 {
-  File::Index f( filename, "rb" );
+  File::Index f( filename, QIODevice::ReadOnly );
   auto size = f.file().size(); // QFile::size() obtains size via statx on Linux
   data.resize( size );
   f.read( data.data(), size );
 }
 
-void Index::open( char const * mode )
-{
-  QFile::OpenMode openMode = QIODevice::Text;
-
-  const char * pch = mode;
-  while ( *pch ) {
-    switch ( *pch ) {
-      case 'r':
-        openMode |= QIODevice::ReadOnly;
-        break;
-      case 'w':
-        openMode |= QIODevice::WriteOnly;
-        break;
-      case '+':
-        openMode &= ~( QIODevice::ReadOnly | QIODevice::WriteOnly );
-        openMode |= QIODevice::ReadWrite;
-        break;
-      case 'a':
-        openMode |= QIODevice::Append;
-        break;
-      case 'b':
-        openMode &= ~QIODevice::Text;
-        break;
-      default:
-        break;
-    }
-    ++pch;
-  }
-
-  if ( !f.open( openMode ) ) {
-    throw exCantOpen( f.fileName().toStdString() + ": " + f.errorString().toUtf8().data() );
-  }
-}
-
-Index::Index( std::string_view filename, char const * mode )
+Index::Index( std::string_view filename, QIODevice::OpenMode mode )
 {
   f.setFileName( QString::fromUtf8( filename.data(), filename.size() ) );
-  open( mode );
+  if ( !f.open( mode ) ) {
+    throw exCantOpen( ( f.fileName() + ": " + f.errorString() ).toStdString() );
+  }
 }
 
 void Index::read( void * buf, qint64 size )

--- a/src/dict/utils/dictfile.hh
+++ b/src/dict/utils/dictfile.hh
@@ -43,7 +43,7 @@ public:
   QMutex lock;
 
   // Create QFile Object and open() it.
-  Index( std::string_view filename, char const * mode );
+  Index( std::string_view filename, QIODevice::OpenMode mode );
 
   /// QFile::read  & QFile::write , but with exception throwing
   void read( void * buf, qint64 size );
@@ -113,8 +113,6 @@ public:
   ~Index() noexcept;
 
 private:
-  // QFile::open but with fopen-like mode settings.
-  void open( char const * mode );
 
   template< typename T >
   void readType( T & value )

--- a/src/dict/xdxf.cc
+++ b/src/dict/xdxf.cc
@@ -125,7 +125,7 @@ static_assert( alignof( IdxHeader ) == 1 );
 
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Index idx( indexFile, "rb" );
+  File::Index idx( indexFile, QIODevice::ReadOnly );
 
   IdxHeader header;
 
@@ -228,7 +228,7 @@ private:
 
 XdxfDictionary::XdxfDictionary( string const & id, string const & indexFile, vector< string > const & dictionaryFiles ):
   BtreeDictionary( id, dictionaryFiles ),
-  idx( indexFile, "rb" ),
+  idx( indexFile, QIODevice::ReadOnly ),
   idxHeader( idx.read< IdxHeader >() )
 {
   // Read the dictionary name
@@ -1077,7 +1077,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
 
         //initializing.indexingDictionary( nameFromFileName( dictFiles[ 0 ] ) );
 
-        File::Index idx( indexFile, "wb" );
+        File::Index idx( indexFile, QIODevice::WriteOnly );
 
         IdxHeader idxHeader;
         map< string, string > abrv;

--- a/src/dict/zim.cc
+++ b/src/dict/zim.cc
@@ -93,7 +93,7 @@ static_assert( alignof( IdxHeader ) == 1 );
 // Some supporting functions
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Index idx( indexFile, "rb" );
+  File::Index idx( indexFile, QIODevice::ReadOnly );
 
   IdxHeader header;
 
@@ -241,7 +241,7 @@ private:
 
 ZimDictionary::ZimDictionary( string const & id, string const & indexFile, vector< string > const & dictionaryFiles ):
   BtreeDictionary( id, dictionaryFiles ),
-  idx( indexFile, "rb" ),
+  idx( indexFile, QIODevice::ReadOnly ),
   idxHeader( idx.read< IdxHeader >() ),
   df( dictionaryFiles[ 0 ] )
 {
@@ -832,7 +832,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
           initializing.indexingDictionary( firstName.mid( n + 1 ).toUtf8().constData() );
         }
 
-        File::Index idx( indexFile, "wb" );
+        File::Index idx( indexFile, QIODevice::WriteOnly );
         IdxHeader idxHeader;
         memset( &idxHeader, 0, sizeof( idxHeader ) );
         idxHeader.namePtr        = 0xFFFFFFFF;

--- a/src/dict/zipsounds.cc
+++ b/src/dict/zipsounds.cc
@@ -60,7 +60,7 @@ static_assert( alignof( IdxHeader ) == 1 );
 
 bool indexIsOldOrBad( string const & indexFile )
 {
-  File::Index idx( indexFile, "rb" );
+  File::Index idx( indexFile, QIODevice::ReadOnly );
 
   IdxHeader header;
 
@@ -140,7 +140,7 @@ ZipSoundsDictionary::ZipSoundsDictionary( string const & id,
                                           string const & indexFile,
                                           vector< string > const & dictionaryFiles ):
   BtreeDictionary( id, dictionaryFiles ),
-  idx( indexFile, "rb" ),
+  idx( indexFile, QIODevice::ReadOnly ),
   idxHeader( idx.read< IdxHeader >() )
 {
   chunks = std::shared_ptr< ChunkedStorage::Reader >( new ChunkedStorage::Reader( idx, idxHeader.chunksOffset ) );
@@ -405,7 +405,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
       if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile ) ) {
         gdDebug( "Zips: Building the index for dictionary: %s\n", fileName.c_str() );
 
-        File::Index idx( indexFile, "wb" );
+        File::Index idx( indexFile, QIODevice::WriteOnly );
         IdxHeader idxHeader;
 
         memset( &idxHeader, 0, sizeof( idxHeader ) );


### PR DESCRIPTION
They are useless even since the original GD.

Stop parsing this 2 char str for nothing.

Depends on https://github.com/xiaoyifang/goldendict-ng/pull/1965 