### PR TITLE
revert: defer+gdonready

### DIFF
--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -877,8 +877,7 @@ QString & MdxDictionary::filterResource( QString & article )
 void MdxDictionary::replaceLinks( QString & id, QString & article )
 {
   QString articleNewText;
-  qsizetype linkPos = 0;
-
+  int linkPos                        = 0;
   QRegularExpressionMatchIterator it = RX::Mdx::allLinksRe.globalMatch( article );
   while ( it.hasNext() ) {
     QRegularExpressionMatch allLinksMatch = it.next();
@@ -954,8 +953,7 @@ void MdxDictionary::replaceLinks( QString & id, QString & article )
         articleNewText += linkTxt;
         match = RX::Mdx::closeScriptTagRe.match( article, linkPos );
         if ( match.hasMatch() ) {
-          articleNewText += QString( QStringLiteral( "gdOnReady(()=>{%1});</script>" ) )
-                              .arg( article.mid( linkPos, match.capturedStart() - linkPos ) );
+          articleNewText += article.mid( linkPos, match.capturedEnd() - linkPos );
           linkPos = match.capturedEnd();
         }
         continue;

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -959,7 +959,7 @@ void MdxDictionary::replaceLinks( QString & id, QString & article )
         continue;
       }
       else {
-        //audio ,script,video ,html5 tags fall here.
+        //audio ,video ,html5 tags fall here.
         match = RX::Mdx::srcRe.match( linkTxt );
         if ( match.hasMatch() ) {
           QString newText;
@@ -971,14 +971,8 @@ void MdxDictionary::replaceLinks( QString & id, QString & article )
           else {
             scheme = "bres://";
           }
-
           newText =
             match.captured( 1 ) + match.captured( 2 ) + scheme + id + "/" + match.captured( 3 ) + match.captured( 2 );
-
-          //add defer to script tag
-          if ( linkType.compare( "script" ) == 0 ) {
-            newText = newText + " defer ";
-          }
 
           newLink = linkTxt.replace( match.capturedStart(), match.capturedLength(), newText );
         }

--- a/src/scripts/gd-builtin.js
+++ b/src/scripts/gd-builtin.js
@@ -1,11 +1,3 @@
-function gdOnReady(func) {
-  if (document.readyState !== "loading") {
-    func();
-  } else {
-    document.addEventListener("DOMContentLoaded", func);
-  }
-}
-
 function gdMakeArticleActive(newId, noEvent) {
   const gdCurrentArticle =
     document.querySelector(".gdactivearticle").attributes.id;


### PR DESCRIPTION
gdonready is used to complemented with defer.
after wrapped with gdonready ,the global js variables/functions seems lost its global scope.