### PR TITLE
fix: regression in finding `{id}-{id}` lang pair from dict name

### DIFF
--- a/src/langcoder.cc
+++ b/src/langcoder.cc
@@ -275,14 +275,18 @@ quint32 LangCoder::guessId( const QString & lang )
 
 std::pair< quint32, quint32 > LangCoder::findLangIdPairFromName( QString const & name )
 {
-  static QRegularExpression reg( "(?=([a-z]{2,3})-([a-z]{2,3}))", QRegularExpression::CaseInsensitiveOption );
+  static QRegularExpression reg( "(^|[^a-z])((?<lang1>[a-z]{2,3})-(?<lang2>[a-z]{2,3}))($|[^a-z])",
+                                 QRegularExpression::CaseInsensitiveOption );
 
   auto matches = reg.globalMatch( name );
   while ( matches.hasNext() ) {
     auto m = matches.next();
+    if ( matches.hasNext() ) {
+      continue; // We use only the last match, skip previous ones
+    }
 
-    auto fromId = guessId( m.captured( 1 ).toLower() );
-    auto toId   = guessId( m.captured( 2 ).toLower() );
+    auto fromId = guessId( m.captured( "lang1" ).toLower() );
+    auto toId   = guessId( m.captured( "lang2" ).toLower() );
 
     if ( code2Exists( intToCode2( fromId ) ) && code2Exists( intToCode2( toId ) ) ) {
       return { fromId, toId };

--- a/website/docs/manage_groups.md
+++ b/website/docs/manage_groups.md
@@ -10,9 +10,9 @@ Additionally, multiple strategies of automatic grouping are provided:
 
 ## Auto groups by dictionary language
 
-For formats like DSL, which has embedded language from / to metadata, GoldenDict will use the dictionary's built-in metadata.
+For formats like DSL, which has embedded language from / to metadata, GD will use the dictionary's built-in metadata.
 
-For other formats, GoldenDict will try to extract languages from the dictionary's name or its file name by finding `{id}-{id}` pair. The `{id}` is 2 or 3 letters ISO 639 codes. For example, if a dictionary named `some name en-zh`, it will be automatically grouped into `en-zh`.
+For other formats, GD will try finding the last `{id}-{id}` pair delimited by non-alphabets in dictionary name or main file name to extract languages. The `{id}` is 2 or 3 letters ISO 639 codes. For example, if a dictionary named `some name en-zh`, it will be automatically grouped into `en-zh`.
 
 Groups created in this method also include a context menu when right-click the group name, in which you can do additional dictionaries grouping by source or target language and combine dictionaries in more large groups.
 


### PR DESCRIPTION
A regression introduced when porting from `QRegex` to `QRegularExpression`.

I didn't put enough thought when porting this one.

* fix https://github.com/xiaoyifang/goldendict-ng/issues/2019
* require either non-alphabet delimiters or at the end or beginning of the name string.
* uses only the last match
* update documentation to clarify the exact extraction method.

For reference, this is the original one https://github.com/goldendict/goldendict/blob/8c5b26a3924f15fb215e2a8e1e96d87531bf5393/langcoder.cc#L325-L342