### PR TITLE
refactor: use configure_file for build time string data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ hotkeys.pro.user.*
 object_script.goldendict.Debug
 object_script.goldendict.Release
 
-version.txt
+src/build_config.hh
 
 *.dmg
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ qt_standard_project_setup()
 set(CMAKE_AUTORCC ON) # not included in the qt_standard_project_setup
 
 #### Things required during configuration
-block() # generate version.txt
+block(PROPAGATE GD_VERSION_FULL)
     string(TIMESTAMP build_time UTC)
     find_package(Git)
     if (EXISTS "${CMAKE_SOURCE_DIR}/.git" AND GIT_FOUND)
@@ -79,9 +79,9 @@ block() # generate version.txt
                 COMMAND ${GIT_EXECUTABLE} -C "${CMAKE_SOURCE_DIR}" rev-parse --short HEAD
                 OUTPUT_STRIP_TRAILING_WHITESPACE
                 OUTPUT_VARIABLE GIT_HASH)
-        file(WRITE "${CMAKE_SOURCE_DIR}/version.txt" "${PROJECT_VERSION}.${GIT_HASH} at ${build_time}")
+        set(GD_VERSION_FULL "${PROJECT_VERSION}.${GIT_HASH} at ${build_time}")
     else () # not built in a git repo
-        file(WRITE "${CMAKE_SOURCE_DIR}/version.txt" "${PROJECT_VERSION} at ${build_time}")
+        set(GD_VERSION_FULL "${PROJECT_VERSION} at ${build_time}")
     endif ()
 endblock()
 
@@ -138,10 +138,6 @@ if (NOT USE_SYSTEM_FMT)
 endif ()
 
 ### Common parts amount all platforms
