### PR TITLE
dev: generally improve cmake build script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25) # ubuntu 23.04 Fedora 36
+cmake_minimum_required(VERSION 3.25) # Debian 11 Ubuntu 24.04 Fedora 36
 
 option(WITH_FFMPEG_PLAYER "Enable support for FFMPEG player" ON)
 option(WITH_EPWING_SUPPORT "Enable epwing support" ON)
@@ -9,8 +9,6 @@ option(WITH_TTS "enable QTexttoSpeech support" OFF)
 option(USE_SYSTEM_FMT "use system fmt instead of bundled one" OFF)
 option(USE_SYSTEM_TOML "use system toml++ instead of bundled one" OFF)
 
-option(WITH_VCPKG_BREAKPAD "build with Breakpad support for VCPKG build only" OFF)
-
 ## Change binary & resources folder to parallel install with original GD.
 ## This flag should be avoided because it leads to small regressions:
 ## 1. There are personal scripts assuming the binary name to be "goldendict" -> require everyone to change the name in their script
@@ -18,8 +16,7 @@ option(WITH_VCPKG_BREAKPAD "build with Breakpad support for VCPKG build only" OF
 ## 3. There are dictionary packages that install files to "/usr/share/goldendict/content" -> nullify the auto dict discovery
 option(USE_ALTERNATIVE_NAME "Force the name goldendict-ng " OFF)
 
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}") # to put staff in the ./cmake folder
-
+option(WITH_VCPKG_BREAKPAD "build with Breakpad support for VCPKG build only" OFF)
 
 # vcpkg handling code, must be placed before project()
 if (WIN32)
@@ -49,7 +46,7 @@ include(FeatureSummary)
 project(goldendict-ng
         VERSION 24.11.0
         LANGUAGES CXX C)
-        
+
 if (APPLE)
     enable_language(OBJCXX)
     set(CMAKE_OBJCXX_STANDARD 17)
@@ -60,13 +57,12 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(GOLDENDICT "goldendict") # binary/executable name
-if (USE_ALTERNATIVE_NAME )
+if (USE_ALTERNATIVE_NAME)
     set(GOLDENDICT "goldendict-ng")
 endif ()
 if (APPLE)
     set(GOLDENDICT "GoldenDict-ng")
-endif()
-
+endif ()
 
 #### Qt
 
@@ -82,7 +78,6 @@ qt_standard_project_setup() # availiable after find_package(Qt6 .... Core
 set(CMAKE_AUTORCC ON) # not included in the qt_standard_project_setup
 
 #### Things required during configuration
-
 block() # generate version.txt
     string(TIMESTAMP build_time UTC)
     find_package(Git)
@@ -163,7 +158,7 @@ target_link_libraries(${GOLDENDICT} PRIVATE
         Qt6::WebEngineWidgets
         Qt6::Widgets
         Qt6::Svg
-        )
+)
 
 if (WITH_TTS)
     target_link_libraries(${GOLDENDICT} PRIVATE Qt6::TextToSpeech)
@@ -176,11 +171,7 @@ target_include_directories(${GOLDENDICT} PRIVATE
         ${PROJECT_SOURCE_DIR}/src/dict
         ${PROJECT_SOURCE_DIR}/src/dict/utils
         ${PROJECT_SOURCE_DIR}/src/ui
-        )
-
-if (WIN32)
-    target_include_directories(${GOLDENDICT} PRIVATE ${PROJECT_SOURCE_DIR}/src/windows)
-endif ()
+)
 
 if (NOT USE_SYSTEM_TOML)
     target_include_directories(${GOLDENDICT} PRIVATE ${PROJECT_SOURCE_DIR}/thirdparty/tomlplusplus)
@@ -199,15 +190,13 @@ target_compile_definitions(${GOLDENDICT} PRIVATE
 )
 
 target_compile_definitions(${GOLDENDICT} PUBLIC
-        CMAKE_USED_HACK  # temporal hack to avoid breaking qmake build
         MAKE_QTMULTIMEDIA_PLAYER
         MAKE_CHINESE_CONVERSION_SUPPORT
-        )
+)
 
 if (WIN32)
     target_compile_definitions(${GOLDENDICT} PUBLIC
             __WIN32
-            INCLUDE_LIBRARY_PATH
     )
 endif ()
 
