### PR TITLE
opt: remove words zoom in(out) from the menu and keep the shortcut

### DIFF
--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -392,12 +392,12 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   ui.menuZoom->addSeparator();
 
-  wordsZoomIn = new QAction( tr( "Words Zoom In" ), this );
-  wordsZoomIn->setShortcuts( QList< QKeySequence >() << QKeySequence( "Alt++" ) << QKeySequence( "Alt+=" ) );
-  wordsZoomOut = new QAction( tr( "Words Zoom Out" ), this );
-  wordsZoomOut->setShortcut( QKeySequence( "Alt+-" ) );
-  wordsZoomBase = new QAction( tr( "Words Normal Size" ), this );
-  wordsZoomBase->setShortcut( QKeySequence( "Alt+0" ) );
+  wordsZoomIn = new QShortcut( this );
+  wordsZoomIn->setKey( QList< QKeySequence >() << QKeySequence( "Alt++" ) << QKeySequence( "Alt+=" ) );
+  wordsZoomOut = new QShortcut( this );
+  wordsZoomOut->setKey( QKeySequence( "Alt+-" ) );
+  wordsZoomBase = new QShortcut( this );
+  wordsZoomBase->setKey( QKeySequence( "Alt+0" ) );
 
   connect( wordsZoomIn, &QAction::triggered, this, &MainWindow::doWordsZoomIn );
   connect( wordsZoomOut, &QAction::triggered, this, &MainWindow::doWordsZoomOut );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -394,15 +394,15 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   ui.menuZoom->addSeparator();
 
   wordsZoomIn = new QShortcut( this );
-  wordsZoomIn->setKey( QList< QKeySequence >() << QKeySequence( "Alt++" ) << QKeySequence( "Alt+=" ) );
+  wordsZoomIn->setKey( QKeySequence( "Alt++" ) );
   wordsZoomOut = new QShortcut( this );
   wordsZoomOut->setKey( QKeySequence( "Alt+-" ) );
   wordsZoomBase = new QShortcut( this );
   wordsZoomBase->setKey( QKeySequence( "Alt+0" ) );
 
-  connect( wordsZoomIn, &QAction::triggered, this, &MainWindow::doWordsZoomIn );
-  connect( wordsZoomOut, &QAction::triggered, this, &MainWindow::doWordsZoomOut );
-  connect( wordsZoomBase, &QAction::triggered, this, &MainWindow::doWordsZoomBase );
+  connect( wordsZoomIn, &QShortcut::triggered, this, &MainWindow::doWordsZoomIn );
+  connect( wordsZoomOut, &QShortcut::triggered, this, &MainWindow::doWordsZoomOut );
+  connect( wordsZoomBase, &QShortcut::triggered, this, &MainWindow::doWordsZoomBase );
 
 // tray icon
 #ifndef Q_OS_MACOS // macOS uses the dock menu instead of the tray icon

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -392,11 +392,11 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   ui.menuZoom->addSeparator();
 
-  wordsZoomIn = ui.menuZoom->addAction( QIcon( ":/icons/icon32_zoomin.png" ), tr( "Words Zoom In" ) );
+  wordsZoomIn = new QAction( tr( "Words Zoom In" ), this );
   wordsZoomIn->setShortcuts( QList< QKeySequence >() << QKeySequence( "Alt++" ) << QKeySequence( "Alt+=" ) );
-  wordsZoomOut = ui.menuZoom->addAction( QIcon( ":/icons/icon32_zoomout.png" ), tr( "Words Zoom Out" ) );
+  wordsZoomOut = new QAction( tr( "Words Zoom Out" ), this );
   wordsZoomOut->setShortcut( QKeySequence( "Alt+-" ) );
-  wordsZoomBase = ui.menuZoom->addAction( QIcon( ":/icons/icon32_zoombase.png" ), tr( "Words Normal Size" ) );
+  wordsZoomBase = new QAction( tr( "Words Normal Size" ), this );
   wordsZoomBase->setShortcut( QKeySequence( "Alt+0" ) );
 
   connect( wordsZoomIn, &QAction::triggered, this, &MainWindow::doWordsZoomIn );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -65,6 +65,7 @@
 #include <QGuiApplication>
 #include <QWebEngineSettings>
 #include <QProxyStyle>
+#include <QShortcut>
 
 #ifdef HAVE_X11
   #if ( QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 ) )

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -394,15 +394,15 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   ui.menuZoom->addSeparator();
 
   wordsZoomIn = new QShortcut( this );
-  wordsZoomIn->setKey( QKeySequence( "Alt++" ) );
+  wordsZoomIn->setKey( QKeySequence( "Alt+=" ) );
   wordsZoomOut = new QShortcut( this );
   wordsZoomOut->setKey( QKeySequence( "Alt+-" ) );
   wordsZoomBase = new QShortcut( this );
   wordsZoomBase->setKey( QKeySequence( "Alt+0" ) );
 
-  connect( wordsZoomIn, &QShortcut::triggered, this, &MainWindow::doWordsZoomIn );
-  connect( wordsZoomOut, &QShortcut::triggered, this, &MainWindow::doWordsZoomOut );
-  connect( wordsZoomBase, &QShortcut::triggered, this, &MainWindow::doWordsZoomBase );
+  connect( wordsZoomIn, &QShortcut::activated, this, &MainWindow::doWordsZoomIn );
+  connect( wordsZoomOut, &QShortcut::activated, this, &MainWindow::doWordsZoomOut );
+  connect( wordsZoomBase, &QShortcut::activated, this, &MainWindow::doWordsZoomBase );
 
 // tray icon
 #ifndef Q_OS_MACOS // macOS uses the dock menu instead of the tray icon

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -40,6 +40,7 @@
 #endif
 //must place the qactiongroup after fixx11h.h, None in QActionGroup conflict with X.h's macro None.
 #include <QActionGroup>
+#include <QShortcut>
 
 using std::string;
 using std::vector;
@@ -118,7 +119,7 @@ private:
   QAction *navBack, *navForward, *navPronounce, *enableScanningAction;
   QAction * beforeOptionsSeparator;
   QAction *zoomIn, *zoomOut, *zoomBase;
-  QAction *wordsZoomIn, *wordsZoomOut, *wordsZoomBase;
+  QShortcut *wordsZoomIn, *wordsZoomOut, *wordsZoomBase;
   QAction *addToFavorites, *beforeAddToFavoritesSeparator;
   QMenu trayIconMenu;
   QMenu * tabMenu;


### PR DESCRIPTION
current situation: the translate line can adjust its font size according to the icon size .
