### PR TITLE
feat: implement `goldendict:://{world}` URL handler for macOS

### DIFF
--- a/redist/mac_info_plist_template_cmake.plist
+++ b/redist/mac_info_plist_template_cmake.plist
@@ -14,5 +14,16 @@
 	<string>org.xiaoyifang</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+
+	<key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>goldendict</string>
+            </array>
+        </dict>
+    </array>
 </dict>
+
 </plist>

--- a/src/macos/gd_clipboard.hh
+++ b/src/macos/gd_clipboard.hh
@@ -1,6 +1,6 @@
-#ifdef __APPLE__
-  #pragma once
+#pragma once
 
+#ifdef __APPLE__
   #include <QClipboard>
   #include <QObject>
   #include <QString>

--- a/src/macos/mac_url_handler.cc
+++ b/src/macos/mac_url_handler.cc
@@ -1,0 +1,11 @@
+#ifdef __APPLE__
+  #include "mac_url_handler.hh"
+  #include <QDebug>
+
+void MacUrlHandler::processURL( const QUrl & url )
+{
+  qDebug() << "External URL received: " << url;
+  emit wordReceived( QStringLiteral( "translateWord: " ) + url.host() );
+}
+
+#endif

--- a/src/macos/mac_url_handler.hh
+++ b/src/macos/mac_url_handler.hh
@@ -1,0 +1,23 @@
+#pragma once
+#ifdef __APPLE__
+
+  #include <QObject>
+  #include <QUrl>
+
+/// See https://doc.qt.io/qt-6/qdesktopservices.html#url-handlers
+class MacUrlHandler: public QObject
+{
+  Q_OBJECT
+
+public:
+  MacUrlHandler( QObject * parent ):
+    QObject( parent )
+  {
+  }
+public slots:
+  void processURL( const QUrl & url );
+signals:
+  void wordReceived( const QString & word );
+};
+
+#endif

--- a/website/docs/topic_anki.md
+++ b/website/docs/topic_anki.md
@@ -53,5 +53,3 @@ On your Anki card's template, you can add the code below to have a "1 click open
 ```
 <a href="goldendict://{{Front}}">{{Front}}</a>
 ```
-
-Note that this feature doesn't available on macOS 


### PR DESCRIPTION
demo

https://github.com/user-attachments/assets/6f285104-7728-4876-9226-dfa8b5fee33f



- close https://github.com/xiaoyifang/goldendict-ng/issues/1867
- related https://github.com/xiaoyifang/goldendict-ng/pull/227
