### PR TITLE
feat: add founded dictionaries bar in the scanpop dialog

### DIFF
--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -17,7 +17,6 @@
 #include "audio/audioplayerfactory.hh"
 #include "instances.hh"
 #include "article_maker.hh"
-#include "scanpopup.hh"
 #include "ui/articleview.hh"
 #include "wordfinder.hh"
 #include "dictionarybar.hh"
@@ -34,6 +33,7 @@
 #ifdef HAVE_X11
   #include <fixx11h.h>
 #endif
+#include "scanpopup.hh"
 
 #if defined( Q_OS_MAC )
   #include "macos/gd_clipboard.hh"

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -316,7 +316,8 @@ void ScanPopup::updateFoundInDictsList()
   auto dictionaries = !grp ? grp->dictionaries : allDictionaries;
   QStringList ids   = definition->getArticlesList();
   QString activeId  = definition->getActiveArticleId();
-
+  toolbar->clear();
+  actionGroup->clear();
   for ( QStringList::const_iterator i = ids.constBegin(); i != ids.constEnd(); ++i ) {
     // Find this dictionary
 

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -77,8 +77,9 @@ ScanPopup::ScanPopup( QWidget * parent,
   hideTimer( this )
 {
   ui.setupUi( this );
-  toolBar = new QToolBar("Dictionaries Toolbar" this );
-
+  toolbar = new QToolBar("Dictionaries Toolbar" this );
+  actionGroup = new QActionGroup(this);
+  actionGroup->setExclusive(true);
   if ( layoutDirection() == Qt::RightToLeft ) {
     // Adjust button icons for Right-To-Left layout
     ui.goBackButton->setIcon( QIcon( ":/icons/next.svg" ) );
@@ -151,7 +152,7 @@ ScanPopup::ScanPopup( QWidget * parent,
   }
 
   addToolBar( Qt::TopToolBarArea, &dictionaryBar );
-  addToolBar( Qt::RightToolBarArea, toolBar );
+  addToolBar( Qt::RightToolBarArea, toolbar );
 
   connect( &dictionaryBar, &DictionaryBar::editGroupRequested, this, &ScanPopup::editGroupRequested );
   connect( this, &ScanPopup::closeMenu, &dictionaryBar, &DictionaryBar::closePopupMenu );
@@ -325,7 +326,7 @@ void ScanPopup::updateFoundInDictsList()
           action->setChecked( true );
         }
         toolbar->addAction( action );
-
+        actionGroup->addAction( action );
         break;
       }
     }

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -77,7 +77,7 @@ ScanPopup::ScanPopup( QWidget * parent,
   hideTimer( this )
 {
   ui.setupUi( this );
-  toolbar = new QToolBar("Dictionaries Toolbar", this );
+  toolbar = new QToolBar( "Dictionaries Toolbar", this );
 
   if ( layoutDirection() == Qt::RightToLeft ) {
     // Adjust button icons for Right-To-Left layout
@@ -292,13 +292,14 @@ ScanPopup::ScanPopup( QWidget * parent,
   applyWordsZoomLevel();
 }
 
-void ScanPopup::onActionTriggered() {
-    QAction *action = qobject_cast<QAction *>(sender());
-    if (action) {
-      auto dictId = action->data().toString();
-      qDebug() << "Action triggered:" << dictId;
-      definition->jumpToDictionary(dictId,false);
-    }
+void ScanPopup::onActionTriggered()
+{
+  QAction * action = qobject_cast< QAction * >( sender() );
+  if ( action ) {
+    auto dictId = action->data().toString();
+    qDebug() << "Action triggered:" << dictId;
+    definition->jumpToDictionary( dictId, false );
+  }
 }
 
 void ScanPopup::updateFoundInDictsList()
@@ -316,29 +317,29 @@ void ScanPopup::updateFoundInDictsList()
   QStringList ids   = definition->getArticlesList();
   QString activeId  = definition->getActiveArticleId();
   toolbar->clear();
-  if( actionGroup ){
+  if ( actionGroup ) {
     delete actionGroup;
   }
   actionGroup = new QActionGroup( this );
-  actionGroup->setExclusive(true);
+  actionGroup->setExclusive( true );
   for ( QStringList::const_iterator i = ids.constBegin(); i != ids.constEnd(); ++i ) {
     // Find this dictionary
 
     for ( unsigned x = dictionaries.size(); x--; ) {
       if ( dictionaries[ x ]->getId() == i->toUtf8().data() ) {
 
-        auto dictionary = dictionaries[ x ];
-        QIcon icon = dictionary->getIcon();
+        auto dictionary  = dictionaries[ x ];
+        QIcon icon       = dictionary->getIcon();
         QString dictName = QString::fromUtf8( dictionary->getName().c_str() );
-        QAction * action = new QAction( dictName,this );
+        QAction * action = new QAction( dictName, this );
         action->setIcon( icon );
         QString id = QString::fromStdString( dictionary->getId() );
         action->setData( id );
-        action->setCheckable(true);
+        action->setCheckable( true );
         if ( id == activeId ) {
           action->setChecked( true );
         }
-        connect(action, &QAction::triggered, this, &ScanPopup::onActionTriggered);
+        connect( action, &QAction::triggered, this, &ScanPopup::onActionTriggered );
         toolbar->addAction( action );
         actionGroup->addAction( action );
         break;

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -317,7 +317,7 @@ void ScanPopup::updateFoundInDictsList()
   QStringList ids   = definition->getArticlesList();
   QString activeId  = definition->getActiveArticleId();
   toolbar->clear();
-  if ( actionGroup!= nullptr ) {
+  if ( actionGroup != nullptr ) {
     actionGroup->deleteLater();
   }
   actionGroup = new QActionGroup( this );

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -317,7 +317,10 @@ void ScanPopup::updateFoundInDictsList()
   QStringList ids   = definition->getArticlesList();
   QString activeId  = definition->getActiveArticleId();
   toolbar->clear();
-  //  actionGroup->removeAllActions();
+  if( actionGroup ){
+    delete actionGroup;
+  }
+  actionGroup = new ActionGroup( this );
   for ( QStringList::const_iterator i = ids.constBegin(); i != ids.constEnd(); ++i ) {
     // Find this dictionary
 
@@ -327,11 +330,11 @@ void ScanPopup::updateFoundInDictsList()
         auto dictionary = dictionaries[ x ];
         QIcon icon = dictionary->getIcon();
         QString dictName = QString::fromUtf8( dictionary->getName().c_str() );
-        QAction * action = addAction( icon, dictName );
-        action->setToolTip( dictName ); // Tooltip need not be shortened
+        QAction * action = new QAction( dictName,this );
+        action->setIcon( icon );
         QString id = QString::fromStdString( dictionary->getId() );
         action->setData( id );
-
+        action->setCheckable(true);
         if ( id == activeId ) {
           action->setChecked( true );
         }

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -317,7 +317,7 @@ void ScanPopup::updateFoundInDictsList()
   QStringList ids   = definition->getArticlesList();
   QString activeId  = definition->getActiveArticleId();
   toolbar->clear();
-  actionGroup->clear();
+  //  actionGroup->removeAllActions();
   for ( QStringList::const_iterator i = ids.constBegin(); i != ids.constEnd(); ++i ) {
     // Find this dictionary
 

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -150,7 +150,6 @@ ScanPopup::ScanPopup( QWidget * parent,
     dictionaryBar.setMutedDictionaries( grp ? &grp->popupMutedDictionaries : nullptr );
   }
 
-  addToolBar( Qt::TopToolBarArea, &dictionaryBar );
   addToolBar( Qt::RightToolBarArea, toolbar );
 
   connect( &dictionaryBar, &DictionaryBar::editGroupRequested, this, &ScanPopup::editGroupRequested );
@@ -179,6 +178,9 @@ ScanPopup::ScanPopup( QWidget * parent,
     restoreState( cfg.popupWindowState );
   }
 
+  //fix this toolbar
+  addToolBar( Qt::TopToolBarArea, &dictionaryBar );
+
   ui.onTopButton->setChecked( cfg.popupWindowAlwaysOnTop );
   ui.onTopButton->setVisible( cfg.pinPopupWindow );
   connect( ui.onTopButton, &QAbstractButton::clicked, this, &ScanPopup::alwaysOnTopClicked );
@@ -186,7 +188,7 @@ ScanPopup::ScanPopup( QWidget * parent,
   ui.pinButton->setChecked( cfg.pinPopupWindow );
 
   if ( cfg.pinPopupWindow ) {
-    dictionaryBar.setMovable( true );
+    dictionaryBar.setMovable( false );
     Qt::WindowFlags flags = pinnedWindowFlags;
     if ( cfg.popupWindowAlwaysOnTop ) {
       flags |= Qt::WindowStaysOnTopHint;
@@ -959,7 +961,7 @@ void ScanPopup::pinButtonClicked( bool checked )
 #endif
 
     setWindowTitle( QString( "%1 - GoldenDict-ng" ).arg( elideInputWord() ) );
-    dictionaryBar.setMovable( true );
+    dictionaryBar.setMovable( false );
     hideTimer.stop();
   }
   else {

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -77,7 +77,7 @@ ScanPopup::ScanPopup( QWidget * parent,
   hideTimer( this )
 {
   ui.setupUi( this );
-  toolbar = new QToolBar("Dictionaries Toolbar" this );
+  toolbar = new QToolBar("Dictionaries Toolbar", this );
   actionGroup = new QActionGroup(this);
   actionGroup->setExclusive(true);
   if ( layoutDirection() == Qt::RightToLeft ) {
@@ -298,7 +298,7 @@ void ScanPopup::onActionTriggered() {
     if (action) {
       auto dictId = action->data().toString();
       qDebug() << "Action triggered:" << dictId;
-      definition->jumpToDictionary(dictId);
+      definition->jumpToDictionary(dictId,false);
     }
 }
 
@@ -326,7 +326,7 @@ void ScanPopup::updateFoundInDictsList()
         auto dictionary = dictionaries[ x ];
         QIcon icon = dictionary->getIcon();
         QString dictName = QString::fromUtf8( dictionary->getName().c_str() );
-        QAction * action = addAction( icon, elideDictName( dictName ) );
+        QAction * action = addAction( icon, dictName );
         action->setToolTip( dictName ); // Tooltip need not be shortened
         QString id = QString::fromStdString( dictionary->getId() );
         action->setData( id );

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -78,8 +78,7 @@ ScanPopup::ScanPopup( QWidget * parent,
 {
   ui.setupUi( this );
   toolbar = new QToolBar("Dictionaries Toolbar", this );
-  actionGroup = new QActionGroup(this);
-  actionGroup->setExclusive(true);
+
   if ( layoutDirection() == Qt::RightToLeft ) {
     // Adjust button icons for Right-To-Left layout
     ui.goBackButton->setIcon( QIcon( ":/icons/next.svg" ) );
@@ -320,7 +319,8 @@ void ScanPopup::updateFoundInDictsList()
   if( actionGroup ){
     delete actionGroup;
   }
-  actionGroup = new ActionGroup( this );
+  actionGroup = new QActionGroup( this );
+  actionGroup->setExclusive(true);
   for ( QStringList::const_iterator i = ids.constBegin(); i != ids.constEnd(); ++i ) {
     // Find this dictionary
 

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -293,6 +293,15 @@ ScanPopup::ScanPopup( QWidget * parent,
   applyWordsZoomLevel();
 }
 
+void ScanPopup::onActionTriggered() {
+    QAction *action = qobject_cast<QAction *>(sender());
+    if (action) {
+      auto dictId = action->data().toString();
+      qDebug() << "Action triggered:" << dictId;
+      definition->jumpToDictionary(dictId);
+    }
+}
+
 void ScanPopup::updateFoundInDictsList()
 {
   if ( !toolbar->isVisible() ) {
@@ -325,6 +334,7 @@ void ScanPopup::updateFoundInDictsList()
         if ( id == activeId ) {
           action->setChecked( true );
         }
+        connect(action, &QAction::triggered, this, &ScanPopup::onActionTriggered);
         toolbar->addAction( action );
         actionGroup->addAction( action );
         break;

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -77,7 +77,7 @@ ScanPopup::ScanPopup( QWidget * parent,
   hideTimer( this )
 {
   ui.setupUi( this );
-  toolbar = new QToolBar( "Dictionaries Toolbar", this );
+  toolbar = new QToolBar( "Found Dictionary", this );
 
   if ( layoutDirection() == Qt::RightToLeft ) {
     // Adjust button icons for Right-To-Left layout
@@ -295,10 +295,10 @@ ScanPopup::ScanPopup( QWidget * parent,
 void ScanPopup::onActionTriggered()
 {
   QAction * action = qobject_cast< QAction * >( sender() );
-  if ( action ) {
+  if ( action != nullptr ) {
     auto dictId = action->data().toString();
     qDebug() << "Action triggered:" << dictId;
-    definition->jumpToDictionary( dictId, false );
+    definition->jumpToDictionary( dictId, true );
   }
 }
 
@@ -313,12 +313,12 @@ void ScanPopup::updateFoundInDictsList()
   unsigned currentId           = ui.groupList->getCurrentGroup();
   Instances::Group const * grp = groups.findGroup( currentId );
 
-  auto dictionaries = !grp ? grp->dictionaries : allDictionaries;
+  auto dictionaries = grp ? grp->dictionaries : allDictionaries;
   QStringList ids   = definition->getArticlesList();
   QString activeId  = definition->getActiveArticleId();
   toolbar->clear();
-  if ( actionGroup ) {
-    delete actionGroup;
+  if ( actionGroup!= nullptr ) {
+    actionGroup->deleteLater();
   }
   actionGroup = new QActionGroup( this );
   actionGroup->setExclusive( true );

--- a/src/ui/scanpopup.hh
+++ b/src/ui/scanpopup.hh
@@ -139,7 +139,7 @@ private:
   Config::Events configEvents;
   DictionaryBar dictionaryBar;
   QToolBar * toolbar;
-  QActionGroup *actionGroup;
+  QActionGroup * actionGroup;
   MainStatusBar * mainStatusBar;
   /// Fonts saved before words zooming is in effect, so it could be reset back.
   QFont wordListDefaultFont, translateLineDefaultFont, groupListDefaultFont;

--- a/src/ui/scanpopup.hh
+++ b/src/ui/scanpopup.hh
@@ -11,6 +11,8 @@
 #include "ui_scanpopup.h"
 #include <QDialog>
 #include <QClipboard>
+#include <QToolBar>
+#include <QActionGroup>
 #include "history.hh"
 #include "dictionarybar.hh"
 #include "mainstatusbar.hh"
@@ -136,7 +138,8 @@ private:
   WordFinder wordFinder;
   Config::Events configEvents;
   DictionaryBar dictionaryBar;
-  QToolBar * toolBar;
+  QToolBar * toolbar;
+  QActionGroup *actionGroup;
   MainStatusBar * mainStatusBar;
   /// Fonts saved before words zooming is in effect, so it could be reset back.
   QFont wordListDefaultFont, translateLineDefaultFont, groupListDefaultFont;

--- a/src/ui/scanpopup.hh
+++ b/src/ui/scanpopup.hh
@@ -140,7 +140,7 @@ private:
   Config::Events configEvents;
   DictionaryBar dictionaryBar;
   QToolBar * toolbar;
-  QActionGroup * actionGroup;
+  QActionGroup * actionGroup=nullptr;
   MainStatusBar * mainStatusBar;
   /// Fonts saved before words zooming is in effect, so it could be reset back.
   QFont wordListDefaultFont, translateLineDefaultFont, groupListDefaultFont;

--- a/src/ui/scanpopup.hh
+++ b/src/ui/scanpopup.hh
@@ -232,4 +232,5 @@ private slots:
 
   void titleChanged( ArticleView *, QString const & title ) const;
   void updateFoundInDictsList();
+  void onActionTriggered();
 };

--- a/src/ui/scanpopup.hh
+++ b/src/ui/scanpopup.hh
@@ -136,6 +136,7 @@ private:
   WordFinder wordFinder;
   Config::Events configEvents;
   DictionaryBar dictionaryBar;
+  QToolBar * toolBar;
   MainStatusBar * mainStatusBar;
   /// Fonts saved before words zooming is in effect, so it could be reset back.
   QFont wordListDefaultFont, translateLineDefaultFont, groupListDefaultFont;
@@ -227,4 +228,5 @@ private slots:
   void alwaysOnTopClicked( bool checked );
 
   void titleChanged( ArticleView *, QString const & title ) const;
+  void updateFoundInDictsList();
 };

--- a/src/ui/scanpopup.hh
+++ b/src/ui/scanpopup.hh
@@ -140,7 +140,7 @@ private:
   Config::Events configEvents;
   DictionaryBar dictionaryBar;
   QToolBar * toolbar;
-  QActionGroup * actionGroup=nullptr;
+  QActionGroup * actionGroup = nullptr;
   MainStatusBar * mainStatusBar;
   /// Fonts saved before words zooming is in effect, so it could be reset back.
   QFont wordListDefaultFont, translateLineDefaultFont, groupListDefaultFont;

--- a/src/ui/scanpopup.hh
+++ b/src/ui/scanpopup.hh
@@ -12,13 +12,14 @@
 #include <QDialog>
 #include <QClipboard>
 #include <QToolBar>
-#include <QActionGroup>
 #include "history.hh"
 #include "dictionarybar.hh"
 #include "mainstatusbar.hh"
 #ifdef HAVE_X11
   #include "scanflag.hh"
 #endif
+
+#include <QActionGroup>
 
 /// This is a popup dialog to show translations when clipboard scanning mode
 /// is enabled.


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4f912a76-2262-4751-9ee6-c6ed26381860)

add a new toolbar at the right side(default) , the toolbar will hold all the found dictionaries which will navigate to the target dictionary when clicked.