### PR TITLE
doc: windows runtime requirement

### DIFF
--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -20,7 +20,7 @@ Choose either
 
 If Qt's version is not changed, you can also download a single `goldendict.exe` and drop it into previous installation's folder (If uncertain, don't do this).
 
-Requires Windows 10 (1809 or later) with [MSVC](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version) runtime.
+Requires Windows 10 (1809 or later) with [MSVC runtime](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version) installed.
 
 
 ## Linux

--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -20,7 +20,8 @@ Choose either
 
 If Qt's version is not changed, you can also download a single `goldendict.exe` and drop it into previous installation's folder (If uncertain, don't do this).
 
-Requires Windows 10 (1809 or later).
+Requires Windows 10 (1809 or later) with [MSVC](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version) runtime.
+
 
 ## Linux
 


### PR DESCRIPTION
On plain installation of windows, goldendict-ng seems to need MSVC runtime.  Mentioning this in the doc would improve user experience. 

Errors:
1. The code execution cannot proceed because MSVCP140.dll was not found. reinstalling the program may fix this problem.
2. The code execution cannot proceed because VCRUNTIME140.dll was not found. reinstalling the program may fix this problem.