### PR TITLE
refactor: default to Qt Multimedia and delete default player shenanigans

### DIFF
--- a/src/audio/README.md
+++ b/src/audio/README.md
@@ -1,3 +1,1 @@
 Code to support GD's internal/external audio players.
-
-Only `audioplayerinterface.hh` is supposed to be used outside this folder.

--- a/src/audio/audioplayerfactory.cc
+++ b/src/audio/audioplayerfactory.cc
@@ -5,8 +5,6 @@
 #include <QObject>
 #include <utility>
 #include "audioplayerfactory.hh"
-#include "ffmpegaudioplayer.hh"
-#include "multimediaaudioplayer.hh"
 #include "externalaudioplayer.hh"
 
 AudioPlayerFactory::AudioPlayerFactory( bool useInternalPlayer,
@@ -48,29 +46,8 @@ void AudioPlayerFactory::setPreferences( bool new_useInternalPlayer,
 void AudioPlayerFactory::reset()
 {
   if ( useInternalPlayer ) {
-    // qobject_cast checks below account for the case when an unsupported backend
-    // is stored in config. After this backend is replaced with the default one
-    // upon preferences saving, the code below does not reset playerPtr with
-    // another object of the same type.
-
-#ifdef MAKE_FFMPEG_PLAYER
-    Q_ASSERT( InternalPlayerBackend::defaultBackend().isFfmpeg()
-              && "Adjust the code below after changing the default backend." );
-
-    if ( !internalPlayerBackend.isQtmultimedia() ) {
-      if ( !playerPtr || !qobject_cast< Ffmpeg::AudioPlayer * >( playerPtr.data() ) ) {
-        playerPtr.reset( new Ffmpeg::AudioPlayer );
-      }
-      return;
-    }
-#endif
-
-#ifdef MAKE_QTMULTIMEDIA_PLAYER
-    if ( !playerPtr || !qobject_cast< MultimediaAudioPlayer * >( playerPtr.data() ) ) {
-      playerPtr.reset( new MultimediaAudioPlayer );
-    }
+    playerPtr.reset( internalPlayerBackend.getActualPlayer() );
     return;
-#endif
   }
 
   std::unique_ptr< ExternalAudioPlayer > externalPlayer( new ExternalAudioPlayer );

--- a/src/audio/internalplayerbackend.hh
+++ b/src/audio/internalplayerbackend.hh
@@ -1,4 +1,8 @@
 #pragma once
+#include "audioplayerinterface.hh"
+#include "ffmpegaudioplayer.hh"
+#include "multimediaaudioplayer.hh"
+#include <QScopedPointer>
 #include <QStringList>
 
 /// Overly engineered dummy/helper/wrapper "backend", which is not, to manage backends.
@@ -7,22 +11,17 @@ class InternalPlayerBackend
 public:
   /// Returns true if at least one backend is available.
   static bool anyAvailable();
-  /// Returns the default backend or null backend if none is available.
-  static InternalPlayerBackend defaultBackend();
+  AudioPlayerInterface * getActualPlayer();
   /// Returns the name list of supported backends.
-  static QStringList nameList();
+  /// The first one willl be the default one
+  static QStringList availableBackends();
 
-  /// Returns true if built with FFmpeg player support and the name matches.
-  bool isFfmpeg() const;
-  /// Returns true if built with Qt Multimedia player support and the name matches.
-  bool isQtmultimedia() const;
-
-  QString const & uiName() const
+  QString const & getName() const
   {
     return name;
   }
 
-  void setUiName( QString const & name_ )
+  void setName( QString const & name_ )
   {
     name = name_;
   }
@@ -38,24 +37,5 @@ public:
   }
 
 private:
-#ifdef MAKE_FFMPEG_PLAYER
-  static InternalPlayerBackend ffmpeg()
-  {
-    return InternalPlayerBackend( "FFmpeg" );
-  }
-#endif
-
-#ifdef MAKE_QTMULTIMEDIA_PLAYER
-  static InternalPlayerBackend qtmultimedia()
-  {
-    return InternalPlayerBackend( "Qt Multimedia" );
-  }
-#endif
-
-  explicit InternalPlayerBackend( QString const & name_ ):
-    name( name_ )
-  {
-  }
-
   QString name;
 };

--- a/src/config.cc
+++ b/src/config.cc
@@ -180,7 +180,6 @@ Preferences::Preferences():
   pronounceOnLoadMain( false ),
   pronounceOnLoadPopup( false ),
   useInternalPlayer( InternalPlayerBackend::anyAvailable() ),
-  internalPlayerBackend( InternalPlayerBackend::defaultBackend() ),
   checkForNewReleases( true ),
   disallowContentFromOtherSites( false ),
   hideGoldenDictHeader( false ),
@@ -951,7 +950,7 @@ Class load()
     }
 
     if ( !preferences.namedItem( "internalPlayerBackend" ).isNull() ) {
-      c.preferences.internalPlayerBackend.setUiName(
+      c.preferences.internalPlayerBackend.setName(
         preferences.namedItem( "internalPlayerBackend" ).toElement().text() );
     }
 
@@ -1918,7 +1917,7 @@ void save( Class const & c )
     preferences.appendChild( opt );
 
     opt = dd.createElement( "internalPlayerBackend" );
-    opt.appendChild( dd.createTextNode( c.preferences.internalPlayerBackend.uiName() ) );
+    opt.appendChild( dd.createTextNode( c.preferences.internalPlayerBackend.getName() ) );
     preferences.appendChild( opt );
 
     opt = dd.createElement( "audioPlaybackProgram" );

--- a/src/config.hh
+++ b/src/config.hh
@@ -329,7 +329,7 @@ struct Preferences
   // Whether the word should be pronounced on page load, in main window/popup
   bool pronounceOnLoadMain, pronounceOnLoadPopup;
   bool useInternalPlayer;
-  InternalPlayerBackend internalPlayerBackend;
+  InternalPlayerBackend internalPlayerBackend{};
   QString audioPlaybackProgram;
 
   ProxyServer proxyServer;

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -294,7 +294,7 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   ui.pronounceOnLoadMain->setChecked( p.pronounceOnLoadMain );
   ui.pronounceOnLoadPopup->setChecked( p.pronounceOnLoadPopup );
 
-  ui.internalPlayerBackend->addItems( InternalPlayerBackend::nameList() );
+  ui.internalPlayerBackend->addItems( InternalPlayerBackend::availableBackends() );
 
   // Make sure that exactly one radio button in the group is checked and that
   // on_useExternalPlayer_toggled() is called.
@@ -304,12 +304,13 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
     // Checking ui.useInternalPlayer automatically unchecks ui.useExternalPlayer.
     ui.useInternalPlayer->setChecked( p.useInternalPlayer );
 
-    int index = ui.internalPlayerBackend->findText( p.internalPlayerBackend.uiName() );
-    if ( index < 0 ) { // The specified backend is unavailable.
-      index = ui.internalPlayerBackend->findText( InternalPlayerBackend::defaultBackend().uiName() );
+    int index = ui.internalPlayerBackend->findText( p.internalPlayerBackend.getName() );
+    if ( index >= 0 ) {
+      ui.internalPlayerBackend->setCurrentIndex( index );
     }
-    Q_ASSERT( index >= 0 && "Logic error: the default backend must be present in the backend name list." );
-    ui.internalPlayerBackend->setCurrentIndex( index );
+    else {
+      // Find no backend, just do nothing and let just let Qt select the first one.
+    }
   }
   else {
     ui.useInternalPlayer->hide();
@@ -493,7 +494,7 @@ Config::Preferences Preferences::getPreferences()
   p.pronounceOnLoadMain  = ui.pronounceOnLoadMain->isChecked();
   p.pronounceOnLoadPopup = ui.pronounceOnLoadPopup->isChecked();
   p.useInternalPlayer    = ui.useInternalPlayer->isChecked();
-  p.internalPlayerBackend.setUiName( ui.internalPlayerBackend->currentText() );
+  p.internalPlayerBackend.setName( ui.internalPlayerBackend->currentText() );
   p.audioPlaybackProgram = ui.audioPlaybackProgram->text();
 
   p.proxyServer.enabled        = ui.useProxyServer->isChecked();


### PR DESCRIPTION
Slightly related to https://github.com/xiaoyifang/goldendict-ng/issues/1738

Because on Linux, qt multimedia can uses the `GStreamer` which uses libspeex and it is not broken.

We currently don't ship FFmpeg backend for Windows & macOS.

If #1738 is not fixable, we can also consider reinstate the FFmpeg backend and build FFmpeg by ourselves.

Changing default back is as simple as changing the order of `availableBackends()`

---