-
-# Note: used as c++ string thus need surrounding " "
-add_compile_definitions(PROGRAM_VERSION="${PROJECT_VERSION}")
-
 target_link_libraries(${GOLDENDICT} PRIVATE
         Qt6::Xml
         Qt6::Concurrent
@@ -226,4 +222,5 @@ elseif (WIN32)
     include(cmake/Package_Windows.cmake)
 endif ()
 
+configure_file("${CMAKE_SOURCE_DIR}/src/build_config.hh.in" "${CMAKE_SOURCE_DIR}/src/build_config.hh")
 feature_summary(WHAT ALL DESCRIPTION "Build configuration:")

--- a/cmake/Package_Linux.cmake
+++ b/cmake/Package_Linux.cmake
@@ -3,11 +3,11 @@ install(FILES ${CMAKE_SOURCE_DIR}/redist/io.github.xiaoyifang.goldendict_ng.desk
 install(FILES ${CMAKE_SOURCE_DIR}/redist/io.github.xiaoyifang.goldendict_ng.metainfo.xml DESTINATION share/metainfo)
 
 if (NOT USE_ALTERNATIVE_NAME)
-    add_compile_definitions(PROGRAM_DATA_DIR="${CMAKE_INSTALL_PREFIX}/share/goldendict")
+    set(GD_PROGRAM_DATA_DIR "${CMAKE_INSTALL_PREFIX}/share/goldendict")
     install(FILES ${CMAKE_SOURCE_DIR}/redist/icons/goldendict.png DESTINATION share/pixmaps)
     install(FILES ${qm_files} DESTINATION share/goldendict/locale)
 else ()
-    add_compile_definitions(PROGRAM_DATA_DIR="${CMAKE_INSTALL_PREFIX}/share/goldendict-ng")
+    set(GD_PROGRAM_DATA_DIR "${CMAKE_INSTALL_PREFIX}/share/goldendict-ng")
     install(FILES ${CMAKE_SOURCE_DIR}/redist/icons/goldendict.png DESTINATION share/pixmaps
             RENAME goldendict-ng.png)
     install(FILES ${qm_files} DESTINATION share/goldendict-ng/locale)

--- a/cmake/Package_Linux.cmake
+++ b/cmake/Package_Linux.cmake
@@ -3,11 +3,11 @@ install(FILES ${CMAKE_SOURCE_DIR}/redist/io.github.xiaoyifang.goldendict_ng.desk
 install(FILES ${CMAKE_SOURCE_DIR}/redist/io.github.xiaoyifang.goldendict_ng.metainfo.xml DESTINATION share/metainfo)
 
 if (NOT USE_ALTERNATIVE_NAME)
-    set(GD_PROGRAM_DATA_DIR "${CMAKE_INSTALL_PREFIX}/share/goldendict")
+    set(GD_PROGRAM_DATA_DIR "\"${CMAKE_INSTALL_PREFIX}/share/goldendict\"")
     install(FILES ${CMAKE_SOURCE_DIR}/redist/icons/goldendict.png DESTINATION share/pixmaps)
     install(FILES ${qm_files} DESTINATION share/goldendict/locale)
 else ()
-    set(GD_PROGRAM_DATA_DIR "${CMAKE_INSTALL_PREFIX}/share/goldendict-ng")
+    set(GD_PROGRAM_DATA_DIR "\"${CMAKE_INSTALL_PREFIX}/share/goldendict-ng\"")
     install(FILES ${CMAKE_SOURCE_DIR}/redist/icons/goldendict.png DESTINATION share/pixmaps
             RENAME goldendict-ng.png)
     install(FILES ${qm_files} DESTINATION share/goldendict-ng/locale)

--- a/resources.qrc
+++ b/resources.qrc
@@ -3,7 +3,6 @@
         <file>icons/add-anki-icon.svg</file>
         <file>icons/document.png</file>
         <file>icons/audio.png</file>
-        <file>version.txt</file>
         <file>icons/arrow.png</file>
         <file>icons/prefix.png</file>
         <file>icons/playsound.png</file>

--- a/src/build_config.hh.in
+++ b/src/build_config.hh.in
@@ -3,5 +3,5 @@
 constexpr auto GD_VERSION_NUMBER = "@PROJECT_VERSION@";
 constexpr auto GD_VERSION_STRING = "@GD_VERSION_FULL@";
 #if !defined( Q_OS_WIN ) && !defined( Q_OS_MACOS )
-  constexpr auto GD_PROGRAM_DATA_DIR = "@GD_PROGRAM_DATA_DIR@";
+  constexpr auto GD_PROGRAM_DATA_DIR = @GD_PROGRAM_DATA_DIR@;
 #endif

--- a/src/build_config.hh.in
+++ b/src/build_config.hh.in
@@ -1,0 +1,7 @@
+#pragma once
+#include <QtGlobal>
+constexpr auto GD_VERSION_NUMBER = "@PROJECT_VERSION@";
+constexpr auto GD_VERSION_STRING = "@GD_VERSION_FULL@";
+#if !defined( Q_OS_WIN ) && !defined( Q_OS_MACOS )
+  constexpr auto GD_PROGRAM_DATA_DIR = "@GD_PROGRAM_DATA_DIR@";
+#endif

--- a/src/config.cc
+++ b/src/config.cc
@@ -2321,6 +2321,7 @@ QString getProgramDataDir() noexcept
   // Hardcode a `$PREFIX/share/goldendict` instead of QStandardPaths::AppDataLocation
   // to avoid unnecessary downstream packaging changes
   return GD_PROGRAM_DATA_DIR;
+#endif
 }
 
 QString getLocDir() noexcept

--- a/src/config.cc
+++ b/src/config.cc
@@ -1,6 +1,7 @@
 /* This file is (c) 2008-2012 Konstantin Isakov <ikm@goldendict.org>
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
+#include "build_config.hh"
 #include "config.hh"
 #include "folding.hh"
 #include <QSaveFile>
@@ -2319,8 +2320,7 @@ QString getProgramDataDir() noexcept
 #else
   // Hardcode a `$PREFIX/share/goldendict` instead of QStandardPaths::AppDataLocation
   // to avoid unnecessary downstream packaging changes
-  return PROGRAM_DATA_DIR;
-#endif
+  return GD_PROGRAM_DATA_DIR;
 }
 
 QString getLocDir() noexcept

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -17,6 +17,7 @@
 #include "mruqmenu.hh"
 #include "gestures.hh"
 #include "dictheadwords.hh"
+#include "build_config.hh"
 #include <QTextStream>
 #include <QDir>
 #include <QUrl>
@@ -3034,7 +3035,7 @@ void MainWindow::checkNewRelease()
           QString latestVersion = tag_name.toString().mid( 1, 8 );
           QString downloadUrl   = html_url.toString();
 
-          if ( latestVersion > PROGRAM_VERSION && latestVersion != cfg.skippedRelease ) {
+          if ( latestVersion > GD_VERSION_NUMBER && latestVersion != cfg.skippedRelease ) {
             QMessageBox msg( QMessageBox::Information,
                              tr( "New Release Available" ),
                              tr( "Version <b>%1</b> of GoldenDict is now available for download.<br>"

--- a/src/version.cc
+++ b/src/version.cc
@@ -1,22 +1,12 @@
+#include "build_config.hh"
 #include "version.hh"
 #include <QFile>
 
 namespace Version {
-QString version()
-{
-  QFile versionFile( ":/version.txt" );
-
-  if ( !versionFile.open( QFile::ReadOnly ) ) {
-    return QStringLiteral( "[Unknown Version]" );
-  }
-  else {
-    return versionFile.readAll().trimmed();
-  }
-}
 
 QString everything()
 {
-  return QStringLiteral( "Version: " ) + Version::version() + "\n" + "Qt " + QLatin1String( qVersion() ) + " "
+  return QStringLiteral( "Version: " ) + GD_VERSION_STRING + "\n" + "Qt " + QLatin1String( qVersion() ) + " "
     + Version::compiler + "\n" + QSysInfo::productType() + " " + QSysInfo::kernelType() + " "
     + QSysInfo::kernelVersion() + " " + QSysInfo::buildAbi() + "\nFlags: " + flags;
 }

--- a/src/version.hh
+++ b/src/version.hh
@@ -33,10 +33,7 @@ const QLatin1String compiler = QLatin1String(
   "Unknown complier"
 #endif
 );
-/// Version string from the version.txt
-QString version();
 
-/// Full report of version & various information
 QString everything();
 
 } // namespace Version


### PR DESCRIPTION
It's pretty standard.
- autoconf -> https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.72/html_node/Configuration-Headers.html
- meson -> https://mesonbuild.com/Configuration.html

The alternative is looking these data from `build.ninja`.