### PR TITLE
refactor: remove DataComiiter interfaces from QHotkeyApplication

### DIFF
--- a/src/hotkeywrapper.cc
+++ b/src/hotkeywrapper.cc
@@ -11,17 +11,6 @@
 QHotkeyApplication::QHotkeyApplication( int & argc, char ** argv ):
   QtSingleApplication( argc, argv )
 {
-  connect( this,
-           &QGuiApplication::commitDataRequest,
-           this,
-           &QHotkeyApplication::hotkeyAppCommitData,
-           Qt::DirectConnection );
-
-  connect( this,
-           &QGuiApplication::saveStateRequest,
-           this,
-           &QHotkeyApplication::hotkeyAppSaveState,
-           Qt::DirectConnection );
 
 #if defined( Q_OS_WIN )
   installNativeEventFilter( this );
@@ -31,43 +20,10 @@ QHotkeyApplication::QHotkeyApplication( int & argc, char ** argv ):
 QHotkeyApplication::QHotkeyApplication( QString const & id, int & argc, char ** argv ):
   QtSingleApplication( id, argc, argv )
 {
-  connect( this,
-           &QGuiApplication::commitDataRequest,
-           this,
-           &QHotkeyApplication::hotkeyAppCommitData,
-           Qt::DirectConnection );
-
-  connect( this,
-           &QGuiApplication::saveStateRequest,
-           this,
-           &QHotkeyApplication::hotkeyAppSaveState,
-           Qt::DirectConnection );
 
 #if defined( Q_OS_WIN )
   installNativeEventFilter( this );
 #endif
-}
-
-void QHotkeyApplication::addDataCommiter( DataCommitter & d )
-{
-  dataCommitters.append( &d );
-}
-
-void QHotkeyApplication::removeDataCommiter( DataCommitter & d )
-{
-  dataCommitters.removeAll( &d );
-}
-
-void QHotkeyApplication::hotkeyAppCommitData( QSessionManager & mgr )
-{
-  for ( int x = 0; x < dataCommitters.size(); ++x ) {
-    dataCommitters[ x ]->commitData( mgr );
-  }
-}
-
-void QHotkeyApplication::hotkeyAppSaveState( QSessionManager & mgr )
-{
-  mgr.setRestartHint( QSessionManager::RestartNever );
 }
 
 #ifdef Q_OS_WIN

--- a/src/hotkeywrapper.hh
+++ b/src/hotkeywrapper.hh
@@ -166,13 +166,6 @@ signals:
 
 //////////////////////////////////////////////////////////////////////////
 
-class DataCommitter
-{
-public:
-
-  virtual void commitData( QSessionManager & ) = 0;
-  virtual ~DataCommitter() {}
-};
 
 class QHotkeyApplication: public QtSingleApplication
 #if defined( Q_OS_WIN )
@@ -183,21 +176,10 @@ class QHotkeyApplication: public QtSingleApplication
   Q_OBJECT
 
   friend class HotkeyWrapper;
-
-  QList< DataCommitter * > dataCommitters;
-
 public:
   QHotkeyApplication( int & argc, char ** argv );
   QHotkeyApplication( QString const & id, int & argc, char ** argv );
 
-  void addDataCommiter( DataCommitter & );
-  void removeDataCommiter( DataCommitter & );
-
-private slots:
-  /// This calls all data committers.
-  void hotkeyAppCommitData( QSessionManager & );
-
-  void hotkeyAppSaveState( QSessionManager & );
 #ifdef Q_OS_WIN
 
 protected:

--- a/src/main.cc
+++ b/src/main.cc
@@ -12,6 +12,7 @@
 #include <QIcon>
 #include <QMessageBox>
 #include <QMutex>
+#include <QSessionManager>
 #include <QString>
 #include <QStringBuilder>
 #include <QtWebEngineCore/QWebEngineUrlScheme>
@@ -584,7 +585,24 @@ int main( int argc, char ** argv )
 
   MainWindow m( cfg );
 
-  app.addDataCommiter( m );
+  // Redirect commit data request to Mainwindow's handler.
+  QObject::connect(
+    &app,
+    &QGuiApplication::commitDataRequest,
+    &m,
+    [ &m ]( auto & ) {
+      m.commitData();
+    },
+    Qt::DirectConnection );
+  // Just don't restart. This probably isn't really needed.
+  QObject::connect(
+    &app,
+    &QGuiApplication::saveStateRequest,
+    &app,
+    []( auto & mgr ) {
+      mgr.setRestartHint( QSessionManager::RestartNever );
+    },
+    Qt::DirectConnection );
 
   QObject::connect( &app, &QtSingleApplication::messageReceived, &m, &MainWindow::messageFromAnotherInstanceReceived );
 
@@ -607,8 +625,6 @@ int main( int argc, char ** argv )
   QObject::connect( KSignalHandler::self(), &KSignalHandler::signalReceived, &m, &MainWindow::quitApp );
 #endif
   int r = app.exec();
-
-  app.removeDataCommiter( m );
 
   if ( logFilePtr->isOpen() ) {
     logFilePtr->close();

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1213,11 +1213,6 @@ void MainWindow::removeGroupComboBoxActionsFromDialog( QDialog * dialog, GroupCo
   }
 }
 
-void MainWindow::commitData( QSessionManager & )
-{
-  commitData();
-}
-
 void MainWindow::commitData()
 {
   if ( cfg.preferences.clearNetworkCacheOnExit ) {

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -44,7 +44,7 @@
 using std::string;
 using std::vector;
 
-class MainWindow: public QMainWindow, public DataCommitter
+class MainWindow: public QMainWindow
 {
   Q_OBJECT
 
@@ -53,7 +53,6 @@ public:
   MainWindow( Config::Class & cfg );
   ~MainWindow();
 
-  virtual void commitData( QSessionManager & );
 
   /// Set group for main/popup window
   void setGroupByName( QString const & name, bool main_window );
@@ -68,6 +67,8 @@ public slots:
   void showStatusBarMessage( QString const &, int, QPixmap const & );
   void wordReceived( QString const & );
   void headwordFromFavorites( QString const &, QString const & );
+  /// Save config and states...
+  void commitData();
   void quitApp();
 
 private:
@@ -76,7 +77,6 @@ private:
   void addGroupComboBoxActionsToDialog( QDialog * dialog, GroupComboBox * pGroupComboBox );
   void removeGroupComboBoxActionsFromDialog( QDialog * dialog, GroupComboBox * pGroupComboBox );
 
-  void commitData();
 
   QSystemTrayIcon * trayIcon;
 


### PR DESCRIPTION
The original GD's author probably wants to invent a mechanism.

He wants objects to manage themselves, implement a "DataCommitter" and register themselves in a list, so that before exiting, they will all be saved.

However, MainWindow's commitData is the only thing that do the work for such long time.

Let's just reduce the whole thing into simply `QObject::connnect`.
