### PR TITLE
Revert "reverse order of <release> in metainfo.xml for flathub's linter"

### DIFF
--- a/redist/io.github.xiaoyifang.goldendict_ng.metainfo.xml
+++ b/redist/io.github.xiaoyifang.goldendict_ng.metainfo.xml
@@ -41,10 +41,10 @@
     <id>org.goldendict_ng.desktop</id>
   </provides>
   <releases>
-    <release version="1.0.0" date="2010-12-03" />
-    <release version="24.05.05" date="2024-05-05" />
-    <release version="24.09.0" date="2024-09-13" />
-    <release version="24.09.1" date="2024-11-04" />
     <release version="25.02.0" date="2025-01-24" />
+    <release version="24.09.1" date="2024-11-02" />
+    <release version="24.09.0" date="2024-09-13" />
+    <release version="24.05.05" date="2024-05-05" />
+    <release version="1.0.0" date="2010-12-03" />
   </releases>
 </component>


### PR DESCRIPTION
Reverts xiaoyifang/goldendict-ng#2104

:)

https://github.com/ximion/appstream/blob/93c0af6df69e319cfb60f855f4e47472b42dac6b/src/as-validator-issue-tag.h#L905-L910

<img width="819" src="https://github.com/user-attachments/assets/2b70a96b-5b76-4d0b-b490-8017d265a8aa" />


https://github.com/flathub/io.github.xiaoyifang.goldendict_ng/pull/37