### PR TITLE
opt: replace some inefficient uses of QUrlQuery

### DIFF
--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -298,27 +298,28 @@ void ArticleView::showDefinition( QString const & word,
   audioLink_.clear();
 
   QUrl req;
+  QUrlQuery reqQuery;
   Contexts contexts( contexts_ );
 
   req.setScheme( "gdlookup" );
   req.setHost( "localhost" );
-  Utils::Url::addQueryItem( req, "word", word );
-  Utils::Url::addQueryItem( req, "group", QString::number( group ) );
+  reqQuery.addQueryItem( "word", word );
+  reqQuery.addQueryItem( "group", QString::number( group ) );
   if ( cfg.preferences.ignoreDiacritics ) {
-    Utils::Url::addQueryItem( req, "ignore_diacritics", "1" );
+    reqQuery.addQueryItem( "ignore_diacritics", "1" );
   }
 
   if ( scrollTo.size() ) {
-    Utils::Url::addQueryItem( req, "scrollto", scrollTo );
+    reqQuery.addQueryItem( "scrollto", scrollTo );
   }
 
   if ( delayedHighlightText.size() ) {
-    Utils::Url::addQueryItem( req, "regexp", delayedHighlightText );
+    reqQuery.addQueryItem( "regexp", delayedHighlightText );
     delayedHighlightText.clear();
   }
 
   if ( Contexts::Iterator pos = contexts.find( "gdanchor" ); pos != contexts.end() ) {
-    Utils::Url::addQueryItem( req, "gdanchor", contexts[ "gdanchor" ] );
+    reqQuery.addQueryItem( "gdanchor", contexts[ "gdanchor" ] );
     contexts.erase( pos );
   }
 
@@ -329,14 +330,16 @@ void ArticleView::showDefinition( QString const & word,
     stream << contexts;
     buf.close();
 
-    Utils::Url::addQueryItem( req, "contexts", QString::fromLatin1( buf.buffer().toBase64() ) );
+    reqQuery.addQueryItem("contexts", QString::fromLatin1( buf.buffer().toBase64() ));
   }
 
   QString mutedDicts = getMutedForGroup( group );
 
   if ( mutedDicts.size() ) {
-    Utils::Url::addQueryItem( req, "muted", mutedDicts );
+    reqQuery.addQueryItem("muted", mutedDicts);
   }
+
+  req.setQuery( reqQuery );
 
   // Any search opened is probably irrelevant now
   closeSearch();
@@ -369,21 +372,25 @@ void ArticleView::showDefinition( QString const & word,
   audioLink_.clear();
 
   QUrl req;
+  QUrlQuery reqQuery;
 
   req.setScheme( "gdlookup" );
   req.setHost( "localhost" );
-  Utils::Url::addQueryItem( req, "word", word );
-  Utils::Url::addQueryItem( req, "dictionaries", dictIDs.join( "," ) );
-  Utils::Url::addQueryItem( req, "regexp", searchRegExp.pattern() );
+
+  reqQuery.addQueryItem(  "word", word );
+  reqQuery.addQueryItem(  "dictionaries", dictIDs.join( "," ) );
+  reqQuery.addQueryItem(  "regexp", searchRegExp.pattern() );
   if ( !searchRegExp.patternOptions().testFlag( QRegularExpression::CaseInsensitiveOption ) ) {
-    Utils::Url::addQueryItem( req, "matchcase", "1" );
+    reqQuery.addQueryItem(  "matchcase", "1" );
   }
   //  if ( searchRegExp.patternSyntax() == QRegExp::WildcardUnix )
   //    Utils::Url::addQueryItem( req, "wildcards", "1" );
-  Utils::Url::addQueryItem( req, "group", QString::number( group ) );
+  reqQuery.addQueryItem(  "group", QString::number( group ) );
   if ( ignoreDiacritics ) {
-    Utils::Url::addQueryItem( req, "ignore_diacritics", "1" );
+    reqQuery.addQueryItem(  "ignore_diacritics", "1" );
   }
+
+  req.setQuery( reqQuery );
 
   // Any search opened is probably irrelevant now
   closeSearch();

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -330,13 +330,13 @@ void ArticleView::showDefinition( QString const & word,
     stream << contexts;
     buf.close();
 
-    reqQuery.addQueryItem("contexts", QString::fromLatin1( buf.buffer().toBase64() ));
+    reqQuery.addQueryItem( "contexts", QString::fromLatin1( buf.buffer().toBase64() ) );
   }
 
   QString mutedDicts = getMutedForGroup( group );
 
   if ( mutedDicts.size() ) {
-    reqQuery.addQueryItem("muted", mutedDicts);
+    reqQuery.addQueryItem( "muted", mutedDicts );
   }
 
   req.setQuery( reqQuery );
@@ -377,17 +377,17 @@ void ArticleView::showDefinition( QString const & word,
   req.setScheme( "gdlookup" );
   req.setHost( "localhost" );
 
-  reqQuery.addQueryItem(  "word", word );
-  reqQuery.addQueryItem(  "dictionaries", dictIDs.join( "," ) );
-  reqQuery.addQueryItem(  "regexp", searchRegExp.pattern() );
+  reqQuery.addQueryItem( "word", word );
+  reqQuery.addQueryItem( "dictionaries", dictIDs.join( "," ) );
+  reqQuery.addQueryItem( "regexp", searchRegExp.pattern() );
   if ( !searchRegExp.patternOptions().testFlag( QRegularExpression::CaseInsensitiveOption ) ) {
-    reqQuery.addQueryItem(  "matchcase", "1" );
+    reqQuery.addQueryItem( "matchcase", "1" );
   }
   //  if ( searchRegExp.patternSyntax() == QRegExp::WildcardUnix )
   //    Utils::Url::addQueryItem( req, "wildcards", "1" );
-  reqQuery.addQueryItem(  "group", QString::number( group ) );
+  reqQuery.addQueryItem( "group", QString::number( group ) );
   if ( ignoreDiacritics ) {
-    reqQuery.addQueryItem(  "ignore_diacritics", "1" );
+    reqQuery.addQueryItem( "ignore_diacritics", "1" );
   }
 
   req.setQuery( reqQuery );

--- a/src/ui/articlewebpage.cc
+++ b/src/ui/articlewebpage.cc
@@ -8,14 +8,16 @@ ArticleWebPage::ArticleWebPage( QObject * parent ):
 bool ArticleWebPage::acceptNavigationRequest( const QUrl & resUrl, NavigationType type, bool isMainFrame )
 {
   QUrl url = resUrl;
+  QUrlQuery urlQuery{ url };
   if ( url.scheme() == "bword" || url.scheme() == "entry" ) {
     url.setScheme( "gdlookup" );
     url.setHost( "localhost" );
     url.setPath( "" );
     auto [ valid, word ] = Utils::Url::getQueryWord( resUrl );
-    Utils::Url::addQueryItem( url, "word", word );
-    Utils::Url::addQueryItem( url, "group", lastReq.group );
-    Utils::Url::addQueryItem( url, "muted", lastReq.mutedDicts );
+    urlQuery.addQueryItem( "word", word );
+    urlQuery.addQueryItem( "group", lastReq.group );
+    urlQuery.addQueryItem( "muted", lastReq.mutedDicts );
+    url.setQuery( urlQuery );
     setUrl( url );
     return false;
   }


### PR DESCRIPTION
The original purpose of `Utils::Url::addQueryItem` was for accommodating `Qt4x5` which were wrappers of Qt4 -> Qt5 API changes. 

This one is inefficient because the construction of `QUrlQuery` needs to parse the query part of the URL. Each call of this function reparse the string. 

The worst case scenario of the one in `articleview.cc` is reparsing the query string 8 times, and each time it gets slightly more expensive.

I am not motivated to replace all, so only the highly used ones are replaced.