### PR TITLE
fix: interface languages inconsistency caused by corner cases of translation files loading

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -466,13 +466,13 @@ int main( int argc, char ** argv )
   QLocale::setDefault( locale );
   QApplication::setLayoutDirection( locale.textDirection() );
 
-  qDebug()<<locale;
+  qDebug() << locale;
   // Load Qt translators based on locale using QLocale-based API
   auto loadTranslation = [ &locale ]( QTranslator & qtranslator,
                                       const QString & filename,
                                       const QString & prefix,
                                       const QString & directory ) {
-    if ( qtranslator.load( locale, filename, prefix, directory,".qm" ) ) {
+    if ( qtranslator.load( locale, filename, prefix, directory, ".qm" ) ) {
       QCoreApplication::installTranslator( &qtranslator );
       qDebug() << "Loaded translator: " << qtranslator.filePath();
     }


### PR DESCRIPTION
1. use same translations loading mechanism (QLocale based QTranslator::load as suggested by https://github.com/xiaoyifang/goldendict-ng/issues/530#issuecomment-1519775951)
2. only load Qt ts file when gd's ts file loading success

<img width="400" src="https://github.com/user-attachments/assets/8020a158-cac0-48dc-aad3-7e1dd49ccebe" />

My lang_region combo is `zh-Hans-CA`

Before:

Qt loading `zh_CN` success and GD's locale failed -> inconsistency -> macOS's system menu translated and GD's menu not translated

Reason: The QLocale's string constructor may or may not have bug. If it doesn't have bug, then we uses it wrong, and something got lost as `zh-Hans-CA` becomes `zh-Hans-CN`. https://github.com/xiaoyifang/goldendict-ng/pull/2119#issuecomment-2630811073

<img width="400"  src="https://github.com/user-attachments/assets/89504caf-e4bd-459c-a6ae-2c0904dec514" />

After:

As `zh-Hans-CA` shouldn't match anything. All 3 failed.

<img width="400" src="https://github.com/user-attachments/assets/ad6541e7-576f-4035-b743-d87625b6a0b8" />
