### PR TITLE
clean: delete unused QSemaphore and do a header cleanup

### DIFF
--- a/src/audio/audiooutput.cc
+++ b/src/audio/audiooutput.cc
@@ -1,7 +1,6 @@
 #include "audiooutput.hh"
 
-#include <QAudioFormat>
-#include <QtConcurrent/qtconcurrentrun.h>
+#include <QtConcurrentRun>
 #include <QFuture>
 #include <QWaitCondition>
 #include <QCoreApplication>

--- a/src/dict/aard.cc
+++ b/src/dict/aard.cc
@@ -16,16 +16,11 @@
 #include <set>
 #include <string>
 
-
+#include <QDir>
 #include <QString>
-#include <QSemaphore>
-#include <QThreadPool>
 #include <QAtomicInt>
-#include <QDomDocument>
 #include <QtEndian>
 #include <QRegularExpression>
-#include "ufile.hh"
-#include "wstring_qt.hh"
 #include "utils.hh"
 
 namespace Aard {

--- a/src/dict/bgl.cc
+++ b/src/dict/bgl.cc
@@ -14,20 +14,17 @@
 #include "language.hh"
 #include "utf8.hh"
 #include "utils.hh"
-
 #include <ctype.h>
 #include <list>
 #include <map>
 #include <set>
 #include <string.h>
 #include <zlib.h>
-
-
 #include <QAtomicInt>
+#include <QCryptographicHash>
+#include <QDir>
 #include <QPainter>
 #include <QRegularExpression>
-#include <QSemaphore>
-#include <QThreadPool>
 
 namespace Bgl {
 

--- a/src/dict/btreeidx.cc
+++ b/src/dict/btreeidx.cc
@@ -4,9 +4,6 @@
 #include "btreeidx.hh"
 #include "folding.hh"
 #include "utf8.hh"
-#include <QRunnable>
-#include <QThreadPool>
-#include <QSemaphore>
 #include <math.h>
 #include <string.h>
 #include <stdlib.h>
@@ -18,7 +15,7 @@
 #include "wildcard.hh"
 #include "globalbroadcaster.hh"
 
-#include <QtConcurrent>
+#include <QtConcurrentRun>
 #include <zlib.h>
 
 namespace BtreeIndexing {

--- a/src/dict/btreeidx.hh
+++ b/src/dict/btreeidx.hh
@@ -5,16 +5,11 @@
 
 #include "dict/dictionary.hh"
 #include "dictfile.hh"
-
-#include <algorithm>
 #include <map>
 #include <stdint.h>
 #include <string>
 #include <vector>
-
 #include <QFuture>
-#include <QList>
-#include <QSet>
 #include <QList>
 
 

--- a/src/dict/dictdfiles.cc
+++ b/src/dict/dictdfiles.cc
@@ -7,7 +7,6 @@
 #include "utf8.hh"
 #include "dictzip.hh"
 #include "htmlescape.hh"
-
 #include "langcoder.hh"
 #include <map>
 #include <set>
@@ -18,6 +17,7 @@
 #include <stdlib.h>
 #include "gddebug.hh"
 #include "ftshelpers.hh"
+#include <QDir>
 #include <QUrl>
 
 

--- a/src/dict/dictserver.cc
+++ b/src/dict/dictserver.cc
@@ -7,11 +7,12 @@
 #include <QUrl>
 #include <QTcpSocket>
 #include <QString>
-#include <list>
 #include "htmlescape.hh"
-
+#include <QCryptographicHash>
+#include <QDir>
+#include <QFileInfo>
 #include <QRegularExpression>
-#include <QtConcurrent>
+#include <QtConcurrentRun>
 
 namespace DictServer {
 

--- a/src/dict/dsl.cc
+++ b/src/dict/dsl.cc
@@ -154,7 +154,6 @@ class DslDictionary: public BtreeIndexing::BtreeDictionary
   QAtomicInt deferredInitDone;
   QMutex deferredInitMutex;
   bool deferredInitRunnableStarted;
-  QSemaphore deferredInitRunnableExited;
 
   string initError;
 
@@ -1405,7 +1404,6 @@ class DslArticleRequest: public Dictionary::DataRequest
   bool ignoreDiacritics;
 
   QAtomicInt isCancelled;
-  QSemaphore hasExited;
   QFuture< void > f;
 
 public:
@@ -1582,7 +1580,6 @@ class DslResourceRequest: public Dictionary::DataRequest
   string resourceName;
 
   QAtomicInt isCancelled;
-  QSemaphore hasExited;
   QFuture< void > f;
 
 public:

--- a/src/dict/dsl.cc
+++ b/src/dict/dsl.cc
@@ -11,7 +11,6 @@
 #include "htmlescape.hh"
 #include "iconv.hh"
 #include "filetype.hh"
-
 #include "audiolink.hh"
 #include "langcoder.hh"
 #include "wstring_qt.hh"
@@ -19,36 +18,22 @@
 #include "gddebug.hh"
 #include "tiff.hh"
 #include "ftshelpers.hh"
-
 #include <map>
 #include <set>
 #include <string>
 #include <vector>
 #include <list>
 #include <wctype.h>
-
-#include <QSemaphore>
 #include <QThreadPool>
 #include <QAtomicInt>
 #include <QUrl>
-
 #include <QDir>
 #include <QFileInfo>
 #include <QPainter>
-#include <QStringList>
-
 #include <QRegularExpression>
-
-// For TIFF conversion
-#include <QImage>
 #include <QByteArray>
-#include <QBuffer>
-
-// For SVG handling
-#include <QtSvg/QSvgRenderer>
-
-#include <QtConcurrent>
-
+#include <QSvgRenderer>
+#include <QtConcurrentRun>
 #include "utils.hh"
 
 namespace Dsl {

--- a/src/dict/epwing.cc
+++ b/src/dict/epwing.cc
@@ -1,26 +1,19 @@
 /* This file is (c) 2014 Abs62
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
+#include <QDir>
 #ifndef NO_EPWING_SUPPORT
 
   #include "epwing_book.hh"
   #include "epwing.hh"
-
   #include <QByteArray>
-  #include <QDir>
-  #include <QRunnable>
-  #include <QSemaphore>
-
   #include <map>
-  #include <QtConcurrent>
+  #include <QtConcurrentRun>
   #include <set>
   #include <string>
-
   #include "btreeidx.hh"
   #include "folding.hh"
   #include "gddebug.hh"
-
   #include "chunkedstorage.hh"
-  #include "wstring_qt.hh"
   #include "filetype.hh"
   #include "ftshelpers.hh"
   #include "globalregex.hh"

--- a/src/dict/gls.cc
+++ b/src/dict/gls.cc
@@ -16,24 +16,16 @@
 #include "dictzip.hh"
 #include "indexedzip.hh"
 #include "ftshelpers.hh"
-
 #include "htmlescape.hh"
 #include "filetype.hh"
 #include "tiff.hh"
 #include "audiolink.hh"
-
 #include <QString>
-#include <QSemaphore>
-#include <QThreadPool>
 #include <QAtomicInt>
-// For TIFF conversion
-#include <QImage>
 #include <QByteArray>
-#include <QBuffer>
-
+#include <QDir>
 #include <QRegularExpression>
 #include <QtCore5Compat/QTextCodec>
-
 #include <string>
 #include <list>
 #include <map>

--- a/src/dict/hunspell.cc
+++ b/src/dict/hunspell.cc
@@ -6,30 +6,22 @@
 #include "htmlescape.hh"
 #include "iconv.hh"
 #include "folding.hh"
-#include "wstring_qt.hh"
 #include "language.hh"
 #include "langcoder.hh"
-
-#include <QRunnable>
-#include <QThreadPool>
-#include <QSemaphore>
-
 #include <QRegularExpression>
-
 #include <QDir>
 #include <QCoreApplication>
 #include <QFileInfo>
-
 #include <set>
+#include "gddebug.hh"
+#include "utils.hh"
+#include <QtConcurrentRun>
+
 #ifndef INCLUDE_LIBRARY_PATH
   #include <hunspell.hxx>
 #else
   #include <hunspell/hunspell.hxx>
 #endif
-#include "gddebug.hh"
-
-#include "utils.hh"
-#include <QtConcurrent>
 
 namespace HunspellMorpho {
 

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -29,6 +29,7 @@
 #include <QDir>
 #include <QRegularExpression>
 #include <QString>
+#include <QStringBuilder>
 #include <QThreadPool>
 #include <QtConcurrentRun>
 

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -11,19 +11,16 @@
 #include "chunkedstorage.hh"
 #include "gddebug.hh"
 #include "langcoder.hh"
-
 #include "audiolink.hh"
 #include "ex.hh"
 #include "mdictparser.hh"
 #include "filetype.hh"
 #include "ftshelpers.hh"
 #include "htmlescape.hh"
-
 #include <algorithm>
 #include <map>
 #include <set>
 #include <list>
-
 #include "globalregex.hh"
 #include "tiff.hh"
 #include "utils.hh"
@@ -33,7 +30,7 @@
 #include <QRegularExpression>
 #include <QString>
 #include <QThreadPool>
-#include <QtConcurrent>
+#include <QtConcurrentRun>
 
 namespace Mdx {
 

--- a/src/dict/sdict.cc
+++ b/src/dict/sdict.cc
@@ -13,8 +13,8 @@
 #include "utf8.hh"
 #include <map>
 #include <QAtomicInt>
+#include <QDir>
 #include <QRegularExpression>
-#include <QSemaphore>
 #include <QString>
 #include <set>
 #include <string>

--- a/src/dict/slob.cc
+++ b/src/dict/slob.cc
@@ -10,25 +10,22 @@
 #include "utf8.hh"
 #include "decompress.hh"
 #include "langcoder.hh"
-#include "wstring_qt.hh"
 #include "ftshelpers.hh"
 #include "htmlescape.hh"
 #include "filetype.hh"
 #include "tiff.hh"
 #include "utils.hh"
-
 #include "iconv.hh"
-
 #include <QString>
+#include <QStringBuilder>
 #include <QFile>
 #include <QFileInfo>
 #include <QDir>
 #include <QMap>
 #include <QProcess>
 #include <QList>
-
+#include <QtEndian>
 #include <QRegularExpression>
-
 #include <string>
 #include <vector>
 #include <utility>

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -11,36 +11,30 @@
 #include "htmlescape.hh"
 #include "langcoder.hh"
 #include "gddebug.hh"
-
 #include "filetype.hh"
 #include "indexedzip.hh"
 #include "tiff.hh"
 #include "ftshelpers.hh"
 #include "audiolink.hh"
-
 #include <zlib.h>
 #include <map>
 #include <set>
 #include <string>
+#include <QString>
+#include <QAtomicInt>
+#include <QDomDocument>
+#include "ufile.hh"
+#include "utils.hh"
+#include <QRegularExpression>
+#include "globalregex.hh"
+#include <QDir>
+#include <stdlib.h>
 
 #ifndef Q_OS_WIN
   #include <arpa/inet.h>
 #else
   #include <winsock.h>
 #endif
-#include <stdlib.h>
-
-
-#include <QString>
-#include <QSemaphore>
-#include <QAtomicInt>
-#include <QStringList>
-#include <QDomDocument>
-#include "ufile.hh"
-#include "utils.hh"
-
-#include <QRegularExpression>
-#include "globalregex.hh"
 
 namespace Stardict {
 

--- a/src/dict/xdxf.cc
+++ b/src/dict/xdxf.cc
@@ -8,7 +8,6 @@
 #include "chunkedstorage.hh"
 #include "dictzip.hh"
 #include "htmlescape.hh"
-
 #include <map>
 #include <set>
 #include <string>
@@ -17,26 +16,19 @@
 #include <wctype.h>
 #include <stdlib.h>
 #include "gddebug.hh"
-#include "wstring_qt.hh"
 #include "xdxf2html.hh"
 #include "ufile.hh"
-#include "dictzip.hh"
 #include "langcoder.hh"
 #include "indexedzip.hh"
 #include "filetype.hh"
 #include "tiff.hh"
 #include "ftshelpers.hh"
-
-
 #include <QIODevice>
 #include <QXmlStreamReader>
-#include <QTextDocument>
 #include <QFileInfo>
 #include <QDir>
 #include <QPainter>
 #include <QRegularExpression>
-#include <QSemaphore>
-#include <QThreadPool>
 #include <QAtomicInt>
 
 #include "utils.hh"

--- a/src/dict/zim.cc
+++ b/src/dict/zim.cc
@@ -5,7 +5,6 @@
 
   #include "zim.hh"
   #include "btreeidx.hh"
-
   #include "folding.hh"
   #include "gddebug.hh"
   #include "utf8.hh"
@@ -23,14 +22,12 @@
   #include <QAtomicInt>
   #include <QImage>
   #include <QDir>
-
   #include <QRegularExpression>
-
   #include <string>
   #include <set>
   #include <map>
   #include <algorithm>
-  #include <QtConcurrent>
+  #include <QtConcurrentRun>
   #include <utility>
   #include "globalregex.hh"
   #include <zim/zim.h>

--- a/src/ftshelpers.hh
+++ b/src/ftshelpers.hh
@@ -2,8 +2,7 @@
 
 #include <QString>
 #include <QList>
-#include <QtConcurrent>
-
+#include <QtConcurrentRun>
 #include "dict/dictionary.hh"
 #include "btreeidx.hh"
 #include "fulltextsearch.hh"

--- a/src/fulltextsearch.cc
+++ b/src/fulltextsearch.cc
@@ -1,14 +1,14 @@
 /* This file is (c) 2014 Abs62
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
-#include "fulltextsearch.hh"
 #include "ftshelpers.hh"
+#include "fulltextsearch.hh"
 #include "gddebug.hh"
-#include "help.hh"
-
-#include <QThreadPool>
-#include <QMessageBox>
 #include "globalregex.hh"
+#include "help.hh"
+#include <QFutureSynchronizer>
+#include <QMessageBox>
+#include <QThreadPool>
 
 namespace FTS {
 

--- a/src/fulltextsearch.hh
+++ b/src/fulltextsearch.hh
@@ -1,19 +1,10 @@
 #pragma once
 
-#include <QAbstractListModel>
-#include <QAction>
-#include <QList>
 #include <QTimer>
-#include <QThread>
 #include <QRunnable>
 #include <QSemaphore>
-#include <QStringList>
-
-#include <QRegularExpression>
-
 #include "dict/dictionary.hh"
 #include "ui_fulltextsearch.h"
-
 #include "config.hh"
 #include "instances.hh"
 #include "delegate.hh"


### PR DESCRIPTION
* Delete 3 unused `QSemaphore` in `dsl.cc`
* Stop using module wide `<QtConcurrent>` header
