### PR TITLE
reverse order of <release> in metainfo.xml for flathub's linter

### DIFF
--- a/redist/io.github.xiaoyifang.goldendict_ng.metainfo.xml
+++ b/redist/io.github.xiaoyifang.goldendict_ng.metainfo.xml
@@ -41,10 +41,10 @@
     <id>org.goldendict_ng.desktop</id>
   </provides>
   <releases>
-    <release version="25.02.0" date="2025-01-24" />
-    <release version="24.09.1" date="2024-11-02" />
-    <release version="24.09.0" date="2024-09-13" />
-    <release version="24.05.05" date="2024-05-05" />
     <release version="1.0.0" date="2010-12-03" />
+    <release version="24.05.05" date="2024-05-05" />
+    <release version="24.09.0" date="2024-09-13" />
+    <release version="24.09.1" date="2024-11-04" />
+    <release version="25.02.0" date="2025-01-24" />
   </releases>
 </component>


### PR DESCRIPTION
😅 f

https://github.com/flathub/io.github.xiaoyifang.goldendict_ng/pull/37

<img width="904" src="https://github.com/user-attachments/assets/d9e35edd-1e1c-48df-8d98-9127faf45a37" />
