### PR TITLE
clean: limit QHotkeyApplication::(un)registerWrapper to Windows only

### DIFF
--- a/src/hotkeywrapper.cc
+++ b/src/hotkeywrapper.cc
@@ -70,6 +70,7 @@ void QHotkeyApplication::hotkeyAppSaveState( QSessionManager & mgr )
   mgr.setRestartHint( QSessionManager::RestartNever );
 }
 
+#ifdef Q_OS_WIN
 void QHotkeyApplication::registerWrapper( HotkeyWrapper * wrapper )
 {
   if ( wrapper && !hotkeyWrappers.contains( wrapper ) ) {
@@ -83,6 +84,7 @@ void QHotkeyApplication::unregisterWrapper( HotkeyWrapper * wrapper )
     hotkeyWrappers.removeAll( wrapper );
   }
 }
+#endif
 
 //////////////////////////////////////////////////////////////////////////
 
@@ -103,7 +105,9 @@ HotkeyWrapper::HotkeyWrapper( QObject * parent ):
   state2( false )
 {
   init();
+  #ifdef Q_OS_WIN
   ( static_cast< QHotkeyApplication * >( qApp ) )->registerWrapper( this );
+  #endif
 }
 
 HotkeyWrapper::~HotkeyWrapper()

--- a/src/hotkeywrapper.hh
+++ b/src/hotkeywrapper.hh
@@ -198,16 +198,15 @@ private slots:
   void hotkeyAppCommitData( QSessionManager & );
 
   void hotkeyAppSaveState( QSessionManager & );
-
+#ifdef Q_OS_WIN
 protected:
   void registerWrapper( HotkeyWrapper * wrapper );
   void unregisterWrapper( HotkeyWrapper * wrapper );
 
-#ifdef Q_OS_WIN
   virtual bool nativeEventFilter( const QByteArray & eventType, void * message, qintptr * result );
-#endif
 
   QList< HotkeyWrapper * > hotkeyWrappers;
+#endif
 };
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/hotkeywrapper.hh
+++ b/src/hotkeywrapper.hh
@@ -199,6 +199,7 @@ private slots:
 
   void hotkeyAppSaveState( QSessionManager & );
 #ifdef Q_OS_WIN
+
 protected:
   void registerWrapper( HotkeyWrapper * wrapper );
   void unregisterWrapper( HotkeyWrapper * wrapper );

--- a/src/macos/machotkeywrapper.mm
+++ b/src/macos/machotkeywrapper.mm
@@ -206,8 +206,6 @@ void HotkeyWrapper::unregister()
             UnregisterEventHotKey(hk.hkRef2);
         }
     }
-
-    (static_cast<QHotkeyApplication*>(qApp))->unregisterWrapper(this);
 }
 
 bool HotkeyWrapper::setGlobalKey(QKeySequence const& seq, int handle)

--- a/src/main.cc
+++ b/src/main.cc
@@ -18,8 +18,6 @@
 #include <stdio.h>
 #include <QStyleFactory>
 
-#include "hotkeywrapper.hh" // X11 headers & fixer causes this file must be included last
-
 #if defined( Q_OS_UNIX )
   #include <clocale>
   #include "unix/ksignalhandler.hh"

--- a/src/unix/x11hotkeywrapper.cc
+++ b/src/unix/x11hotkeywrapper.cc
@@ -303,7 +303,6 @@ void HotkeyWrapper::unregister()
   while ( grabbedKeys.size() )
     ungrabKey( grabbedKeys.begin() );
 
-  ( static_cast< QHotkeyApplication * >( qApp ) )->unregisterWrapper( this );
 }
 
 #endif

--- a/src/unix/x11hotkeywrapper.cc
+++ b/src/unix/x11hotkeywrapper.cc
@@ -302,7 +302,6 @@ void HotkeyWrapper::unregister()
 
   while ( grabbedKeys.size() )
     ungrabKey( grabbedKeys.begin() );
-
 }
 
 #endif


### PR DESCRIPTION
These stuffs serve no purpose except for Windows's `nativeEventFilter`.

AFAIK, it is also unnecessary for Windows too, because only one "wrapper" is ever needed. However, right now I don't have access to a Windows machine.


The introduction of `nativeEventFilter`, which was called as `winEventFilter`, in Original commit doesn't explain anything https://github.com/goldendict/goldendict/commit/0b8743547107653d80fc1eec90a96ab57fb1fd33#diff-55edcc575deee8d79439ced3ef499d0a7369bff2be1717395fd5fab7128f5db5R204

Tested on Linux.