### PR TITLE
clean: rm oudated TODO about QItemEditorFactory::registerEditor's lifetime

### DIFF
--- a/src/ui/edit_sources_models.cc
+++ b/src/ui/edit_sources_models.cc
@@ -37,11 +37,8 @@ Sources::Sources( QWidget * parent, Config::Class const & cfg ):
   Config::Lingua const & lingua = cfg.lingua;
   Config::Forvo const & forvo   = cfg.forvo;
 
-  // TODO: will programTypeEditorCreator and itemEditorFactory be destroyed by
-  // anyone?
-  QItemEditorCreatorBase * programTypeEditorCreator = new QStandardItemEditorCreator< ProgramTypeEditor >();
-
-  itemEditorFactory->registerEditor( QMetaType::Int, programTypeEditorCreator );
+  // itemEditorFactory owns the ProgramTypeEditor
+  itemEditorFactory->registerEditor( QMetaType::Int, new QStandardItemEditorCreator< ProgramTypeEditor >() );
 
   itemDelegate->setItemEditorFactory( itemEditorFactory.get() );
 


### PR DESCRIPTION
https://doc.qt.io/qt-6/qitemeditorfactory.html#registerEditor

The original GD is leaking memory here.

However, it is fixed by https://github.com/xiaoyifang/goldendict-ng/commit/16f853b68b5c648fd42baeeb35158162539079a6#diff-b04fa5c862334cf34d4f59188ab1bd597387ece9a46b3149fea381bcd42ec195R299