### PR TITLE
clean: delete a non-existential "welcome tab" widget

### DIFF
--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -41,25 +41,6 @@
       <property name="elideMode">
        <enum>Qt::ElideRight</enum>
       </property>
-      <widget class="QWidget" name="tab">
-       <attribute name="title">
-        <string>Welcome!</string>
-       </attribute>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
-       </layout>
-      </widget>
      </widget>
     </item>
    </layout>


### PR DESCRIPTION
This widget never even exists.

Looks like a placeholder before the current "Welcome" page.

Note the inconsistent parent-child relationship between generated code & the ui file. This probably runes into undefined corner case. (I hate ui file.)

<img width="400px" src="https://github.com/user-attachments/assets/2940aecc-f5f9-4016-adea-f970d094949e">
<img width="400px" src="https://github.com/user-attachments/assets/cf4baea6-6bb2-443b-b090-3a2c19ca377e">