@@ -215,10 +204,9 @@ if (WITH_FFMPEG_PLAYER)
     target_compile_definitions(${GOLDENDICT} PUBLIC MAKE_FFMPEG_PLAYER)
 endif ()
 
-if(NOT WITH_TTS)
+if (NOT WITH_TTS)
     target_compile_definitions(${GOLDENDICT} PUBLIC NO_TTS_SUPPORT)
-endif()
-
+endif ()
 
 if (NOT WITH_EPWING_SUPPORT)
     target_compile_definitions(${GOLDENDICT} PUBLIC NO_EPWING_SUPPORT)
@@ -235,9 +223,9 @@ endif ()
 #### libraries linking && includes for Win or Unix
 
 if (WIN32)
-    include(Deps_Vcpkg)
+    include(cmake/Deps_Vcpkg.cmake)
 else ()
-    include(Deps_Unix)
+    include(cmake/Deps_Unix.cmake)
 endif ()
 
 #### add translations
@@ -261,156 +249,11 @@ add_dependencies(${GOLDENDICT} "release_translations")
 #### installation or assemble redistribution
 
 if (APPLE)
-    set(PLIST_FILE "${CMAKE_BINARY_DIR}/info_generated.plist")
-    configure_file("${CMAKE_SOURCE_DIR}/redist/mac_info_plist_template_cmake.plist" "${PLIST_FILE}" @ONLY)
-
-    set_target_properties(${GOLDENDICT} PROPERTIES
-            MACOSX_BUNDLE TRUE
-            MACOSX_BUNDLE_INFO_PLIST "${PLIST_FILE}"
-    )
-
-    set(Assembling_Dir "${CMAKE_BINARY_DIR}/redist")
-    set(App_Name "${GOLDENDICT}.app")
-    set(Redistributable_APP "${Assembling_Dir}/${App_Name}")
-
-    # if anything wrong, delete this and affect lines, and see what's Qt will generate by default.
-    set(QtConfPath "${Redistributable_APP}/Contents/Resources/qt.conf")
-
-    qt_generate_deploy_script(
-            TARGET ${GOLDENDICT}
-            OUTPUT_SCRIPT deploy_script
-            CONTENT "
-            set(QT_DEPLOY_PREFIX \"${Redistributable_APP}\")
-            set(QT_DEPLOY_TRANSLATIONS_DIR \"Contents/Resources/translations\")
-            qt_deploy_runtime_dependencies(
-                        EXECUTABLE \"${Redistributable_APP}\"
-                        ADDITIONAL_LIBRARIES ${BREW_ICU_ADDITIONAL_DYLIBS}
-                        GENERATE_QT_CONF
-                        NO_APP_STORE_COMPLIANCE)
-            qt_deploy_translations()
-            qt_deploy_qt_conf(\"${QtConfPath}\"
-                         PLUGINS_DIR PlugIns
-                         TRANSLATIONS_DIR Resources/translations)
-            "
-    )
-
-    install(TARGETS ${GOLDENDICT} BUNDLE DESTINATION "${Assembling_Dir}")
-    install(FILES ${qm_files} DESTINATION "${Redistributable_APP}/Contents/MacOS/locale")
-
-    if (IS_READABLE "/opt/homebrew/share/opencc/")
-        set(OPENCC_DATA_PATH "/opt/homebrew/share/opencc/" CACHE PATH "opencc's data path")
-    elseif (IS_READABLE "/usr/local/share/opencc/")
-        set(OPENCC_DATA_PATH "/usr/local/share/opencc/" CACHE PATH "opencc's data path")
-    else ()
-        message(FATAL_ERROR "Cannot find opencc's data folder!")
-    endif ()
-
-    file(REAL_PATH "${OPENCC_DATA_PATH}" OPENCC_DATA_PATH_FOR_REAL)
-
-    message(STATUS "OPENCC data is found -> ${OPENCC_DATA_PATH_FOR_REAL}")
-    install(DIRECTORY "${OPENCC_DATA_PATH_FOR_REAL}" DESTINATION "${Redistributable_APP}/Contents/MacOS")
-
-    install(SCRIPT ${deploy_script})
-
-    install(CODE "execute_process(COMMAND codesign --force --deep -s - ${Redistributable_APP})")
-
-    find_program(CREATE-DMG "create-dmg")
-    if (CREATE-DMG)
-        install(CODE "
-        execute_process(COMMAND ${CREATE-DMG} \
-            --skip-jenkins \
-            --format \"ULMO\"
-            --volname ${CMAKE_PROJECT_NAME}-${CMAKE_PROJECT_VERSION}-${CMAKE_SYSTEM_PROCESSOR} \
-            --volicon ${CMAKE_SOURCE_DIR}/icons/macicon.icns \
-            --icon \"${App_Name}\" 100 100
-            --app-drop-link 300 100 \
-            \"GoldenDict-ng-${CMAKE_PROJECT_VERSION}-Qt${Qt6_VERSION}-macOS-${CMAKE_SYSTEM_PROCESSOR}.dmg\" \
-            \"${Assembling_Dir}\")"
-        )
-    else ()
-        message(WARNING "create-dmg not found. No .dmg will be created")
-    endif ()
-
-endif ()
-
-if (LINUX OR BSD)
-    install(TARGETS ${GOLDENDICT})
-    install(FILES ${CMAKE_SOURCE_DIR}/redist/io.github.xiaoyifang.goldendict_ng.desktop DESTINATION share/applications)
-    install(FILES ${CMAKE_SOURCE_DIR}/redist/io.github.xiaoyifang.goldendict_ng.metainfo.xml DESTINATION share/metainfo)
-
-    if (NOT USE_ALTERNATIVE_NAME)
-        # see: config.cc -> getProgramDataDir
-        add_compile_definitions(PROGRAM_DATA_DIR="${CMAKE_INSTALL_PREFIX}/share/goldendict")
-        install(FILES ${CMAKE_SOURCE_DIR}/redist/icons/goldendict.png DESTINATION share/pixmaps)
-        install(FILES ${qm_files} DESTINATION share/goldendict/locale)
-    else ()
-        add_compile_definitions(PROGRAM_DATA_DIR="${CMAKE_INSTALL_PREFIX}/share/goldendict-ng")
-        install(FILES ${CMAKE_SOURCE_DIR}/redist/icons/goldendict.png DESTINATION share/pixmaps
-                RENAME goldendict-ng.png)
-        install(FILES ${qm_files} DESTINATION share/goldendict-ng/locale)
-
-        block() # patch the desktop file to adapt the binary & icon file's name change
-            file(READ "${CMAKE_SOURCE_DIR}/redist/io.github.xiaoyifang.goldendict_ng.desktop" DESKTOP_FILE_CONTENT)
-            string(REGEX REPLACE "\nIcon=goldendict\n" "\nIcon=goldendict-ng\n" DESKTOP_FILE_CONTENT "${DESKTOP_FILE_CONTENT}")
-            string(REGEX REPLACE "\nExec=goldendict %u\n" "\nExec=goldendict-ng %u\n" DESKTOP_FILE_CONTENT "${DESKTOP_FILE_CONTENT}")
-            file(WRITE "${CMAKE_SOURCE_DIR}/redist/io.github.xiaoyifang.goldendict_ng.desktop" "${DESKTOP_FILE_CONTENT}")
-        endblock()
-    endif ()
-endif ()
-
-if (WIN32)
-
-    set_target_properties(${GOLDENDICT}
-            PROPERTIES
-            WIN32_EXECUTABLE TRUE
-            RUNTIME_OUTPUT_DIRECTORY "${GD_WIN_OUTPUT_DIR}"
-            LIBRARY_OUTPUT_DIRECTORY "${GD_WIN_OUTPUT_DIR}"
-    )
-
-    set(CMAKE_INSTALL_PREFIX "${GD_WIN_OUTPUT_DIR}" CACHE PATH "If you see this message, don't change this unless you want look into CMake build script. If you are an expert, yes, this is wrong. Help welcomed." FORCE)
-
-    qt_generate_deploy_script(
-            TARGET ${GOLDENDICT}
-            OUTPUT_SCRIPT deploy_script
-            CONTENT "qt_deploy_runtime_dependencies(
-                    EXECUTABLE \"${CMAKE_INSTALL_PREFIX}/goldendict.exe\"
-                    BIN_DIR .
-                    LIB_DIR .
-            )"
-    )
-
-    install(SCRIPT ${deploy_script})
-    install(DIRECTORY "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/share/opencc" DESTINATION .)
-    # TODO: do we really need to carry a copy of openSSL?
-    install(FILES "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/libssl-3-x64.dll" DESTINATION .)
-    install(FILES "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/libcrypto-3-x64.dll" DESTINATION .)
-
-    # trick CPack to make the output folder as NSIS installer
-    install(DIRECTORY "${GD_WIN_OUTPUT_DIR}/"
-            DESTINATION .
-            FILES_MATCHING
-            PATTERN "*"
-            PATTERN "*.pdb" EXCLUDE
-            PATTERN "*.ilk" EXCLUDE)
-
-
-    set(CPACK_PACKAGE_FILE_NAME "GoldenDict-ng-${PROJECT_VERSION}-Qt${Qt6Widgets_VERSION}")
-    set(CPACK_GENERATOR "7Z;NSIS64")
-
-    # override the default install path, which is $PROGRAMFILES64\${project-name} ${project-version} in NSIS
-    set(CPACK_PACKAGE_INSTALL_DIRECTORY "GoldenDict-ng")
-
-    # NSIS specificS
-    set(CPACK_NSIS_MANIFEST_DPI_AWARE ON)
-    set(CPACK_NSIS_MUI_ICON "${CMAKE_SOURCE_DIR}/icons/programicon.ico")
-    set(CPACK_NSIS_PACKAGE_NAME "${CMAKE_PROJECT_NAME}-${CMAKE_PROJECT_VERSION}")
-    set(CPACK_NSIS_DISPLAY_NAME "${CMAKE_PROJECT_NAME}-${CMAKE_PROJECT_VERSION}")
-    set(CPACK_NSIS_URL_INFO_ABOUT [=[https://xiaoyifang.github.io/goldendict-ng/]=])
-    set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.txt")
-    set(CPACK_NSIS_CREATE_ICONS_EXTRA "CreateShortCut '$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\GoldenDict-ng.lnk' '$INSTDIR\\\\${GOLDENDICT}.exe'")
-    set(CPACK_NSIS_DELETE_ICONS_EXTRA "Delete '$SMPROGRAMS\\\\$START_MENU\\\\GoldenDict-ng.lnk'")
-
-    include(CPack)
+    include(cmake/Package_macOS.cmake)
+elseif (LINUX OR BSD)
+    include(cmake/Package_Linux.cmake)
+elseif (WIN32)
+    include(cmake/Package_Windows.cmake)
 endif ()
 
 feature_summary(WHAT ALL DESCRIPTION "Build configuration:")

--- a/cmake/Deps_Unix.cmake
+++ b/cmake/Deps_Unix.cmake
@@ -1,5 +1,4 @@
 #### Various workarounds
-
 if (APPLE)
     # old & new homebrew's include paths
     target_include_directories(${GOLDENDICT} PRIVATE /usr/local/include /opt/homebrew/include)
@@ -29,25 +28,21 @@ endif ()
 ##### Finding packages from package manager
 
 find_package(PkgConfig REQUIRED)
-find_package(ZLIB REQUIRED)
-find_package(BZip2 REQUIRED)
 
-# Consider all PkgConfig dependencies as one
-pkg_check_modules(PKGCONFIG_DEPS IMPORTED_TARGET
+# Import all PkgConfig dependencies as one
+pkg_check_modules(DEPS REQUIRED IMPORTED_TARGET
+        bzip2
         hunspell
+        liblzma
         lzo2
         opencc
         vorbis # .ogg
         vorbisfile
-        liblzma
         xapian-core
+        zlib
 )
 
-target_link_libraries(${GOLDENDICT} PRIVATE
-        PkgConfig::PKGCONFIG_DEPS
-        BZip2::BZip2
-        ZLIB::ZLIB
-)
+target_link_libraries(${GOLDENDICT} PRIVATE PkgConfig::DEPS)
 
 # On FreeBSD, there are two iconv, libc iconv & GNU libiconv.
 # The system one is good enough, the following is a workaround to use libc iconv on freeBSD.
@@ -88,7 +83,7 @@ if (WITH_ZIM)
                 COMMAND_ERROR_IS_FATAL ANY)
         message(STATUS "Found correct homebrew icu path -> ${ICU_REQUIRED_BY_ZIM_PREFIX}")
         set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:${ICU_REQUIRED_BY_ZIM_PREFIX}/lib/pkgconfig")
-        message(STATUS "Updated pkg_config_path -> $ENV{PKG_CONFIG_PATH}:${ICU_REQUIRED_BY_ZIM_PREFIX}/lib/pkgconfig")
+        message(STATUS "Updated pkg_config_path -> $ENV{PKG_CONFIG_PATH}")
 
         # icu4c as transitive dependency of libzim may not be automatically copied into app bundle
         # so we manually discover the icu4c from homebrew, then find the relevent dylibs

--- a/cmake/Package_Linux.cmake
+++ b/cmake/Package_Linux.cmake
@@ -1,0 +1,22 @@
+install(TARGETS ${GOLDENDICT})
+install(FILES ${CMAKE_SOURCE_DIR}/redist/io.github.xiaoyifang.goldendict_ng.desktop DESTINATION share/applications)
+install(FILES ${CMAKE_SOURCE_DIR}/redist/io.github.xiaoyifang.goldendict_ng.metainfo.xml DESTINATION share/metainfo)
+
+if (NOT USE_ALTERNATIVE_NAME)
+    # see: config.cc -> getProgramDataDir
+    add_compile_definitions(PROGRAM_DATA_DIR="${CMAKE_INSTALL_PREFIX}/share/goldendict")
+    install(FILES ${CMAKE_SOURCE_DIR}/redist/icons/goldendict.png DESTINATION share/pixmaps)
+    install(FILES ${qm_files} DESTINATION share/goldendict/locale)
+else ()
+    add_compile_definitions(PROGRAM_DATA_DIR="${CMAKE_INSTALL_PREFIX}/share/goldendict-ng")
+    install(FILES ${CMAKE_SOURCE_DIR}/redist/icons/goldendict.png DESTINATION share/pixmaps
+            RENAME goldendict-ng.png)
+    install(FILES ${qm_files} DESTINATION share/goldendict-ng/locale)
+
+    block() # patch the desktop file to adapt the binary & icon file's name change
+        file(READ "${CMAKE_SOURCE_DIR}/redist/io.github.xiaoyifang.goldendict_ng.desktop" DESKTOP_FILE_CONTENT)
+        string(REGEX REPLACE "\nIcon=goldendict\n" "\nIcon=goldendict-ng\n" DESKTOP_FILE_CONTENT "${DESKTOP_FILE_CONTENT}")
+        string(REGEX REPLACE "\nExec=goldendict %u\n" "\nExec=goldendict-ng %u\n" DESKTOP_FILE_CONTENT "${DESKTOP_FILE_CONTENT}")
+        file(WRITE "${CMAKE_SOURCE_DIR}/redist/io.github.xiaoyifang.goldendict_ng.desktop" "${DESKTOP_FILE_CONTENT}")
+    endblock()
+endif ()

--- a/cmake/Package_Windows.cmake
+++ b/cmake/Package_Windows.cmake
@@ -1,0 +1,55 @@
+set_target_properties(${GOLDENDICT}
+        PROPERTIES
+        WIN32_EXECUTABLE TRUE
+        RUNTIME_OUTPUT_DIRECTORY "${GD_WIN_OUTPUT_DIR}"
+        LIBRARY_OUTPUT_DIRECTORY "${GD_WIN_OUTPUT_DIR}"
+)
+
+# TODO: this breaks "Multi-Config" build systems like VisualStudio.
+set(CMAKE_INSTALL_PREFIX "${GD_WIN_OUTPUT_DIR}" CACHE PATH "If you see this message, don't change this unless you want look into CMake build script. If you are an expert, yes, this is wrong. Help welcomed." FORCE)
+
+qt_generate_deploy_script(
+        TARGET ${GOLDENDICT}
+        OUTPUT_SCRIPT deploy_script
+        CONTENT "qt_deploy_runtime_dependencies(
+                EXECUTABLE \"${CMAKE_INSTALL_PREFIX}/goldendict.exe\"
+                BIN_DIR .
+                LIB_DIR .
+        )"
+)
+
+install(SCRIPT ${deploy_script})
+install(DIRECTORY "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/share/opencc" DESTINATION .)
+# Note: This is runtime dependency that aren't copied automatically
+# See Qt's network -> SSDL documentation https://doc.qt.io/qt-6/ssl.html#considerations-while-packaging-your-application
+install(FILES "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/libssl-3-x64.dll" DESTINATION .)
+install(FILES "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/libcrypto-3-x64.dll" DESTINATION .)
+
+# trick CPack to make the output folder as NSIS installer
+install(DIRECTORY "${GD_WIN_OUTPUT_DIR}/"
+        DESTINATION .
+        FILES_MATCHING
+        PATTERN "*"
+        PATTERN "*.pdb" EXCLUDE
+        PATTERN "*.ilk" EXCLUDE)
+
+
+set(CPACK_PACKAGE_FILE_NAME "GoldenDict-ng-${PROJECT_VERSION}-Qt${Qt6Widgets_VERSION}")
+set(CPACK_GENERATOR "7Z;NSIS64")
+
+# override the default install path, which is $PROGRAMFILES64\${project-name} ${project-version} in NSIS
+set(CPACK_PACKAGE_INSTALL_DIRECTORY "GoldenDict-ng")
+
+# NSIS specificS
+set(CPACK_NSIS_MANIFEST_DPI_AWARE ON)
+set(CPACK_NSIS_MUI_ICON "${CMAKE_SOURCE_DIR}/icons/programicon.ico")
+set(CPACK_NSIS_PACKAGE_NAME "${CMAKE_PROJECT_NAME}-${CMAKE_PROJECT_VERSION}")
+set(CPACK_NSIS_DISPLAY_NAME "${CMAKE_PROJECT_NAME}-${CMAKE_PROJECT_VERSION}")
+
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.txt")
+
+# Copied from https://crascit.com/2015/08/07/cmake_cpack_nsis_shortcuts_with_parameters/
+set(CPACK_NSIS_CREATE_ICONS_EXTRA "CreateShortCut '$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\GoldenDict-ng.lnk' '$INSTDIR\\\\${GOLDENDICT}.exe'")
+set(CPACK_NSIS_DELETE_ICONS_EXTRA "Delete '$SMPROGRAMS\\\\$START_MENU\\\\GoldenDict-ng.lnk'")
+
+include(CPack)

--- a/cmake/Package_macOS.cmake
+++ b/cmake/Package_macOS.cmake
@@ -1,0 +1,69 @@
+set(PLIST_FILE "${CMAKE_BINARY_DIR}/info_generated.plist")
+configure_file("${CMAKE_SOURCE_DIR}/redist/mac_info_plist_template_cmake.plist" "${PLIST_FILE}" @ONLY)
+
+set_target_properties(${GOLDENDICT} PROPERTIES
+        MACOSX_BUNDLE TRUE
+        MACOSX_BUNDLE_INFO_PLIST "${PLIST_FILE}"
+)
+
+set(Assembling_Dir "${CMAKE_BINARY_DIR}/redist")
+set(App_Name "${GOLDENDICT}.app")
+set(Redistributable_APP "${Assembling_Dir}/${App_Name}")
+
+# if anything wrong, delete this and affect lines, and see what's Qt will generate by default.
+set(QtConfPath "${Redistributable_APP}/Contents/Resources/qt.conf")
+
+qt_generate_deploy_script(
+        TARGET ${GOLDENDICT}
+        OUTPUT_SCRIPT deploy_script
+        CONTENT "
+        set(QT_DEPLOY_PREFIX \"${Redistributable_APP}\")
+        set(QT_DEPLOY_TRANSLATIONS_DIR \"Contents/Resources/translations\")
+        qt_deploy_runtime_dependencies(
+                    EXECUTABLE \"${Redistributable_APP}\"
+                    ADDITIONAL_LIBRARIES ${BREW_ICU_ADDITIONAL_DYLIBS}
+                    GENERATE_QT_CONF
+                    NO_APP_STORE_COMPLIANCE)
+        qt_deploy_translations()
+        qt_deploy_qt_conf(\"${QtConfPath}\"
+                     PLUGINS_DIR PlugIns
+                     TRANSLATIONS_DIR Resources/translations)
+        "
+)
+
+install(TARGETS ${GOLDENDICT} BUNDLE DESTINATION "${Assembling_Dir}")
+install(FILES ${qm_files} DESTINATION "${Redistributable_APP}/Contents/MacOS/locale")
+
+if (IS_READABLE "/opt/homebrew/share/opencc/")
+    set(OPENCC_DATA_PATH "/opt/homebrew/share/opencc/" CACHE PATH "opencc's data path")
+elseif (IS_READABLE "/usr/local/share/opencc/")
+    set(OPENCC_DATA_PATH "/usr/local/share/opencc/" CACHE PATH "opencc's data path")
+else ()
+    message(FATAL_ERROR "Cannot find opencc's data folder!")
+endif ()
+
+file(REAL_PATH "${OPENCC_DATA_PATH}" OPENCC_DATA_PATH_FOR_REAL)
+
+message(STATUS "OPENCC data is found -> ${OPENCC_DATA_PATH_FOR_REAL}")
+install(DIRECTORY "${OPENCC_DATA_PATH_FOR_REAL}" DESTINATION "${Redistributable_APP}/Contents/MacOS")
+
+install(SCRIPT ${deploy_script})
+
+install(CODE "execute_process(COMMAND codesign --force --deep -s - ${Redistributable_APP})")
+
+find_program(CREATE-DMG "create-dmg")
+if (CREATE-DMG)
+    install(CODE "
+    execute_process(COMMAND ${CREATE-DMG} \
+        --skip-jenkins \
+        --format \"ULMO\"
+        --volname ${CMAKE_PROJECT_NAME}-${CMAKE_PROJECT_VERSION}-${CMAKE_SYSTEM_PROCESSOR} \
+        --volicon ${CMAKE_SOURCE_DIR}/icons/macicon.icns \
+        --icon \"${App_Name}\" 100 100
+        --app-drop-link 300 100 \
+        \"GoldenDict-ng-${CMAKE_PROJECT_VERSION}-Qt${Qt6_VERSION}-macOS-${CMAKE_SYSTEM_PROCESSOR}.dmg\" \
+        \"${Assembling_Dir}\")"
+    )
+else ()
+    message(WARNING "create-dmg not found. No .dmg will be created")
+endif ()

--- a/src/dict/hunspell.cc
+++ b/src/dict/hunspell.cc
@@ -15,12 +15,7 @@
 #include <set>
 #include "utils.hh"
 #include <QtConcurrentRun>
-
-#ifndef INCLUDE_LIBRARY_PATH
-  #include <hunspell.hxx>
-#else
-  #include <hunspell/hunspell.hxx>
-#endif
+#include <hunspell/hunspell.hxx>
 
 namespace HunspellMorpho {
 


### PR DESCRIPTION
* split packaging code of three platforms into separate files
* add and correct comments
* using PkgConfig as much as possible (pkgconfig is the de facto standard now days. All competitors of CMake will support it first, and users of libraries will demand library authors to support PkgConfig because some of them don't use CMake. CMake's specific `<PackageName>-config.cmake` files should just die in general for public projects and for public use.)
* delete outdated macros