### PR TITLE
clean: remove duplicated `getName` overrides

### DIFF
--- a/src/dict/dictdfiles.cc
+++ b/src/dict/dictdfiles.cc
@@ -92,11 +92,6 @@ public:
 
   ~DictdDictionary();
 
-  string getName() noexcept override
-  {
-    return dictionaryName;
-  }
-
   map< Dictionary::Property, string > getProperties() noexcept override
   {
     return map< Dictionary::Property, string >();

--- a/src/dict/dictserver.cc
+++ b/src/dict/dictserver.cc
@@ -176,7 +176,6 @@ class DictServerDictionary: public Dictionary::Class
 {
   Q_OBJECT
 
-  string name;
   QString url, icon;
   quint32 langId;
   QString errorString;
@@ -196,11 +195,13 @@ public:
                         QString const & strategies_,
                         QString const & icon_ ):
     Dictionary::Class( id, vector< string >() ),
-    name( name_ ),
     url( url_ ),
     icon( icon_ ),
     langId( 0 )
   {
+
+    dictionaryName = name_ ;
+
     int pos = url.indexOf( "://" );
     if ( pos < 0 ) {
       url = "dict://" + url;
@@ -299,11 +300,6 @@ public:
   ~DictServerDictionary() override
   {
     disconnectFromServer( socket );
-  }
-
-  string getName() noexcept override
-  {
-    return name;
   }
 
   map< Property, string > getProperties() noexcept override

--- a/src/dict/dsl.cc
+++ b/src/dict/dsl.cc
@@ -172,10 +172,6 @@ public:
 
   ~DslDictionary();
 
-  string getName() noexcept override
-  {
-    return dictionaryName;
-  }
 
   map< Dictionary::Property, string > getProperties() noexcept override
   {

--- a/src/dict/epwing.cc
+++ b/src/dict/epwing.cc
@@ -82,7 +82,6 @@ class EpwingDictionary: public BtreeIndexing::BtreeDictionary
   QMutex idxMutex;
   File::Index idx;
   IdxHeader idxHeader;
-  string bookName;
   ChunkedStorage::Reader chunks;
   Epwing::Book::EpwingBook eBook;
   QString cacheDirectory;
@@ -96,15 +95,6 @@ public:
 
   ~EpwingDictionary();
 
-  string getName() noexcept override
-  {
-    return bookName;
-  }
-
-  void setName( string _name ) noexcept override
-  {
-    bookName = _name;
-  }
 
   map< Dictionary::Property, string > getProperties() noexcept override
   {
@@ -227,7 +217,7 @@ EpwingDictionary::EpwingDictionary( string const & id,
   idx.seek( sizeof( idxHeader ) );
   if ( data.size() > 0 ) {
     idx.read( &data.front(), idxHeader.nameSize );
-    bookName = string( &data.front(), idxHeader.nameSize );
+    dictionaryName = string( &data.front(), idxHeader.nameSize );
   }
 
   // Initialize eBook

--- a/src/dict/forvo.cc
+++ b/src/dict/forvo.cc
@@ -31,7 +31,6 @@ public:
                    QString const & languageCode_,
                    QNetworkAccessManager & netMgr_ ):
     Dictionary::Class( id, vector< string >() ),
-    name( name_ ),
     apiKey( apiKey_ ),
     languageCode( languageCode_ ),
     netMgr( netMgr_ )

--- a/src/dict/forvo.cc
+++ b/src/dict/forvo.cc
@@ -20,7 +20,6 @@ namespace {
 
 class ForvoDictionary: public Dictionary::Class
 {
-  string name;
   QString apiKey, languageCode;
   QNetworkAccessManager & netMgr;
 
@@ -37,12 +36,9 @@ public:
     languageCode( languageCode_ ),
     netMgr( netMgr_ )
   {
+    dictionaryName = name_;
   }
 
-  string getName() noexcept override
-  {
-    return name;
-  }
 
   map< Property, string > getProperties() noexcept override
   {

--- a/src/dict/gls.cc
+++ b/src/dict/gls.cc
@@ -358,11 +358,6 @@ public:
 
   ~GlsDictionary();
 
-  string getName() noexcept override
-  {
-    return dictionaryName;
-  }
-
   map< Dictionary::Property, string > getProperties() noexcept override
   {
     return map< Dictionary::Property, string >();

--- a/src/dict/hunspell.cc
+++ b/src/dict/hunspell.cc
@@ -41,7 +41,6 @@ namespace {
 
 class HunspellDictionary: public Dictionary::Class
 {
-  string name;
   Hunspell hunspell;
 
 #ifdef Q_OS_WIN32
@@ -56,19 +55,15 @@ public:
   /// files[ 0 ] should be .aff file, files[ 1 ] should be .dic file.
   HunspellDictionary( string const & id, string const & name_, vector< string > const & files ):
     Dictionary::Class( id, files ),
-    name( name_ ),
 #ifdef Q_OS_WIN32
     hunspell( Utf8ToLocal8Bit( files[ 0 ] ).c_str(), Utf8ToLocal8Bit( files[ 1 ] ).c_str() )
 #else
     hunspell( files[ 0 ].c_str(), files[ 1 ].c_str() )
 #endif
   {
+  dictionaryName = name_;
   }
 
-  string getName() noexcept override
-  {
-    return name;
-  }
 
   map< Property, string > getProperties() noexcept override
   {

--- a/src/dict/lingualibre.cc
+++ b/src/dict/lingualibre.cc
@@ -60,7 +60,6 @@ private slots:
 class LinguaDictionary: public Dictionary::Class
 {
 
-  string name;
   QString languageCode;
   QString langWikipediaID;
   QNetworkAccessManager & netMgr;
@@ -68,10 +67,10 @@ class LinguaDictionary: public Dictionary::Class
 public:
   LinguaDictionary( string const & id, string name_, QString languageCode_, QNetworkAccessManager & netMgr_ ):
     Dictionary::Class( id, vector< string >() ),
-    name( std::move( name_ ) ),
     languageCode( std::move( languageCode_ ) ),
     netMgr( netMgr_ )
   {
+  dictionaryName = name_;
     /* map of iso lang code to wikipedia lang id
 
 Data was obtained by this query on https://commons-query.wikimedia.org/
@@ -166,10 +165,6 @@ WHERE {
     }
   }
 
-  string getName() noexcept override
-  {
-    return name;
-  }
 
   map< Property, string > getProperties() noexcept override
   {

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -215,10 +215,6 @@ public:
 
   void deferredInit() override;
 
-  string getName() noexcept override
-  {
-    return dictionaryName;
-  }
 
   map< Dictionary::Property, string > getProperties() noexcept override
   {

--- a/src/dict/sdict.cc
+++ b/src/dict/sdict.cc
@@ -113,10 +113,6 @@ public:
 
   ~SdictDictionary();
 
-  string getName() noexcept override
-  {
-    return dictionaryName;
-  }
 
   map< Dictionary::Property, string > getProperties() noexcept override
   {

--- a/src/dict/slob.cc
+++ b/src/dict/slob.cc
@@ -614,10 +614,6 @@ public:
 
   ~SlobDictionary();
 
-  string getName() noexcept override
-  {
-    return dictionaryName;
-  }
 
   map< Dictionary::Property, string > getProperties() noexcept override
   {

--- a/src/dict/sounddir.cc
+++ b/src/dict/sounddir.cc
@@ -61,7 +61,6 @@ bool indexIsOldOrBad( string const & indexFile )
 
 class SoundDirDictionary: public BtreeIndexing::BtreeDictionary
 {
-  string name;
   QMutex idxMutex;
   File::Index idx;
   IdxHeader idxHeader;
@@ -109,13 +108,13 @@ SoundDirDictionary::SoundDirDictionary( string const & id,
                                         vector< string > const & dictionaryFiles,
                                         QString const & iconFilename_ ):
   BtreeDictionary( id, dictionaryFiles ),
-  name(  ),
   idx( indexFile, QIODevice::ReadOnly ),
   idxHeader( idx.read< IdxHeader >() ),
   chunks( idx, idxHeader.chunksOffset ),
   iconFilename( iconFilename_ )
 {
-    dictionaryName = name_;
+  dictionaryName = name_;
+
   // Initialize the index
 
   openIndex( IndexInfo( idxHeader.indexBtreeMaxElements, idxHeader.indexRootOffset ), idx, idxMutex );

--- a/src/dict/sounddir.cc
+++ b/src/dict/sounddir.cc
@@ -76,10 +76,6 @@ public:
                       vector< string > const & dictionaryFiles,
                       QString const & iconFilename_ );
 
-  string getName() noexcept override
-  {
-    return name;
-  }
 
   map< Dictionary::Property, string > getProperties() noexcept override
   {
@@ -113,12 +109,13 @@ SoundDirDictionary::SoundDirDictionary( string const & id,
                                         vector< string > const & dictionaryFiles,
                                         QString const & iconFilename_ ):
   BtreeDictionary( id, dictionaryFiles ),
-  name( name_ ),
+  name(  ),
   idx( indexFile, QIODevice::ReadOnly ),
   idxHeader( idx.read< IdxHeader >() ),
   chunks( idx, idxHeader.chunksOffset ),
   iconFilename( iconFilename_ )
 {
+    dictionaryName = name_;
   // Initialize the index
 
   openIndex( IndexInfo( idxHeader.indexBtreeMaxElements, idxHeader.indexRootOffset ), idx, idxMutex );

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -128,7 +128,6 @@ class StardictDictionary: public BtreeIndexing::BtreeDictionary
   QMutex idxMutex;
   File::Index idx;
   IdxHeader idxHeader;
-  string bookName;
   string sameTypeSequence;
   ChunkedStorage::Reader chunks;
   QMutex dzMutex;
@@ -141,17 +140,6 @@ public:
   StardictDictionary( string const & id, string const & indexFile, vector< string > const & dictionaryFiles );
 
   ~StardictDictionary();
-
-  string getName() noexcept override
-  {
-    return bookName;
-  }
-
-  void setName( string _name ) noexcept override
-  {
-    bookName = _name;
-  }
-
 
   map< Dictionary::Property, string > getProperties() noexcept override
   {
@@ -236,7 +224,7 @@ StardictDictionary::StardictDictionary( string const & id,
   BtreeDictionary( id, dictionaryFiles ),
   idx( indexFile, QIODevice::ReadOnly ),
   idxHeader( idx.read< IdxHeader >() ),
-  bookName( loadString( idxHeader.bookNameSize ) ),
+  dictionaryName( loadString( idxHeader.bookNameSize ) ),
   sameTypeSequence( loadString( idxHeader.sameTypeSequenceSize ) ),
   chunks( idx, idxHeader.chunksOffset )
 {

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -224,10 +224,10 @@ StardictDictionary::StardictDictionary( string const & id,
   BtreeDictionary( id, dictionaryFiles ),
   idx( indexFile, QIODevice::ReadOnly ),
   idxHeader( idx.read< IdxHeader >() ),
-  dictionaryName( loadString( idxHeader.bookNameSize ) ),
   sameTypeSequence( loadString( idxHeader.sameTypeSequenceSize ) ),
   chunks( idx, idxHeader.chunksOffset )
 {
+  dictionaryName = loadString( idxHeader.bookNameSize );
   // Open the .dict file
 
   DZ_ERRORS error;

--- a/src/dict/website.cc
+++ b/src/dict/website.cc
@@ -474,7 +474,7 @@ void WebSiteDictionary::loadIcon() noexcept
       loadIconFromFile( fInfo.absoluteFilePath(), true );
     }
   }
-  if ( dictionaryIcon.isNull() && !loadIconFromText( ":/icons/webdict.svg", QString::fromStdString( name ) ) ) {
+  if ( dictionaryIcon.isNull() && !loadIconFromText( ":/icons/webdict.svg", QString::fromStdString( dictionaryName ) ) ) {
     dictionaryIcon = QIcon( ":/icons/webdict.svg" );
   }
   dictionaryIconLoaded = true;

--- a/src/dict/website.cc
+++ b/src/dict/website.cc
@@ -22,7 +22,6 @@ namespace {
 
 class WebSiteDictionary: public Dictionary::Class
 {
-  string name;
   QByteArray urlTemplate;
   bool experimentalIframe;
   QString iconFilename;
@@ -38,12 +37,13 @@ public:
                      bool inside_iframe_,
                      QNetworkAccessManager & netMgr_ ):
     Dictionary::Class( id, vector< string >() ),
-    name( name_ ),
     iconFilename( iconFilename_ ),
     inside_iframe( inside_iframe_ ),
     netMgr( netMgr_ ),
     experimentalIframe( false )
   {
+    dictionaryName = name_;
+
     if ( urlTemplate_.startsWith( "http://" ) || urlTemplate_.startsWith( "https://" ) ) {
       experimentalIframe = true;
     }
@@ -53,10 +53,6 @@ public:
     dictionaryDescription = urlTemplate_;
   }
 
-  string getName() noexcept override
-  {
-    return name;
-  }
 
   map< Property, string > getProperties() noexcept override
   {

--- a/src/dict/website.cc
+++ b/src/dict/website.cc
@@ -474,7 +474,8 @@ void WebSiteDictionary::loadIcon() noexcept
       loadIconFromFile( fInfo.absoluteFilePath(), true );
     }
   }
-  if ( dictionaryIcon.isNull() && !loadIconFromText( ":/icons/webdict.svg", QString::fromStdString( dictionaryName ) ) ) {
+  if ( dictionaryIcon.isNull()
+       && !loadIconFromText( ":/icons/webdict.svg", QString::fromStdString( dictionaryName ) ) ) {
     dictionaryIcon = QIcon( ":/icons/webdict.svg" );
   }
   dictionaryIconLoaded = true;

--- a/src/dict/xdxf.cc
+++ b/src/dict/xdxf.cc
@@ -149,10 +149,6 @@ public:
 
   ~XdxfDictionary();
 
-  string getName() noexcept override
-  {
-    return dictionaryName;
-  }
 
   map< Dictionary::Property, string > getProperties() noexcept override
   {

--- a/src/dict/zim.cc
+++ b/src/dict/zim.cc
@@ -164,10 +164,7 @@ public:
 
   ~ZimDictionary() = default;
 
-  string getName() noexcept override
-  {
-    return dictionaryName;
-  }
+
 
   map< Dictionary::Property, string > getProperties() noexcept override
   {


### PR DESCRIPTION
`dictionaryName` has `protected` visibility.

https://github.com/xiaoyifang/goldendict-ng/blob/9c46e5c317b894c3aab9dfb6efd2dd38e94352c7/src/dict/dictionary.hh#L318

Classes that don't use it just carries an unused std::string.