### PR TITLE
clean: replace QAbstractItemModel with more suitable QAbstractTableModel

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -35,6 +35,7 @@ Checks: >
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
   -performance-enum-size,
+  -readability-else-after-return,
   -readability-function-cognitive-complexity,
   -readability-identifier-length,
   -readability-magic-numbers,

--- a/src/ui/edit_sources_models.cc
+++ b/src/ui/edit_sources_models.cc
@@ -87,7 +87,7 @@ Sources::Sources( QWidget * parent, Config::Class const & cfg ):
 
   ui.paths->setTabKeyNavigation( true );
   ui.paths->setModel( &pathsModel );
-
+  
   fitPathsColumns();
 
   ui.soundDirs->setTabKeyNavigation( true );
@@ -389,7 +389,7 @@ Config::Forvo Sources::getForvo() const
 ////////// MediaWikisModel
 
 MediaWikisModel::MediaWikisModel( QWidget * parent, Config::MediaWikis const & mediawikis_ ):
-  QAbstractItemModel( parent ),
+  QAbstractTableModel( parent ),
   mediawikis( mediawikis_ )
 {
 }
@@ -417,15 +417,6 @@ void MediaWikisModel::addNewWiki()
   endInsertRows();
 }
 
-QModelIndex MediaWikisModel::index( int row, int column, QModelIndex const & /*parent*/ ) const
-{
-  return createIndex( row, column );
-}
-
-QModelIndex MediaWikisModel::parent( QModelIndex const & /*parent*/ ) const
-{
-  return QModelIndex();
-}
 
 Qt::ItemFlags MediaWikisModel::flags( QModelIndex const & index ) const
 {
@@ -560,7 +551,7 @@ bool MediaWikisModel::setData( QModelIndex const & index, const QVariant & value
 ////////// WebSitesModel
 
 WebSitesModel::WebSitesModel( QWidget * parent, Config::WebSites const & webSites_ ):
-  QAbstractItemModel( parent ),
+  QAbstractTableModel( parent ),
   webSites( webSites_ )
 {
 }
@@ -588,15 +579,6 @@ void WebSitesModel::addNewSite()
   endInsertRows();
 }
 
-QModelIndex WebSitesModel::index( int row, int column, QModelIndex const & /*parent*/ ) const
-{
-  return createIndex( row, column );
-}
-
-QModelIndex WebSitesModel::parent( QModelIndex const & /*parent*/ ) const
-{
-  return QModelIndex();
-}
 
 Qt::ItemFlags WebSitesModel::flags( QModelIndex const & index ) const
 {
@@ -751,7 +733,7 @@ bool WebSitesModel::setData( QModelIndex const & index, const QVariant & value, 
 ////////// DictServersModel
 
 DictServersModel::DictServersModel( QWidget * parent, Config::DictServers const & dictServers_ ):
-  QAbstractItemModel( parent ),
+  QAbstractTableModel( parent ),
   dictServers( dictServers_ )
 {
 }
@@ -775,16 +757,6 @@ void DictServersModel::addNewServer()
   beginInsertRows( QModelIndex(), dictServers.size(), dictServers.size() );
   dictServers.push_back( d );
   endInsertRows();
-}
-
-QModelIndex DictServersModel::index( int row, int column, QModelIndex const & /*parent*/ ) const
-{
-  return createIndex( row, column );
-}
-
-QModelIndex DictServersModel::parent( QModelIndex const & /*parent*/ ) const
-{
-  return QModelIndex();
 }
 
 Qt::ItemFlags DictServersModel::flags( QModelIndex const & index ) const
@@ -933,7 +905,7 @@ bool DictServersModel::setData( QModelIndex const & index, const QVariant & valu
 ////////// ProgramsModel
 
 ProgramsModel::ProgramsModel( QWidget * parent, Config::Programs const & programs_ ):
-  QAbstractItemModel( parent ),
+  QAbstractTableModel( parent ),
   programs( programs_ )
 {
 }
@@ -957,16 +929,6 @@ void ProgramsModel::addNewProgram()
   beginInsertRows( QModelIndex(), programs.size(), programs.size() );
   programs.push_back( p );
   endInsertRows();
-}
-
-QModelIndex ProgramsModel::index( int row, int column, QModelIndex const & /*parent*/ ) const
-{
-  return createIndex( row, column );
-}
-
-QModelIndex ProgramsModel::parent( QModelIndex const & /*parent*/ ) const
-{
-  return QModelIndex();
 }
 
 Qt::ItemFlags ProgramsModel::flags( QModelIndex const & index ) const
@@ -1136,7 +1098,7 @@ void ProgramTypeEditor::setType( int t )
 ////////// PathsModel
 
 PathsModel::PathsModel( QWidget * parent, Config::Paths const & paths_ ):
-  QAbstractItemModel( parent ),
+  QAbstractTableModel( parent ),
   paths( paths_ )
 {
 }
@@ -1155,19 +1117,9 @@ void PathsModel::addNewPath( QString const & path )
   endInsertRows();
 }
 
-QModelIndex PathsModel::index( int row, int column, QModelIndex const & /*parent*/ ) const
-{
-  return createIndex( row, column );
-}
-
-QModelIndex PathsModel::parent( QModelIndex const & /*parent*/ ) const
-{
-  return QModelIndex();
-}
-
 Qt::ItemFlags PathsModel::flags( QModelIndex const & index ) const
 {
-  Qt::ItemFlags result = QAbstractItemModel::flags( index );
+  Qt::ItemFlags result = QAbstractTableModel::flags( index );
 
   if ( Config::isPortableVersion() ) {
     if ( index.isValid() && index.row() == 0 ) {
@@ -1256,7 +1208,7 @@ bool PathsModel::setData( QModelIndex const & index, const QVariant & /*value*/,
 ////////// SoundDirsModel
 
 SoundDirsModel::SoundDirsModel( QWidget * parent, Config::SoundDirs const & soundDirs_ ):
-  QAbstractItemModel( parent ),
+  QAbstractTableModel( parent ),
   soundDirs( soundDirs_ )
 {
 }
@@ -1273,16 +1225,6 @@ void SoundDirsModel::addNewSoundDir( QString const & path, QString const & name 
   beginInsertRows( QModelIndex(), soundDirs.size(), soundDirs.size() );
   soundDirs.push_back( Config::SoundDir( path, name ) );
   endInsertRows();
-}
-
-QModelIndex SoundDirsModel::index( int row, int column, QModelIndex const & /*parent*/ ) const
-{
-  return createIndex( row, column );
-}
-
-QModelIndex SoundDirsModel::parent( QModelIndex const & /*parent*/ ) const
-{
-  return QModelIndex();
 }
 
 Qt::ItemFlags SoundDirsModel::flags( QModelIndex const & index ) const
@@ -1383,7 +1325,7 @@ bool SoundDirsModel::setData( QModelIndex const & index, const QVariant & value,
 ////////// HunspellDictsModel
 
 HunspellDictsModel::HunspellDictsModel( QWidget * parent, Config::Hunspell const & hunspell ):
-  QAbstractItemModel( parent ),
+  QAbstractTableModel( parent ),
   enabledDictionaries( hunspell.enabledDictionaries )
 {
   changePath( hunspell.dictionariesPath );
@@ -1394,16 +1336,6 @@ void HunspellDictsModel::changePath( QString const & newPath )
   dataFiles = HunspellMorpho::findDataFiles( newPath );
   beginResetModel();
   endResetModel();
-}
-
-QModelIndex HunspellDictsModel::index( int row, int column, QModelIndex const & /*parent*/ ) const
-{
-  return createIndex( row, column );
-}
-
-QModelIndex HunspellDictsModel::parent( QModelIndex const & /*parent*/ ) const
-{
-  return QModelIndex();
 }
 
 Qt::ItemFlags HunspellDictsModel::flags( QModelIndex const & index ) const

--- a/src/ui/edit_sources_models.cc
+++ b/src/ui/edit_sources_models.cc
@@ -87,7 +87,7 @@ Sources::Sources( QWidget * parent, Config::Class const & cfg ):
 
   ui.paths->setTabKeyNavigation( true );
   ui.paths->setModel( &pathsModel );
-  
+
   fitPathsColumns();
 
   ui.soundDirs->setTabKeyNavigation( true );

--- a/src/ui/edit_sources_models.cc
+++ b/src/ui/edit_sources_models.cc
@@ -420,7 +420,7 @@ void MediaWikisModel::addNewWiki()
 
 Qt::ItemFlags MediaWikisModel::flags( QModelIndex const & index ) const
 {
-  Qt::ItemFlags result = QAbstractItemModel::flags( index );
+  Qt::ItemFlags result = QAbstractTableModel::flags( index );
 
   if ( index.isValid() ) {
     if ( !index.column() ) {
@@ -582,7 +582,7 @@ void WebSitesModel::addNewSite()
 
 Qt::ItemFlags WebSitesModel::flags( QModelIndex const & index ) const
 {
-  Qt::ItemFlags result = QAbstractItemModel::flags( index );
+  Qt::ItemFlags result = QAbstractTableModel::flags( index );
 
   if ( index.isValid() ) {
     if ( index.column() <= 1 ) {
@@ -761,7 +761,7 @@ void DictServersModel::addNewServer()
 
 Qt::ItemFlags DictServersModel::flags( QModelIndex const & index ) const
 {
-  Qt::ItemFlags result = QAbstractItemModel::flags( index );
+  Qt::ItemFlags result = QAbstractTableModel::flags( index );
 
   if ( index.isValid() ) {
     if ( !index.column() ) {
@@ -933,7 +933,7 @@ void ProgramsModel::addNewProgram()
 
 Qt::ItemFlags ProgramsModel::flags( QModelIndex const & index ) const
 {
-  Qt::ItemFlags result = QAbstractItemModel::flags( index );
+  Qt::ItemFlags result = QAbstractTableModel::flags( index );
 
   if ( index.isValid() ) {
     if ( !index.column() ) {
@@ -1229,7 +1229,7 @@ void SoundDirsModel::addNewSoundDir( QString const & path, QString const & name 
 
 Qt::ItemFlags SoundDirsModel::flags( QModelIndex const & index ) const
 {
-  Qt::ItemFlags result = QAbstractItemModel::flags( index );
+  Qt::ItemFlags result = QAbstractTableModel::flags( index );
 
   if ( index.isValid() && index.column() < 3 ) {
     result |= Qt::ItemIsEditable;
@@ -1340,7 +1340,7 @@ void HunspellDictsModel::changePath( QString const & newPath )
 
 Qt::ItemFlags HunspellDictsModel::flags( QModelIndex const & index ) const
 {
-  Qt::ItemFlags result = QAbstractItemModel::flags( index );
+  Qt::ItemFlags result = QAbstractTableModel::flags( index );
 
   if ( index.isValid() ) {
     if ( !index.column() ) {

--- a/src/ui/edit_sources_models.hh
+++ b/src/ui/edit_sources_models.hh
@@ -18,7 +18,7 @@ class ChineseConversion;
 #endif
 
 /// A model to be projected into the mediawikis view, according to Qt's MVC model
-class MediaWikisModel: public QAbstractItemModel
+class MediaWikisModel: public QAbstractTableModel
 {
   Q_OBJECT
 
@@ -35,14 +35,12 @@ public:
     return mediawikis;
   }
 
-  QModelIndex index( int row, int column, QModelIndex const & parent ) const;
-  QModelIndex parent( QModelIndex const & parent ) const;
-  Qt::ItemFlags flags( QModelIndex const & index ) const;
-  int rowCount( QModelIndex const & parent ) const;
-  int columnCount( QModelIndex const & parent ) const;
-  QVariant headerData( int section, Qt::Orientation orientation, int role ) const;
-  QVariant data( QModelIndex const & index, int role ) const;
-  bool setData( QModelIndex const & index, const QVariant & value, int role );
+  Qt::ItemFlags flags( QModelIndex const & index ) const override;
+  int rowCount( QModelIndex const & parent ) const override;
+  int columnCount( QModelIndex const & parent ) const override;
+  QVariant headerData( int section, Qt::Orientation orientation, int role ) const override;
+  QVariant data( QModelIndex const & index, int role ) const override;
+  bool setData( QModelIndex const & index, const QVariant & value, int role ) override;
 
 private:
 
@@ -50,7 +48,7 @@ private:
 };
 
 /// A model to be projected into the webSites view, according to Qt's MVC model
-class WebSitesModel: public QAbstractItemModel
+class WebSitesModel: public QAbstractTableModel
 {
   Q_OBJECT
 
@@ -67,14 +65,12 @@ public:
     return webSites;
   }
 
-  QModelIndex index( int row, int column, QModelIndex const & parent ) const;
-  QModelIndex parent( QModelIndex const & parent ) const;
-  Qt::ItemFlags flags( QModelIndex const & index ) const;
-  int rowCount( QModelIndex const & parent ) const;
-  int columnCount( QModelIndex const & parent ) const;
-  QVariant headerData( int section, Qt::Orientation orientation, int role ) const;
-  QVariant data( QModelIndex const & index, int role ) const;
-  bool setData( QModelIndex const & index, const QVariant & value, int role );
+  Qt::ItemFlags flags( QModelIndex const & index ) const override;
+  int rowCount( QModelIndex const & parent ) const override;
+  int columnCount( QModelIndex const & parent ) const override;
+  QVariant headerData( int section, Qt::Orientation orientation, int role ) const override;
+  QVariant data( QModelIndex const & index, int role ) const override;
+  bool setData( QModelIndex const & index, const QVariant & value, int role ) override;
 
 private:
 
@@ -82,7 +78,7 @@ private:
 };
 
 /// A model to be projected into the dictServers view, according to Qt's MVC model
-class DictServersModel: public QAbstractItemModel
+class DictServersModel: public QAbstractTableModel
 {
   Q_OBJECT
 
@@ -99,14 +95,12 @@ public:
     return dictServers;
   }
 
-  QModelIndex index( int row, int column, QModelIndex const & parent ) const;
-  QModelIndex parent( QModelIndex const & parent ) const;
-  Qt::ItemFlags flags( QModelIndex const & index ) const;
-  int rowCount( QModelIndex const & parent ) const;
-  int columnCount( QModelIndex const & parent ) const;
-  QVariant headerData( int section, Qt::Orientation orientation, int role ) const;
-  QVariant data( QModelIndex const & index, int role ) const;
-  bool setData( QModelIndex const & index, const QVariant & value, int role );
+  Qt::ItemFlags flags( QModelIndex const & index ) const override;
+  int rowCount( QModelIndex const & parent ) const override;
+  int columnCount( QModelIndex const & parent ) const override;
+  QVariant headerData( int section, Qt::Orientation orientation, int role ) const override;
+  QVariant data( QModelIndex const & index, int role ) const override;
+  bool setData( QModelIndex const & index, const QVariant & value, int role ) override;
 
 private:
 
@@ -114,7 +108,7 @@ private:
 };
 
 /// A model to be projected into the programs view, according to Qt's MVC model
-class ProgramsModel: public QAbstractItemModel
+class ProgramsModel: public QAbstractTableModel
 {
   Q_OBJECT
 
@@ -131,14 +125,12 @@ public:
     return programs;
   }
 
-  QModelIndex index( int row, int column, QModelIndex const & parent ) const;
-  QModelIndex parent( QModelIndex const & parent ) const;
-  Qt::ItemFlags flags( QModelIndex const & index ) const;
-  int rowCount( QModelIndex const & parent ) const;
-  int columnCount( QModelIndex const & parent ) const;
-  QVariant headerData( int section, Qt::Orientation orientation, int role ) const;
-  QVariant data( QModelIndex const & index, int role ) const;
-  bool setData( QModelIndex const & index, const QVariant & value, int role );
+  Qt::ItemFlags flags( QModelIndex const & index ) const override;
+  int rowCount( QModelIndex const & parent ) const override;
+  int columnCount( QModelIndex const & parent ) const override;
+  QVariant headerData( int section, Qt::Orientation orientation, int role ) const override;
+  QVariant data( QModelIndex const & index, int role ) const override;
+  bool setData( QModelIndex const & index, const QVariant & value, int role ) override;
 
 private:
 
@@ -162,7 +154,7 @@ public:
 };
 
 /// A model to be projected into the paths view, according to Qt's MVC model
-class PathsModel: public QAbstractItemModel
+class PathsModel: public QAbstractTableModel
 {
   Q_OBJECT
 
@@ -179,14 +171,12 @@ public:
     return paths;
   }
 
-  QModelIndex index( int row, int column, QModelIndex const & parent ) const;
-  QModelIndex parent( QModelIndex const & parent ) const;
-  Qt::ItemFlags flags( QModelIndex const & index ) const;
-  int rowCount( QModelIndex const & parent ) const;
-  int columnCount( QModelIndex const & parent ) const;
-  QVariant headerData( int section, Qt::Orientation orientation, int role ) const;
-  QVariant data( QModelIndex const & index, int role ) const;
-  bool setData( QModelIndex const & index, const QVariant & value, int role );
+  Qt::ItemFlags flags( QModelIndex const & index ) const override;
+  int rowCount( QModelIndex const & parent ) const override;
+  int columnCount( QModelIndex const & parent ) const override;
+  QVariant headerData( int section, Qt::Orientation orientation, int role ) const override;
+  QVariant data( QModelIndex const & index, int role ) const override;
+  bool setData( QModelIndex const & index, const QVariant & value, int role ) override;
 
 private:
 
@@ -194,7 +184,7 @@ private:
 };
 
 /// A model to be projected into the soundDirs view, according to Qt's MVC model
-class SoundDirsModel: public QAbstractItemModel
+class SoundDirsModel: public QAbstractTableModel
 {
   Q_OBJECT
 
@@ -211,14 +201,12 @@ public:
     return soundDirs;
   }
 
-  QModelIndex index( int row, int column, QModelIndex const & parent ) const;
-  QModelIndex parent( QModelIndex const & parent ) const;
-  Qt::ItemFlags flags( QModelIndex const & index ) const;
-  int rowCount( QModelIndex const & parent ) const;
-  int columnCount( QModelIndex const & parent ) const;
-  QVariant headerData( int section, Qt::Orientation orientation, int role ) const;
-  QVariant data( QModelIndex const & index, int role ) const;
-  bool setData( QModelIndex const & index, const QVariant & value, int role );
+  Qt::ItemFlags flags( QModelIndex const & index ) const override;
+  int rowCount( QModelIndex const & parent ) const override;
+  int columnCount( QModelIndex const & parent ) const override;
+  QVariant headerData( int section, Qt::Orientation orientation, int role ) const override;
+  QVariant data( QModelIndex const & index, int role ) const override;
+  bool setData( QModelIndex const & index, const QVariant & value, int role ) override;
 
 private:
 
@@ -226,7 +214,7 @@ private:
 };
 
 /// A model to be projected into the hunspell dictionaries view, according to Qt's MVC model
-class HunspellDictsModel: public QAbstractItemModel
+class HunspellDictsModel: public QAbstractTableModel
 {
   Q_OBJECT
 
@@ -242,14 +230,12 @@ public:
     return enabledDictionaries;
   }
 
-  QModelIndex index( int row, int column, QModelIndex const & parent ) const;
-  QModelIndex parent( QModelIndex const & parent ) const;
-  Qt::ItemFlags flags( QModelIndex const & index ) const;
-  int rowCount( QModelIndex const & parent ) const;
-  int columnCount( QModelIndex const & parent ) const;
-  QVariant headerData( int section, Qt::Orientation orientation, int role ) const;
-  QVariant data( QModelIndex const & index, int role ) const;
-  bool setData( QModelIndex const & index, const QVariant & value, int role );
+  Qt::ItemFlags flags( QModelIndex const & index ) const override;
+  int rowCount( QModelIndex const & parent ) const override;
+  int columnCount( QModelIndex const & parent ) const override;
+  QVariant headerData( int section, Qt::Orientation orientation, int role ) const override;
+  QVariant data( QModelIndex const & index, int role ) const override;
+  bool setData( QModelIndex const & index, const QVariant & value, int role ) override;
 
 private:
 


### PR DESCRIPTION
- delete boilerplates (`parent` which is useless for 2 dimension data & `index` which can just have a fix implementation for 2 dimension data)
- add `override` when overriding

The primary feature of `QAbstractTableModel` is implementing things that isn't needed by a table-like data, which is what we use.
