### PR TITLE
handle ACE / punnycode in macOS url handler too

### DIFF
--- a/src/macos/mac_url_handler.cc
+++ b/src/macos/mac_url_handler.cc
@@ -5,7 +5,8 @@
 void MacUrlHandler::processURL( const QUrl & url )
 {
   qDebug() << "External URL received: " << url;
-  emit wordReceived( QStringLiteral( "translateWord: " ) + url.host() );
+  emit wordReceived( QStringLiteral( "translateWord: " )
+                     + QUrl::fromAce( url.authority().toLatin1(), QUrl::IgnoreIDNWhitelist ) );
 }
 
 #endif

--- a/src/macos/mac_url_handler.cc
+++ b/src/macos/mac_url_handler.cc
@@ -8,5 +8,4 @@ void MacUrlHandler::processURL( const QUrl & url )
   emit wordReceived( QStringLiteral( "translateWord: " )
                      + QUrl::fromAce( url.authority().toLatin1(), QUrl::IgnoreIDNWhitelist ) );
 }
-
 #endif


### PR DESCRIPTION
amend https://github.com/xiaoyifang/goldendict-ng/pull/2133

macOS is more uniformed. Globally, the URL will be converted to punnycode / ACE code.

Tested with Safari, so I assume it works everywhere.