### PR TITLE
fix: respect the setting of QT_ENABLE_HIGHDPI_SCALING of the system

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -348,8 +348,8 @@ int main( int argc, char ** argv )
 
 
   //high dpi screen support
-  if (!qEnvironmentVariableIsSet("QT_ENABLE_HIGHDPI_SCALING") ||
-       qEnvironmentVariableIsEmpty("QT_ENABLE_HIGHDPI_SCALING")) {
+  if ( !qEnvironmentVariableIsSet( "QT_ENABLE_HIGHDPI_SCALING" )
+       || qEnvironmentVariableIsEmpty( "QT_ENABLE_HIGHDPI_SCALING" ) ) {
     qputenv( "QT_ENABLE_HIGHDPI_SCALING", "1" );
   }
   QApplication::setHighDpiScaleFactorRoundingPolicy( Qt::HighDpiScaleFactorRoundingPolicy::PassThrough );

--- a/src/main.cc
+++ b/src/main.cc
@@ -351,8 +351,8 @@ int main( int argc, char ** argv )
   if (!qEnvironmentVariableIsSet("QT_ENABLE_HIGHDPI_SCALING") ||
        qEnvironmentVariableIsEmpty("QT_ENABLE_HIGHDPI_SCALING")) {
     qputenv( "QT_ENABLE_HIGHDPI_SCALING", "1" );
-    QApplication::setHighDpiScaleFactorRoundingPolicy( Qt::HighDpiScaleFactorRoundingPolicy::PassThrough );
   }
+  QApplication::setHighDpiScaleFactorRoundingPolicy( Qt::HighDpiScaleFactorRoundingPolicy::PassThrough );
 
   QHotkeyApplication app( "GoldenDict-ng", argc, argv );
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -348,8 +348,11 @@ int main( int argc, char ** argv )
 
 
   //high dpi screen support
-  qputenv( "QT_ENABLE_HIGHDPI_SCALING", "1" );
-  QApplication::setHighDpiScaleFactorRoundingPolicy( Qt::HighDpiScaleFactorRoundingPolicy::PassThrough );
+  if (!qEnvironmentVariableIsSet("QT_ENABLE_HIGHDPI_SCALING") ||
+       qEnvironmentVariableIsEmpty("QT_ENABLE_HIGHDPI_SCALING")) {
+    qputenv( "QT_ENABLE_HIGHDPI_SCALING", "1" );
+    QApplication::setHighDpiScaleFactorRoundingPolicy( Qt::HighDpiScaleFactorRoundingPolicy::PassThrough );
+  }
 
   QHotkeyApplication app( "GoldenDict-ng", argc, argv );
 


### PR DESCRIPTION
Setting QT_ENABLE_HIGHDPI_SCALING to 1 might not work well in some cases. Instead of hard-coding it to 1, this commit checks if it is already set, and if it is empty or not set, then set it to 1. This allows overriding the QT_ENABLE_HIGHDPI_SCALING to 0 by respecting the system-wide setting of environment variables.