### PR TITLE
fix Hunspell regression related to encoding

### DIFF
--- a/src/common/iconv.cc
+++ b/src/common/iconv.cc
@@ -106,6 +106,12 @@ std::string Iconv::toUtf8( char const * fromEncoding, void const * fromData, siz
   return outStr.toStdString();
 }
 
+std::string Iconv::toUtf8( char const * fromEncoding, std::u32string_view str )
+{
+  // u32string::size -> returns the number of char32_t instead of the length of bytes
+  return toUtf8( fromEncoding, str.data(), str.size() * sizeof( char32_t ) );
+}
+
 QString Iconv::toQString( char const * fromEncoding, void const * fromData, size_t dataSize )
 {
   if ( dataSize == 0 ) {

--- a/src/common/iconv.hh
+++ b/src/common/iconv.hh
@@ -31,6 +31,7 @@ public:
   // Converts a given block of data from the given encoding to an utf8-encoded
   // string.
   static std::string toUtf8( char const * fromEncoding, void const * fromData, size_t dataSize );
+  static std::string toUtf8( char const * fromEncoding, std::u32string_view str );
 
   static QString toQString( char const * fromEncoding, void const * fromData, size_t dataSize );
 

--- a/src/dict/hunspell.cc
+++ b/src/dict/hunspell.cc
@@ -207,7 +207,7 @@ void HunspellArticleRequest::run()
 
     QMutexLocker _( &hunspellMutex );
 
-    string trimmedWord_utf8 = Iconv::toUtf8( Text::utf32, trimmedWord.data(), trimmedWord.size() );
+    string trimmedWord_utf8 = Iconv::toUtf8( Text::utf32_le, trimmedWord );
 
     if ( hunspell.spell( trimmedWord_utf8 ) ) {
       // Good word -- no spelling suggestions then.
@@ -361,7 +361,7 @@ QList< std::u32string > suggest( std::u32string & word, QMutex & hunspellMutex, 
   try {
     QMutexLocker _( &hunspellMutex );
 
-    auto suggestions = hunspell.analyze( Iconv::toUtf8( Text::utf32, word.data(), word.size() ) );
+    auto suggestions = hunspell.analyze( Iconv::toUtf8( Text::utf32_le, word ) );
     if ( !suggestions.empty() ) {
       // There were some suggestions made for us. Make an appropriate output.
 
@@ -464,7 +464,7 @@ void HunspellPrefixMatchRequest::run()
 
     QMutexLocker _( &hunspellMutex );
 
-    if ( hunspell.spell( Iconv::toUtf8( Text::utf32, trimmedWord.data(), trimmedWord.size() ) ) ) {
+    if ( hunspell.spell( Iconv::toUtf8( Text::utf32_le, trimmedWord ) ) ) {
       // Known word -- add it to the result
 
       QMutexLocker _( &dataMutex );


### PR DESCRIPTION
close https://github.com/xiaoyifang/goldendict-ng/issues/1998

Issue caused by https://github.com/xiaoyifang/goldendict-ng/pull/1990 https://github.com/xiaoyifang/goldendict-ng/pull/1989

Two things I missed

* `u32string::size` returns number of `char32_t` instead of number of bytes.
* `libiconv` doesn't check the byte order of `UTF-32` string (UTF-32 only uses 21 bits out of 32 bits, so I always assume checking byte order of UTF-32 string is easy). Related source code https://git.savannah.gnu.org/gitweb/?p=libiconv.git;a=blob;f=lib/utf32.h;h=4c11a89906c47aa9e42bc9a575ee5e37fcfeb27a;hb=HEAD#l26