### PR TITLE
fix: multimedia memleak

### DIFF
--- a/src/audio/multimediaaudioplayer.cc
+++ b/src/audio/multimediaaudioplayer.cc
@@ -26,12 +26,11 @@ void MultimediaAudioPlayer::audioOutputChange()
 QString MultimediaAudioPlayer::play( const char * data, int size )
 {
   stop();
-  audioBuffer = new QBuffer();
-  audioBuffer->setData( data, size );
-  if ( !audioBuffer->open( QIODevice::ReadOnly ) ) {
+  audioBuffer.setData( data, size );
+  if ( !audioBuffer.open( QIODevice::ReadOnly ) ) {
     return tr( "Couldn't open audio buffer for reading." );
   }
-  player.setSourceDevice( audioBuffer );
+  player.setSourceDevice( &audioBuffer );
 
   audioOutput.setDevice( QMediaDevices::defaultAudioOutput() );
   player.setAudioOutput( &audioOutput );
@@ -43,12 +42,8 @@ QString MultimediaAudioPlayer::play( const char * data, int size )
 void MultimediaAudioPlayer::stop()
 {
   player.stop();
-
-  if ( audioBuffer ) {
-    audioBuffer->close();
-    audioBuffer->setData( QByteArray() ); // Free memory.
-    audioBuffer.clear();
-  }
+  audioBuffer.close();
+  audioBuffer.setData( QByteArray() ); // Free memory.
 }
 
 void MultimediaAudioPlayer::onMediaPlayerError()

--- a/src/audio/multimediaaudioplayer.hh
+++ b/src/audio/multimediaaudioplayer.hh
@@ -28,7 +28,7 @@ private slots:
 
 
 private:
-  QPointer< QBuffer > audioBuffer;
+  QBuffer audioBuffer;
   QMediaPlayer player; ///< Depends on audioBuffer.
   QAudioOutput audioOutput;
   QMediaDevices mediaDevices;

--- a/src/audio/multimediaaudioplayer.hh
+++ b/src/audio/multimediaaudioplayer.hh
@@ -10,7 +10,6 @@
   #include <QBuffer>
   #include <QMediaDevices>
   #include <QMediaPlayer>
-  #include <QPointer>
 
 class MultimediaAudioPlayer: public AudioPlayerInterface
 {


### PR DESCRIPTION
QPointer.clear will not delete, like unique_ptr. So just make the QBuffer in the stack.