### PR TITLE
feat: auto dark reader mode for Windows

### DIFF
--- a/src/article_maker.cc
+++ b/src/article_maker.cc
@@ -161,7 +161,10 @@ std::string ArticleMaker::makeHtmlHeader( QString const & word, QString const & 
 
 #if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
   if ( GlobalBroadcaster::instance()->getPreference()->darkReaderMode == Config::Dark::Auto
-       && QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark ) {
+  #if !defined( Q_OS_WINDOWS ) // not properly works on Windows.
+       && QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark
+  #endif
+       && GlobalBroadcaster::instance()->getPreference()->darkMode == Config::Dark::On ) {
     darkReaderModeEnabled = true;
   }
 #endif


### PR DESCRIPTION
Not a proper way to do that after qt6.8 due to [the new API](https://doc.qt.io/qt-6/qstylehints.html#colorScheme-prop), but it just works on 6.7 or older.

and I'm not sure whether the dark mode's switch should be considered into auto mode in other platforms.
