### PR TITLE
clean: delete  Dictionary::getProperties which is unused since the first commit of GD

### DIFF
--- a/src/dict/aard.cc
+++ b/src/dict/aard.cc
@@ -216,11 +216,6 @@ public:
 
   ~AardDictionary();
 
-  map< Dictionary::Property, string > getProperties() noexcept override
-  {
-    return map< Dictionary::Property, string >();
-  }
-
   unsigned long getArticleCount() noexcept override
   {
     return idxHeader.articleCount;

--- a/src/dict/bgl.cc
+++ b/src/dict/bgl.cc
@@ -173,11 +173,6 @@ public:
 
   BglDictionary( string const & id, string const & indexFile, string const & dictionaryFile );
 
-  map< Dictionary::Property, string > getProperties() noexcept override
-  {
-    return map< Dictionary::Property, string >();
-  }
-
   unsigned long getArticleCount() noexcept override
   {
     return idxHeader.articleCount;

--- a/src/dict/dictdfiles.cc
+++ b/src/dict/dictdfiles.cc
@@ -91,11 +91,6 @@ public:
 
   ~DictdDictionary();
 
-  map< Dictionary::Property, string > getProperties() noexcept override
-  {
-    return map< Dictionary::Property, string >();
-  }
-
   unsigned long getArticleCount() noexcept override
   {
     return idxHeader.articleCount;

--- a/src/dict/dictionary.hh
+++ b/src/dict/dictionary.hh
@@ -30,13 +30,6 @@ using std::string;
 using gd::wstring;
 using std::map;
 
-enum Property {
-  Author,
-  Copyright,
-  Description,
-  Email
-};
-
 DEF_EX( Ex, "Dictionary error", std::exception )
 DEF_EX( exIndexOutOfRange, "The supplied index is out of range", Ex )
 DEF_EX( exSliceOutOfRange, "The requested data slice is out of range", Ex )
@@ -379,10 +372,6 @@ public:
   {
     metadata_enable_fts = _enable_FTS;
   }
-
-  /// Returns all the available properties, like the author's name, copyright,
-  /// description etc. All strings are in utf8.
-  virtual map< Property, string > getProperties() noexcept = 0;
 
   /// Returns the features the dictionary possess. See the Feature enum for
   /// their list.

--- a/src/dict/dictserver.cc
+++ b/src/dict/dictserver.cc
@@ -303,10 +303,6 @@ public:
     disconnectFromServer( socket );
   }
 
-  map< Property, string > getProperties() noexcept override
-  {
-    return {};
-  }
 
   unsigned long getArticleCount() noexcept override
   {

--- a/src/dict/dsl.cc
+++ b/src/dict/dsl.cc
@@ -156,11 +156,6 @@ public:
   ~DslDictionary();
 
 
-  map< Dictionary::Property, string > getProperties() noexcept override
-  {
-    return map< Dictionary::Property, string >();
-  }
-
   unsigned long getArticleCount() noexcept override
   {
     return idxHeader.articleCount;

--- a/src/dict/epwing.cc
+++ b/src/dict/epwing.cc
@@ -87,12 +87,6 @@ public:
 
   ~EpwingDictionary();
 
-
-  map< Dictionary::Property, string > getProperties() noexcept override
-  {
-    return map< Dictionary::Property, string >();
-  }
-
   unsigned long getArticleCount() noexcept override
   {
     return idxHeader.articleCount;

--- a/src/dict/forvo.cc
+++ b/src/dict/forvo.cc
@@ -38,11 +38,6 @@ public:
   }
 
 
-  map< Property, string > getProperties() noexcept override
-  {
-    return map< Property, string >();
-  }
-
   unsigned long getArticleCount() noexcept override
   {
     return 0;

--- a/src/dict/gls.cc
+++ b/src/dict/gls.cc
@@ -349,11 +349,6 @@ public:
 
   ~GlsDictionary();
 
-  map< Dictionary::Property, string > getProperties() noexcept override
-  {
-    return map< Dictionary::Property, string >();
-  }
-
   unsigned long getArticleCount() noexcept override
   {
     return idxHeader.articleCount;

--- a/src/dict/hunspell.cc
+++ b/src/dict/hunspell.cc
@@ -55,12 +55,6 @@ public:
     dictionaryName = name_;
   }
 
-
-  map< Property, string > getProperties() noexcept override
-  {
-    return map< Property, string >();
-  }
-
   unsigned long getArticleCount() noexcept override
   {
     return 0;

--- a/src/dict/lingualibre.cc
+++ b/src/dict/lingualibre.cc
@@ -165,12 +165,6 @@ WHERE {
     }
   }
 
-
-  map< Property, string > getProperties() noexcept override
-  {
-    return {};
-  }
-
   unsigned long getArticleCount() noexcept override
   {
     return 0;

--- a/src/dict/lsa.cc
+++ b/src/dict/lsa.cc
@@ -159,11 +159,6 @@ public:
 
   string getName() noexcept override;
 
-  map< Dictionary::Property, string > getProperties() noexcept override
-  {
-    return map< Dictionary::Property, string >();
-  }
-
   unsigned long getArticleCount() noexcept override
   {
     return idxHeader.soundsCount;

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -212,12 +212,6 @@ public:
 
   void deferredInit() override;
 
-
-  map< Dictionary::Property, string > getProperties() noexcept override
-  {
-    return {};
-  }
-
   unsigned long getArticleCount() noexcept override
   {
     return idxHeader.articleCount;

--- a/src/dict/mediawiki.cc
+++ b/src/dict/mediawiki.cc
@@ -56,11 +56,6 @@ public:
     return name;
   }
 
-  map< Property, string > getProperties() noexcept override
-  {
-    return map< Property, string >();
-  }
-
   unsigned long getArticleCount() noexcept override
   {
     return 0;

--- a/src/dict/programs.cc
+++ b/src/dict/programs.cc
@@ -36,11 +36,6 @@ public:
     return prg.name.toUtf8().data();
   }
 
-  map< Property, string > getProperties() noexcept override
-  {
-    return map< Property, string >();
-  }
-
   unsigned long getArticleCount() noexcept override
   {
     return 0;

--- a/src/dict/sdict.cc
+++ b/src/dict/sdict.cc
@@ -113,11 +113,6 @@ public:
   ~SdictDictionary();
 
 
-  map< Dictionary::Property, string > getProperties() noexcept override
-  {
-    return map< Dictionary::Property, string >();
-  }
-
   unsigned long getArticleCount() noexcept override
   {
     return idxHeader.articleCount;

--- a/src/dict/slob.cc
+++ b/src/dict/slob.cc
@@ -610,12 +610,6 @@ public:
 
   ~SlobDictionary();
 
-
-  map< Dictionary::Property, string > getProperties() noexcept override
-  {
-    return map< Dictionary::Property, string >();
-  }
-
   unsigned long getArticleCount() noexcept override
   {
     return idxHeader.articleCount;

--- a/src/dict/sounddir.cc
+++ b/src/dict/sounddir.cc
@@ -75,12 +75,6 @@ public:
                       vector< string > const & dictionaryFiles,
                       QString const & iconFilename_ );
 
-
-  map< Dictionary::Property, string > getProperties() noexcept override
-  {
-    return map< Dictionary::Property, string >();
-  }
-
   unsigned long getArticleCount() noexcept override
   {
     return idxHeader.soundsCount;

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -134,11 +134,6 @@ public:
 
   ~StardictDictionary();
 
-  map< Dictionary::Property, string > getProperties() noexcept override
-  {
-    return map< Dictionary::Property, string >();
-  }
-
   unsigned long getArticleCount() noexcept override
   {
     return idxHeader.wordCount;

--- a/src/dict/transliteration/transliteration.cc
+++ b/src/dict/transliteration/transliteration.cc
@@ -26,11 +26,6 @@ string BaseTransliterationDictionary::getName() noexcept
   return name;
 }
 
-map< Dictionary::Property, string > BaseTransliterationDictionary::getProperties() noexcept
-{
-  return map< Dictionary::Property, string >();
-}
-
 unsigned long BaseTransliterationDictionary::getArticleCount() noexcept
 {
   return 0;

--- a/src/dict/transliteration/transliteration.hh
+++ b/src/dict/transliteration/transliteration.hh
@@ -28,8 +28,6 @@ public:
 
   virtual string getName() noexcept;
 
-  virtual map< Dictionary::Property, string > getProperties() noexcept;
-
   virtual unsigned long getArticleCount() noexcept;
 
   virtual unsigned long getWordCount() noexcept;

--- a/src/dict/voiceengines.cc
+++ b/src/dict/voiceengines.cc
@@ -47,10 +47,6 @@ public:
     return voiceEngine.name.toUtf8().data();
   }
 
-  map< Property, string > getProperties() noexcept override
-  {
-    return map< Property, string >();
-  }
 
   unsigned long getArticleCount() noexcept override
   {

--- a/src/dict/website.cc
+++ b/src/dict/website.cc
@@ -52,12 +52,6 @@ public:
     dictionaryDescription = urlTemplate_;
   }
 
-
-  map< Property, string > getProperties() noexcept override
-  {
-    return map< Property, string >();
-  }
-
   unsigned long getArticleCount() noexcept override
   {
     return 0;

--- a/src/dict/xdxf.cc
+++ b/src/dict/xdxf.cc
@@ -140,12 +140,6 @@ public:
 
   ~XdxfDictionary();
 
-
-  map< Dictionary::Property, string > getProperties() noexcept override
-  {
-    return map< Dictionary::Property, string >();
-  }
-
   unsigned long getArticleCount() noexcept override
   {
     return idxHeader.articleCount;

--- a/src/dict/zim.cc
+++ b/src/dict/zim.cc
@@ -161,11 +161,6 @@ public:
   ~ZimDictionary() = default;
 
 
-  map< Dictionary::Property, string > getProperties() noexcept override
-  {
-    return {};
-  }
-
   unsigned long getArticleCount() noexcept override
   {
     return idxHeader.articleCount;

--- a/src/dict/zipsounds.cc
+++ b/src/dict/zipsounds.cc
@@ -107,10 +107,6 @@ public:
 
   string getName() noexcept override;
 
-  map< Dictionary::Property, string > getProperties() noexcept override
-  {
-    return map< Dictionary::Property, string >();
-  }
 
   unsigned long getArticleCount() noexcept override
   {


### PR DESCRIPTION
Pure deletion.

It was never used because every dictionary format's Description is a bulk of text.
