### PR TITLE
clean: enable `QT_ENABLE_STRICT_MODE_UP_TO` for Qt6.8.2+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,7 @@ target_compile_definitions(${GOLDENDICT} PRIVATE
 )
 
 # make life harder https://doc.qt.io/qt-6/qtglobal.html#QT_ENABLE_STRICT_MODE_UP_TO
-if (Qt6Widgets_VERSION VERSION_GREATER_EQUAL "6.8.2")
+if (Qt6Widgets_VERSION VERSION_GREATER_EQUAL 6.8.2)
     target_compile_definitions(${GOLDENDICT} PRIVATE
             QT_ENABLE_STRICT_MODE_UP_TO=0x060800
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,13 @@ target_compile_definitions(${GOLDENDICT} PRIVATE
         QT_NO_DEPRECATED_WARNINGS
 )
 
+# make life harder https://doc.qt.io/qt-6/qtglobal.html#QT_ENABLE_STRICT_MODE_UP_TO
+if (Qt6Widgets_VERSION VERSION_GREATER_EQUAL "6.8.2")
+    target_compile_definitions(${GOLDENDICT} PRIVATE
+            QT_ENABLE_STRICT_MODE_UP_TO=0x060800
+    )
+endif ()
+
 target_compile_definitions(${GOLDENDICT} PUBLIC
         MAKE_QTMULTIMEDIA_PLAYER
         MAKE_CHINESE_CONVERSION_SUPPORT

--- a/src/dict/lingualibre.cc
+++ b/src/dict/lingualibre.cc
@@ -270,7 +270,7 @@ void LinguaArticleRequest::addQuery( QNetworkAccessManager & mgr, const std::u32
 
   qDebug() << "lingualibre query " << reqUrl;
 
-  auto netRequest = QNetworkRequest( reqUrl );
+  auto netRequest = QNetworkRequest( QUrl( reqUrl ) );
   netRequest.setTransferTimeout( 3000 );
 
   auto netReply = std::shared_ptr< QNetworkReply >( mgr.get( netRequest ) );

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -352,9 +352,7 @@ public:
       QStringList sl;
       walkNode( doc.firstChild(), sl );
 
-      QStringListIterator itr( sl );
-      while ( itr.hasNext() ) {
-        QString s = itr.next();
+      for ( auto s : sl ) {
         translatePW( s );
         ss += s;
         ss += "<br>";

--- a/src/dict/transliteration/custom.cc
+++ b/src/dict/transliteration/custom.cc
@@ -36,7 +36,7 @@ void CustomTransTable::parse( const QString & content )
       continue;
     }
 
-    ins( parts[ 0 ].toUtf8(), parts[ 1 ].toUtf8() );
+    ins( parts[ 0 ].toStdString().c_str(), parts[ 1 ].toStdString().c_str() );
   }
 }
 

--- a/src/fulltextsearch.cc
+++ b/src/fulltextsearch.cc
@@ -248,7 +248,7 @@ FullTextSearchDialog::FullTextSearchDialog( QWidget * parent,
   helpAction.setShortcut( QKeySequence( "F1" ) );
   helpAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
 
-  connect( &helpAction, &QAction::triggered, []() {
+  connect( &helpAction, &QAction::triggered, this, []() {
     Help::openHelpWebpage( Help::section::ui_fulltextserch );
   } );
   connect( ui.helpButton, &QAbstractButton::clicked, &helpAction, &QAction::trigger );

--- a/src/iframeschemehandler.cc
+++ b/src/iframeschemehandler.cc
@@ -74,7 +74,7 @@ void IframeSchemeHandler::requestStarted( QWebEngineUrlRequestJob * requestJob )
 
 
     if ( const auto match = baseTag.match( articleString ); match.hasMatch() ) {
-      base = reply->url().resolved( match.captured( 1 ) ).url();
+      base = reply->url().resolved( QUrl( match.captured( 1 ) ) ).url();
     }
 
     QString baseTagHtml = QString( R"(<base href="%1">)" ).arg( base );

--- a/src/texttospeechsource.cc
+++ b/src/texttospeechsource.cc
@@ -22,12 +22,12 @@ TextToSpeechSource::TextToSpeechSource( QWidget * parent, Config::VoiceEngines v
   ui.selectedVoiceEngines->setItemDelegateForColumn( VoiceEnginesModel::kColumnEngineDName,
                                                      new VoiceEngineItemDelegate( engines, this ) );
 
-  foreach( Config::VoiceEngine ve, voiceEngines )
+  for ( const auto & ve : voiceEngines )
   {
     occupiedEngines.insert( ve.name );
   }
 
-  foreach( SpeechClient::Engine engine, engines )
+  for ( const auto & engine : engines )
   {
     QMap< QString, QVariant > map;
     map[ "engine_name" ] = engine.engine_name;
@@ -356,8 +356,7 @@ void VoiceEnginesModel::setEngineParams( QModelIndex idx, int volume, int rate )
 VoiceEngineEditor::VoiceEngineEditor( SpeechClient::Engines const & engines, QWidget * parent ):
   QComboBox( parent )
 {
-  foreach( SpeechClient::Engine engine, engines )
-  {
+  for ( const auto & engine : engines ) {
     addItem( engine.name, engine.engine_name );
   }
 }

--- a/src/texttospeechsource.cc
+++ b/src/texttospeechsource.cc
@@ -22,13 +22,11 @@ TextToSpeechSource::TextToSpeechSource( QWidget * parent, Config::VoiceEngines v
   ui.selectedVoiceEngines->setItemDelegateForColumn( VoiceEnginesModel::kColumnEngineDName,
                                                      new VoiceEngineItemDelegate( engines, this ) );
 
-  for ( const auto & ve : voiceEngines )
-  {
+  for ( const auto & ve : voiceEngines ) {
     occupiedEngines.insert( ve.name );
   }
 
-  for ( const auto & engine : engines )
-  {
+  for ( const auto & engine : engines ) {
     QMap< QString, QVariant > map;
     map[ "engine_name" ] = engine.engine_name;
     map[ "locale" ]      = engine.locale;

--- a/src/tiff.cc
+++ b/src/tiff.cc
@@ -19,11 +19,8 @@ void tiff2img( std::vector< char > & data, const char * format )
     QSize screenSize = QApplication::primaryScreen()->availableSize();
     QSize imgSize    = img.size();
     int scaleSize    = qMin( imgSize.width(), screenSize.width() );
-
     img.scaledToWidth( scaleSize ).save( &buffer, format );
-
-    data.resize( buffer.size() );
-    memcpy( &data.front(), buffer.data(), data.size() );
+    buffer.setData( data.data(),data.size() );
     buffer.close();
   }
 }

--- a/src/tiff.cc
+++ b/src/tiff.cc
@@ -8,20 +8,23 @@
 
 namespace GdTiff {
 
-void tiff2img( std::vector< char > & data, const char * format )
+void tiff2img( std::vector< char > & data )
 {
   QImage img = QImage::fromData( (unsigned char *)&data.front(), data.size() );
 
   if ( !img.isNull() ) {
     QByteArray ba;
-    QBuffer buffer( &ba );
+
+    QBuffer buffer( &ba ); // buffer doesn't own ba
     buffer.open( QIODevice::WriteOnly );
+
     QSize screenSize = QApplication::primaryScreen()->availableSize();
     QSize imgSize    = img.size();
     int scaleSize    = qMin( imgSize.width(), screenSize.width() );
-    img.scaledToWidth( scaleSize ).save( &buffer, format );
-    buffer.setData( data.data(),data.size() );
-    buffer.close();
+    img.scaledToWidth( scaleSize ).save( &buffer, "webp" );
+
+    memcpy( data.data(), ba.data(), ba.size() );
+    data.resize( ba.size() );
   }
 }
 

--- a/src/tiff.cc
+++ b/src/tiff.cc
@@ -25,6 +25,7 @@ void tiff2img( std::vector< char > & data )
 
     memcpy( data.data(), ba.data(), ba.size() );
     data.resize( ba.size() );
+    buffer.close();
   }
 }
 

--- a/src/tiff.hh
+++ b/src/tiff.hh
@@ -5,5 +5,4 @@
 namespace GdTiff {
 
 void tiff2img( std::vector< char > & data );
-
 }

--- a/src/tiff.hh
+++ b/src/tiff.hh
@@ -4,6 +4,6 @@
 #include <vector>
 namespace GdTiff {
 
-void tiff2img( std::vector< char > & data, const char * format = "webp" );
+void tiff2img( std::vector< char > & data );
 
 }

--- a/src/ui/about.cc
+++ b/src/ui/about.cc
@@ -14,7 +14,7 @@ About::About( QWidget * parent ):
 
   ui.versionInfo->setText( Version::everything() );
 
-  connect( ui.copyInfoBtn, &QPushButton::clicked, [] {
+  connect( ui.copyInfoBtn, &QPushButton::clicked, this, [] {
     QGuiApplication::clipboard()->setText( Version::everything() );
   } );
 }

--- a/src/ui/dictheadwords.cc
+++ b/src/ui/dictheadwords.cc
@@ -92,7 +92,7 @@ DictHeadwords::DictHeadwords( QWidget * parent, Config::Class & cfg_, Dictionary
     helpAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
 
     connect( ui.helpButton, &QAbstractButton::clicked, &helpAction, &QAction::trigger );
-    connect( &helpAction, &QAction::triggered, []() {
+    connect( &helpAction, &QAction::triggered, this, []() {
       Help::openHelpWebpage( Help::section::ui_headwords );
     } );
 

--- a/src/ui/edit_dictionaries.cc
+++ b/src/ui/edit_dictionaries.cc
@@ -55,7 +55,7 @@ EditDictionaries::EditDictionaries( QWidget * parent,
   helpAction.setShortcut( QKeySequence( "F1" ) );
   helpAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
 
-  connect( &helpAction, &QAction::triggered, [ this ]() {
+  connect( &helpAction, &QAction::triggered, this, [ this ]() {
     if ( ui.tabs->currentWidget() == this->groups ) {
       Help::openHelpWebpage( Help::section::manage_groups );
     }

--- a/src/ui/favoritespanewidget.cc
+++ b/src/ui/favoritespanewidget.cc
@@ -60,9 +60,9 @@ void FavoritesPaneWidget::setUp( Config::Class * cfg, QMenu * menu )
   // Handle context menu, reusing some of the top-level window's History menu
   m_favoritesMenu = new QMenu( this );
   m_separator     = m_favoritesMenu->addSeparator();
-  QListIterator< QAction * > actionsIter( menu->actions() );
-  while ( actionsIter.hasNext() ) {
-    m_favoritesMenu->addAction( actionsIter.next() );
+
+  for ( const auto & a : menu->actions() ) {
+    m_favoritesMenu->addAction( a );
   }
 
   // Make the favorites pane's titlebar

--- a/src/ui/historypanewidget.cc
+++ b/src/ui/historypanewidget.cc
@@ -37,9 +37,8 @@ void HistoryPaneWidget::setUp( Config::Class * cfg, History * history, QMenu * m
   // Handle context menu, reusing some of the top-level window's History menu
   m_historyMenu = new QMenu( this );
   m_separator   = m_historyMenu->addSeparator();
-  QListIterator< QAction * > actionsIter( menu->actions() );
-  while ( actionsIter.hasNext() ) {
-    m_historyMenu->addAction( actionsIter.next() );
+  for ( const auto & a : menu->actions() ) {
+    m_historyMenu->addAction( a );
   }
 
   // Make the history pane's titlebar
@@ -105,9 +104,8 @@ void HistoryPaneWidget::copySelectedItems()
   }
 
   QStringList selectedStrings;
-  QListIterator< QModelIndex > i( selectedIdxs );
-  while ( i.hasNext() ) {
-    selectedStrings << m_historyList->model()->data( i.next() ).toString();
+  for ( const auto & id : selectedIdxs ) {
+    selectedStrings << m_historyList->model()->data( id ).toString();
   }
 
   QApplication::clipboard()->setText( selectedStrings.join( QString::fromLatin1( "\n" ) ) );
@@ -124,18 +122,16 @@ void HistoryPaneWidget::deleteSelectedItems()
 
   QList< int > idxsToDelete;
 
-  QListIterator< QModelIndex > i( selectedIdxs );
-  while ( i.hasNext() ) {
-    idxsToDelete << i.next().row();
+  for ( const auto & id : selectedIdxs ) {
+    idxsToDelete << id.row();
   }
 
   // Need to sort indexes in the decreasing order so that
   // the first deletions won't affect the indexes for subsequent deletions.
   std::sort( idxsToDelete.begin(), idxsToDelete.end(), std::greater< int >() );
 
-  QListIterator< int > idxs( idxsToDelete );
-  while ( idxs.hasNext() ) {
-    m_history->removeItem( idxs.next() );
+  for ( const auto & id : idxsToDelete ) {
+    m_history->removeItem( id );
   }
 
   if ( idxsToDelete.size() == 1 ) {

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -267,7 +267,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   navPronounce->setEnabled( false );
   navToolbar->widgetForAction( navPronounce )->setObjectName( "soundButton" );
 
-  connect( navPronounce, &QAction::triggered, [ this ]() {
+  connect( navPronounce, &QAction::triggered, this, [ this ]() {
     getCurrentArticleView()->playSound();
   } );
 
@@ -642,7 +642,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   connect( &addTab, &QAbstractButton::clicked, this, &MainWindow::addNewTab );
 
-  connect( ui.tabWidget, &MainTabWidget::tabBarDoubleClicked, [ this ]( const int index ) {
+  connect( ui.tabWidget, &MainTabWidget::tabBarDoubleClicked, this, [ this ]( const int index ) {
     if ( -1 == index ) { // empty space at tabbar clicked.
       this->addNewTab();
     }
@@ -666,7 +666,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   connect( ui.visitForum, &QAction::triggered, this, &MainWindow::visitForum );
   connect( ui.openConfigFolder, &QAction::triggered, this, &MainWindow::openConfigFolder );
   connect( ui.about, &QAction::triggered, this, &MainWindow::showAbout );
-  connect( ui.showReference, &QAction::triggered, []() {
+  connect( ui.showReference, &QAction::triggered, this, []() {
     Help::openHelpWebpage();
   } );
 
@@ -678,10 +678,10 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   connect( translateBox->translateLine(), &QLineEdit::textEdited, this, &MainWindow::translateInputChanged );
 
-  connect( ui.translateLine, &QLineEdit::returnPressed, [ this ]() {
+  connect( ui.translateLine, &QLineEdit::returnPressed, this, [ this ]() {
     translateInputFinished( true );
   } );
-  connect( translateBox, &TranslateBox::returnPressed, [ this ]() {
+  connect( translateBox, &TranslateBox::returnPressed, this, [ this ]() {
     translateInputFinished( true );
   } );
 
@@ -3020,7 +3020,7 @@ void MainWindow::checkNewRelease()
 
   auto * github_reply = dictNetMgr.get( github_release_api ); // will be marked as deleteLater when reply finished.
 
-  QObject::connect( github_reply, &QNetworkReply::finished, [ github_reply, this ]() {
+  QObject::connect( github_reply, &QNetworkReply::finished, github_reply, [ github_reply, this ]() {
     if ( github_reply->error() != QNetworkReply::NoError ) {
       qWarning() << "Version check failed: " << github_reply->errorString();
     }
@@ -3089,7 +3089,7 @@ void MainWindow::trayIconActivated( QSystemTrayIcon::ActivationReason r )
 
 void MainWindow::visitHomepage()
 {
-  QDesktopServices::openUrl( QApplication::organizationDomain() );
+  QDesktopServices::openUrl( QUrl( QApplication::organizationDomain() ) );
 }
 
 void MainWindow::openConfigFolder()
@@ -3191,13 +3191,9 @@ void MainWindow::toggleMenuBarTriggered( bool announce )
   // depending on the menubar state.
 
   QList< QMenu * > allMenus = menuBar()->findChildren< QMenu * >();
-  QListIterator< QMenu * > menuIter( allMenus );
-  while ( menuIter.hasNext() ) {
-    QMenu * menu                      = menuIter.next();
+  for ( const auto & menu : allMenus ) {
     QList< QAction * > allMenuActions = menu->actions();
-    QListIterator< QAction * > actionsIter( allMenuActions );
-    while ( actionsIter.hasNext() ) {
-      QAction * action = actionsIter.next();
+    for ( const auto & action : allMenuActions ) {
       if ( !action->shortcut().isEmpty() ) {
         if ( cfg.preferences.hideMenubar ) {
           // add all menubar actions to the main window,
@@ -3401,7 +3397,7 @@ void MainWindow::on_saveArticle_triggered()
     QWebEnginePage * page = view->page();
 
     // Connect the printFinished signal to handle operations after printing is complete
-    connect( page, &QWebEnginePage::pdfPrintingFinished, [ = ]( const QString & filePath, bool success ) {
+    connect( page, &QWebEnginePage::pdfPrintingFinished, page, [ = ]( const QString & filePath, bool success ) {
       if ( success ) {
         qDebug() << "PDF exported successfully to:" << filePath;
       }

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -30,7 +30,7 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   helpAction.setShortcut( QKeySequence( "F1" ) );
   helpAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
 
-  connect( &helpAction, &QAction::triggered, [ this ]() {
+  connect( &helpAction, &QAction::triggered, this, [ this ]() {
     const auto * currentTab = ui.tabWidget->currentWidget();
     if ( ui.tab_popup == currentTab ) {
       Help::openHelpWebpage( Help::section::ui_popup );

--- a/src/ui/translatebox.cc
+++ b/src/ui/translatebox.cc
@@ -49,7 +49,7 @@ TranslateBox::TranslateBox( QWidget * parent ):
   completer->setMaxVisibleItems( 16 );
   completer->popup()->setMinimumHeight( 256 );
 
-  connect( translate_line, &QLineEdit::returnPressed, [ this ]() {
+  connect( translate_line, &QLineEdit::returnPressed, this, [ this ]() {
     emit returnPressed();
   } );
 }


### PR DESCRIPTION
Enable this https://doc.qt.io/qt-6/qtglobal.html#QT_ENABLE_STRICT_MODE_UP_TO

For 6.8.2 is because this commit https://github.com/qt/qtbase/commit/f9163ae7a8167daded0798654d99a2e3a5aaa2b5 . 

The `QT_NO_CAST_FROM_ASCII` is too much to fix.

Changes and problems that could have been prevented:

- Java-style iterators for Qt containers 
  - 🤮🤮 We have a few
- foreach macro https://doc.qt.io/qt-6/foreach-keyword.html#the-foreach-keyword
  - 🤮🤮 a few in TTS
  - https://github.com/qt/qtbase/blob/6dc0e593939cbeaeb45392d8daf7fcd90e8cb0f8/src/corelib/global/qforeach.h#L42-L44
- QUrl implicit conversions from QString
  - This bug https://github.com/xiaoyifang/goldendict-ng/pull/1425
- Allowing narrowing conversions in signal-slot connections (see QT_NO_NARROWING_CONVERSIONS_IN_CONNECT)
  - Pretty sure we fixed this one or two times
- Overloads of QObject::connect that do not take a context object (see QT_NO_CONTEXTLESS_CONNECT)
  - ~~https://github.com/xiaoyifang/goldendict-ng/pull/1819~~ (edit: not really related)
  - This one is gone https://doc.qt.io/qt-6/qobject.html#connect-2