### PR TITLE
fix: replace default external audio player from `mplayer` to `vlc`

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -497,10 +497,6 @@ Class load()
       c.paths.push_back( Path( getPortableVersionDictionaryDir(), true ) );
     }
 
-#ifndef Q_OS_WIN32
-    c.preferences.audioPlaybackProgram = "mplayer";
-#endif
-
     QString possibleMorphologyPath = getProgramDataDir() + "/content/morphology";
 
     if ( QDir( possibleMorphologyPath ).exists() ) {
@@ -959,7 +955,7 @@ Class load()
       c.preferences.audioPlaybackProgram = preferences.namedItem( "audioPlaybackProgram" ).toElement().text();
     }
     else {
-      c.preferences.audioPlaybackProgram = "mplayer";
+      c.preferences.audioPlaybackProgram = "vlc --intf dummy --play-and-exit";
     }
 
     QDomNode proxy = preferences.namedItem( "proxyserver" );


### PR DESCRIPTION
Inspired by https://github.com/xiaoyifang/goldendict-ng/issues/1738

mplayer project has passed its prime and pretty much replaced by mpv.

Let's change it to vlc (and necessary flags to make it no-gui and quit right after).