### PR TITLE
fix: <script> without src is not delayed like <script src="..." defer>

### DIFF
--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -956,7 +956,7 @@ void MdxDictionary::replaceLinks( QString & id, QString & article )
         if ( match.hasMatch() ) {
           articleNewText += QString( QStringLiteral( "gdOnReady(()=>{%1});</script>" ) )
                               .arg( article.mid( linkPos, match.capturedStart() - linkPos ) );
-          linkPos += articleNewText.size();
+          linkPos += match.capturedEnd();
         }
         continue;
       }

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -953,8 +953,11 @@ void MdxDictionary::replaceLinks( QString & id, QString & article )
         articleNewText += linkTxt;
         match = RX::Mdx::closeScriptTagRe.match( article, linkPos );
         if ( match.hasMatch() ) {
-          articleNewText += article.mid( linkPos, match.capturedEnd() - linkPos );
-          linkPos = match.capturedEnd();
+          articleNewText += "gdDeferOnReady(() => {";
+          articleNewText += article.mid( linkPos, match.capturedStart() - linkPos );
+          QString endtag = "});</script>";
+          articleNewText += endtag;
+          linkPos = match.capturedEnd() + endtag.size();
         }
         continue;
       }

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -877,7 +877,8 @@ QString & MdxDictionary::filterResource( QString & article )
 void MdxDictionary::replaceLinks( QString & id, QString & article )
 {
   QString articleNewText;
-  int linkPos                        = 0;
+  qsizetype linkPos = 0;
+
   QRegularExpressionMatchIterator it = RX::Mdx::allLinksRe.globalMatch( article );
   while ( it.hasNext() ) {
     QRegularExpressionMatch allLinksMatch = it.next();
@@ -953,11 +954,9 @@ void MdxDictionary::replaceLinks( QString & id, QString & article )
         articleNewText += linkTxt;
         match = RX::Mdx::closeScriptTagRe.match( article, linkPos );
         if ( match.hasMatch() ) {
-          articleNewText += "gdDeferOnReady(() => {";
-          articleNewText += article.mid( linkPos, match.capturedStart() - linkPos );
-          QString endtag = "});</script>";
-          articleNewText += endtag;
-          linkPos = match.capturedEnd() + endtag.size();
+          articleNewText += QString( QStringLiteral( "gdOnReady(()=>{%1});</script>" ) )
+                              .arg( article.mid( linkPos, match.capturedStart() - linkPos ) );
+          linkPos += articleNewText.size();
         }
         continue;
       }

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -956,7 +956,7 @@ void MdxDictionary::replaceLinks( QString & id, QString & article )
         if ( match.hasMatch() ) {
           articleNewText += QString( QStringLiteral( "gdOnReady(()=>{%1});</script>" ) )
                               .arg( article.mid( linkPos, match.capturedStart() - linkPos ) );
-          linkPos += match.capturedEnd();
+          linkPos = match.capturedEnd();
         }
         continue;
       }

--- a/src/scripts/gd-builtin.js
+++ b/src/scripts/gd-builtin.js
@@ -1,3 +1,11 @@
+function gdOnReady(func) {
+  if (document.readyState !== "loading") {
+    func();
+  } else {
+    document.addEventListener("DOMContentLoaded", func);
+  }
+}
+
 function gdMakeArticleActive(newId, noEvent) {
   const gdCurrentArticle =
     document.querySelector(".gdactivearticle").attributes.id;


### PR DESCRIPTION
Fix issue caused by `defer` for external scripts.

https://github.com/xiaoyifang/goldendict-ng/blob/ad192634235a89c62fc07eb766cc180c1533b418/src/dict/mdx.cc#L978-L981

The `defer` will delay the execution of external script to a time between "Page loaded" and `DOMContentLoaded`.

I don't put much thought yet, but this will immediately fix https://github.com/xiaoyifang/goldendict-ng/issues/1984

Also don't want to use jQuery because it creates a barrier on approaching the HTML standard.