### PR TITLE
opt: properly use Qt containers in range for loops with std::as_const

### DIFF
--- a/src/dict/dictserver.cc
+++ b/src/dict/dictserver.cc
@@ -365,7 +365,7 @@ QString const & DictServerDictionary::getDescription()
   if ( dictionaryDescription.isEmpty() ) {
     dictionaryDescription = QCoreApplication::translate( "DictServer", "Url: " ) + url + "<br>";
     dictionaryDescription += QCoreApplication::translate( "DictServer", "Databases: " ) + "<br>";
-    for ( const auto & serverDatabase : databases ) {
+    for ( const auto & serverDatabase : std::as_const(databases) ) {
       dictionaryDescription += serverDatabase + "<br>";
     }
     dictionaryDescription +=
@@ -374,7 +374,7 @@ QString const & DictServerDictionary::getDescription()
       dictionaryDescription += "<br><br>";
       dictionaryDescription += QCoreApplication::translate( "DictServer", "Server databases" ) + " ("
         + QString::number( serverDatabases.size() ) + "):" + "<br>";
-      for ( const auto & serverDatabase : serverDatabases ) {
+      for ( const auto & serverDatabase : std::as_const(serverDatabases) ) {
         dictionaryDescription += serverDatabase + "<br>";
       }
     }
@@ -607,7 +607,7 @@ public:
       static QRegularExpression leadingRespCode( "^\\d{3} " );
       uint32_t leadingSpaceCount      = 0;
       uint32_t firstLeadingSpaceCount = 0;
-      for ( const QString & line : lines ) {
+      for ( const QString & line : std::as_const(lines) ) {
         //ignore 15X lines
         if ( leadingRespCode.match( line ).hasMatch() ) {
           continue;

--- a/src/dict/dictserver.cc
+++ b/src/dict/dictserver.cc
@@ -365,7 +365,7 @@ QString const & DictServerDictionary::getDescription()
   if ( dictionaryDescription.isEmpty() ) {
     dictionaryDescription = QCoreApplication::translate( "DictServer", "Url: " ) + url + "<br>";
     dictionaryDescription += QCoreApplication::translate( "DictServer", "Databases: " ) + "<br>";
-    for ( const auto & serverDatabase : std::as_const(databases) ) {
+    for ( const auto & serverDatabase : std::as_const( databases ) ) {
       dictionaryDescription += serverDatabase + "<br>";
     }
     dictionaryDescription +=
@@ -374,7 +374,7 @@ QString const & DictServerDictionary::getDescription()
       dictionaryDescription += "<br><br>";
       dictionaryDescription += QCoreApplication::translate( "DictServer", "Server databases" ) + " ("
         + QString::number( serverDatabases.size() ) + "):" + "<br>";
-      for ( const auto & serverDatabase : std::as_const(serverDatabases) ) {
+      for ( const auto & serverDatabase : std::as_const( serverDatabases ) ) {
         dictionaryDescription += serverDatabase + "<br>";
       }
     }
@@ -607,7 +607,7 @@ public:
       static QRegularExpression leadingRespCode( "^\\d{3} " );
       uint32_t leadingSpaceCount      = 0;
       uint32_t firstLeadingSpaceCount = 0;
-      for ( const QString & line : std::as_const(lines) ) {
+      for ( const QString & line : std::as_const( lines ) ) {
         //ignore 15X lines
         if ( leadingRespCode.match( line ).hasMatch() ) {
           continue;

--- a/src/dict/hunspell.cc
+++ b/src/dict/hunspell.cc
@@ -342,7 +342,7 @@ void HunspellHeadwordsRequest::run()
     if ( !suggestions.empty() ) {
       QMutexLocker _( &dataMutex );
 
-      for ( const auto & suggestion : suggestions ) {
+      for ( const auto & suggestion : std::as_const(suggestions) ) {
         matches.push_back( suggestion );
       }
     }
@@ -570,7 +570,7 @@ void getSuggestionsForExpression( std::u32string const & expression,
     }
   }
 
-  for ( const auto & result : results ) {
+  for ( const auto & result : std::as_const(results) ) {
     if ( result != trimmedWord ) {
       suggestions.push_back( result );
     }

--- a/src/dict/hunspell.cc
+++ b/src/dict/hunspell.cc
@@ -342,7 +342,7 @@ void HunspellHeadwordsRequest::run()
     if ( !suggestions.empty() ) {
       QMutexLocker _( &dataMutex );
 
-      for ( const auto & suggestion : std::as_const(suggestions) ) {
+      for ( const auto & suggestion : std::as_const( suggestions ) ) {
         matches.push_back( suggestion );
       }
     }
@@ -570,7 +570,7 @@ void getSuggestionsForExpression( std::u32string const & expression,
     }
   }
 
-  for ( const auto & result : std::as_const(results) ) {
+  for ( const auto & result : std::as_const( results ) ) {
     if ( result != trimmedWord ) {
       suggestions.push_back( result );
     }

--- a/src/dict/programs.cc
+++ b/src/dict/programs.cc
@@ -330,7 +330,7 @@ void ProgramWordSearchRequest::instanceFinished( QByteArray output, QString erro
     output.replace( "\r\n", "\n" );
     QStringList result = QString::fromUtf8( output ).split( "\n", Qt::SkipEmptyParts );
 
-    for ( const auto & x : result ) {
+    for ( const auto & x : std::as_const(result) ) {
       matches.push_back( Dictionary::WordMatch( x.toStdU32String() ) );
     }
 

--- a/src/dict/programs.cc
+++ b/src/dict/programs.cc
@@ -330,7 +330,7 @@ void ProgramWordSearchRequest::instanceFinished( QByteArray output, QString erro
     output.replace( "\r\n", "\n" );
     QStringList result = QString::fromUtf8( output ).split( "\n", Qt::SkipEmptyParts );
 
-    for ( const auto & x : std::as_const(result) ) {
+    for ( const auto & x : std::as_const( result ) ) {
       matches.push_back( Dictionary::WordMatch( x.toStdU32String() ) );
     }
 

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -352,7 +352,7 @@ public:
       QStringList sl;
       walkNode( doc.firstChild(), sl );
 
-      for ( auto s : std::as_const(sl) ) {
+      for ( auto s : std::as_const( sl ) ) {
         translatePW( s );
         ss += s;
         ss += "<br>";

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -352,7 +352,7 @@ public:
       QStringList sl;
       walkNode( doc.firstChild(), sl );
 
-      for ( auto s : sl ) {
+      for ( auto s : std::as_const(sl) ) {
         translatePW( s );
         ss += s;
         ss += "<br>";

--- a/src/dict/xdxf.cc
+++ b/src/dict/xdxf.cc
@@ -737,7 +737,7 @@ QString readXhtmlData( QXmlStreamReader & stream )
 
       QXmlStreamAttributes attrs = stream.attributes();
 
-      for ( const auto & attr : std::as_const(attrs) ) {
+      for ( const auto & attr : std::as_const( attrs ) ) {
         result += Utils::escape( attr.name().toString() );
         result += "=\"" + Utils::escape( attr.value().toString() ) + "\"";
       }

--- a/src/dict/xdxf.cc
+++ b/src/dict/xdxf.cc
@@ -737,7 +737,7 @@ QString readXhtmlData( QXmlStreamReader & stream )
 
       QXmlStreamAttributes attrs = stream.attributes();
 
-      for ( const auto & attr : attrs ) {
+      for ( const auto & attr : std::as_const(attrs) ) {
         result += Utils::escape( attr.name().toString() );
         result += "=\"" + Utils::escape( attr.value().toString() ) + "\"";
       }

--- a/src/ftshelpers.cc
+++ b/src/ftshelpers.cc
@@ -227,7 +227,7 @@ void FTSResultsRequest::run()
         QMutexLocker _( &dataMutex );
         QString id = QString::fromUtf8( dict.getId().c_str() );
         dict.getHeadwordsFromOffsets( offsetsForHeadwords, headwords, &isCancelled );
-        for ( const auto & headword : std::as_const(headwords) ) {
+        for ( const auto & headword : std::as_const( headwords ) ) {
           foundHeadwords->append( FTS::FtsHeadword( headword, id, QStringList(), matchCase ) );
         }
       }

--- a/src/ftshelpers.cc
+++ b/src/ftshelpers.cc
@@ -227,7 +227,7 @@ void FTSResultsRequest::run()
         QMutexLocker _( &dataMutex );
         QString id = QString::fromUtf8( dict.getId().c_str() );
         dict.getHeadwordsFromOffsets( offsetsForHeadwords, headwords, &isCancelled );
-        for ( const auto & headword : headwords ) {
+        for ( const auto & headword : std::as_const(headwords) ) {
           foundHeadwords->append( FTS::FtsHeadword( headword, id, QStringList(), matchCase ) );
         }
       }

--- a/src/headwordsmodel.cc
+++ b/src/headwordsmodel.cc
@@ -196,7 +196,7 @@ QSet< QString > HeadwordListModel::getRemainRows( int & nodeIndex )
   _dict->findHeadWordsWithLenth( nodeIndex, &headword, 10000 );
 
   QSet< QString > filtered;
-  for ( const auto & word : headword ) {
+  for ( const auto & word : std::as_const(headword) ) {
     if ( !containWord( word ) ) {
       filtered.insert( word );
     }

--- a/src/headwordsmodel.cc
+++ b/src/headwordsmodel.cc
@@ -196,7 +196,7 @@ QSet< QString > HeadwordListModel::getRemainRows( int & nodeIndex )
   _dict->findHeadWordsWithLenth( nodeIndex, &headword, 10000 );
 
   QSet< QString > filtered;
-  for ( const auto & word : std::as_const(headword) ) {
+  for ( const auto & word : std::as_const( headword ) ) {
     if ( !containWord( word ) ) {
       filtered.insert( word );
     }

--- a/src/history.cc
+++ b/src/history.cc
@@ -114,7 +114,7 @@ bool History::save()
   }
 
   QTextStream out( &file );
-  for ( const auto & i : items ) {
+  for ( const auto & i : std::as_const(items) ) {
     // "0 " is to keep compatibility with the original GD (an unused number)
     out << "0 " << i.word.trimmed() << '\n';
   }

--- a/src/history.cc
+++ b/src/history.cc
@@ -114,7 +114,7 @@ bool History::save()
   }
 
   QTextStream out( &file );
-  for ( const auto & i : std::as_const(items) ) {
+  for ( const auto & i : std::as_const( items ) ) {
     // "0 " is to keep compatibility with the original GD (an unused number)
     out << "0 " << i.word.trimmed() << '\n';
   }

--- a/src/langcoder.cc
+++ b/src/langcoder.cc
@@ -230,7 +230,7 @@ quint32 LangCoder::findIdForLanguage( std::u32string const & lang )
 {
   const auto langFolded = QByteArrayView( Text::toUtf8( lang ) );
 
-  for ( auto const & lc : std::as_const(LANG_CODE_MAP) ) {
+  for ( auto const & lc : std::as_const( LANG_CODE_MAP ) ) {
     if ( langFolded.compare( lc.lang, Qt::CaseInsensitive ) == 0 ) {
       return code2toInt( lc.code2.toStdString().c_str() );
     }
@@ -241,7 +241,7 @@ quint32 LangCoder::findIdForLanguage( std::u32string const & lang )
 
 quint32 LangCoder::findIdForLanguageCode3( std::string const & code )
 {
-  for ( auto const & lc : std::as_const(LANG_CODE_MAP) ) {
+  for ( auto const & lc : std::as_const( LANG_CODE_MAP ) ) {
     if ( code == lc.code3 ) {
       return code2toInt( lc.code2 );
     }
@@ -261,7 +261,7 @@ quint32 LangCoder::guessId( const QString & lang )
 
   // check if it could be the whole language name
   if ( lstr.size() >= 3 ) {
-    for ( auto const & lc : std::as_const(LANG_CODE_MAP) ) {
+    for ( auto const & lc : std::as_const( LANG_CODE_MAP ) ) {
       if ( lstr == ( lstr.size() == 3 ? QString::fromStdString( lc.code3 ) : QString::fromStdString( lc.lang ) ) ) {
         return code2toInt( lc.code2 );
       }

--- a/src/langcoder.cc
+++ b/src/langcoder.cc
@@ -230,7 +230,7 @@ quint32 LangCoder::findIdForLanguage( std::u32string const & lang )
 {
   const auto langFolded = QByteArrayView( Text::toUtf8( lang ) );
 
-  for ( auto const & lc : LANG_CODE_MAP ) {
+  for ( auto const & lc : std::as_const(LANG_CODE_MAP) ) {
     if ( langFolded.compare( lc.lang, Qt::CaseInsensitive ) == 0 ) {
       return code2toInt( lc.code2.toStdString().c_str() );
     }
@@ -241,7 +241,7 @@ quint32 LangCoder::findIdForLanguage( std::u32string const & lang )
 
 quint32 LangCoder::findIdForLanguageCode3( std::string const & code )
 {
-  for ( auto const & lc : LANG_CODE_MAP ) {
+  for ( auto const & lc : std::as_const(LANG_CODE_MAP) ) {
     if ( code == lc.code3 ) {
       return code2toInt( lc.code2 );
     }
@@ -261,7 +261,7 @@ quint32 LangCoder::guessId( const QString & lang )
 
   // check if it could be the whole language name
   if ( lstr.size() >= 3 ) {
-    for ( auto const & lc : LANG_CODE_MAP ) {
+    for ( auto const & lc : std::as_const(LANG_CODE_MAP) ) {
       if ( lstr == ( lstr.size() == 3 ? QString::fromStdString( lc.code3 ) : QString::fromStdString( lc.lang ) ) ) {
         return code2toInt( lc.code2 );
       }

--- a/src/speechclient.hh
+++ b/src/speechclient.hh
@@ -52,7 +52,7 @@ public:
   #endif
       sp->setLocale( e.locale );
       auto voices = sp->availableVoices();
-      for ( const auto & voice : voices ) {
+      for ( const auto & voice : std::as_const(voices) ) {
         if ( voice.name() == e.voice_name ) {
           sp->setVoice( voice );
 

--- a/src/speechclient.hh
+++ b/src/speechclient.hh
@@ -52,7 +52,7 @@ public:
   #endif
       sp->setLocale( e.locale );
       auto voices = sp->availableVoices();
-      for ( const auto & voice : std::as_const(voices) ) {
+      for ( const auto & voice : std::as_const( voices ) ) {
         if ( voice.name() == e.voice_name ) {
           sp->setVoice( voice );
 

--- a/src/texttospeechsource.cc
+++ b/src/texttospeechsource.cc
@@ -26,7 +26,7 @@ TextToSpeechSource::TextToSpeechSource( QWidget * parent, Config::VoiceEngines v
     occupiedEngines.insert( ve.name );
   }
 
-  for ( const auto & engine : engines ) {
+  for ( const auto & engine : std::as_const(engines) ) {
     QMap< QString, QVariant > map;
     map[ "engine_name" ] = engine.engine_name;
     map[ "locale" ]      = engine.locale;

--- a/src/texttospeechsource.cc
+++ b/src/texttospeechsource.cc
@@ -26,7 +26,7 @@ TextToSpeechSource::TextToSpeechSource( QWidget * parent, Config::VoiceEngines v
     occupiedEngines.insert( ve.name );
   }
 
-  for ( const auto & engine : std::as_const(engines) ) {
+  for ( const auto & engine : std::as_const( engines ) ) {
     QMap< QString, QVariant > map;
     map[ "engine_name" ] = engine.engine_name;
     map[ "locale" ]      = engine.locale;

--- a/src/ui/dictheadwords.cc
+++ b/src/ui/dictheadwords.cc
@@ -340,7 +340,7 @@ void DictHeadwords::exportAllWords( QProgressDialog & progress, QTextStream & ou
       break;
     }
 
-    for ( const auto & item : std::as_const(headwords) ) {
+    for ( const auto & item : std::as_const( headwords ) ) {
       progress.setValue( totalCount++ );
 
       writeWordToFile( out, item );

--- a/src/ui/dictheadwords.cc
+++ b/src/ui/dictheadwords.cc
@@ -340,7 +340,7 @@ void DictHeadwords::exportAllWords( QProgressDialog & progress, QTextStream & ou
       break;
     }
 
-    for ( const auto & item : headwords ) {
+    for ( const auto & item : std::as_const(headwords) ) {
       progress.setValue( totalCount++ );
 
       writeWordToFile( out, item );

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -147,7 +147,7 @@ void DictionaryBar::showContextMenu( QContextMenuEvent * event, bool extended )
 
   unsigned refsAdded = 0;
 
-  for ( const auto & dictAction : dictActions ) {
+  for ( const auto & dictAction : std::as_const(dictActions) ) {
 
     // Enough! Or the menu would become too large.
     if ( refsAdded++ >= maxDictionaryRefsInContextMenu && !extended ) {
@@ -220,7 +220,7 @@ void DictionaryBar::mutedDictionariesChanged()
 
   setUpdatesEnabled( false );
 
-  for ( const auto & dictAction : dictActions ) {
+  for ( const auto & dictAction : std::as_const(dictActions) ) {
     bool const isUnmuted = !mutedDictionaries->contains( dictAction->data().toString() );
 
     if ( isUnmuted != dictAction->isChecked() ) {
@@ -253,7 +253,7 @@ void DictionaryBar::actionWasTriggered( QAction * action )
     // For solo, all dictionaries must be unchecked, since we're handling
     // the result of the dictionary being (un)checked, and in case we were
     // in solo, now we would end up with no dictionaries being checked at all.
-    for ( const auto & dictAction : dictActions ) {
+    for ( const auto & dictAction : std::as_const(dictActions) ) {
       if ( dictAction->isChecked() ) {
         isSolo = false;
         break;
@@ -275,13 +275,13 @@ void DictionaryBar::actionWasTriggered( QAction * action )
       }
 
       if ( isSolo ) {
-        for ( const auto & dictAction : dictActions ) {
+        for ( const auto & dictAction : std::as_const(dictActions) ) {
           mutedDictionaries->remove( dictAction->data().toString() );
         }
       }
       else {
         // Make dictionary solo
-        for ( const auto & dictAction : dictActions ) {
+        for ( const auto & dictAction : std::as_const(dictActions) ) {
           QString const dictId = dictAction->data().toString();
 
           if ( dictId == id ) {
@@ -325,7 +325,7 @@ void DictionaryBar::dictsPaneClicked( const QString & id )
     return;
   }
 
-  for ( const auto & dictAction : dictActions ) {
+  for ( const auto & dictAction : std::as_const(dictActions) ) {
     QString const dictId = dictAction->data().toString();
     if ( dictId == id ) {
       dictAction->activate( QAction::Trigger );

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -147,7 +147,7 @@ void DictionaryBar::showContextMenu( QContextMenuEvent * event, bool extended )
 
   unsigned refsAdded = 0;
 
-  for ( const auto & dictAction : std::as_const(dictActions) ) {
+  for ( const auto & dictAction : std::as_const( dictActions ) ) {
 
     // Enough! Or the menu would become too large.
     if ( refsAdded++ >= maxDictionaryRefsInContextMenu && !extended ) {
@@ -220,7 +220,7 @@ void DictionaryBar::mutedDictionariesChanged()
 
   setUpdatesEnabled( false );
 
-  for ( const auto & dictAction : std::as_const(dictActions) ) {
+  for ( const auto & dictAction : std::as_const( dictActions ) ) {
     bool const isUnmuted = !mutedDictionaries->contains( dictAction->data().toString() );
 
     if ( isUnmuted != dictAction->isChecked() ) {
@@ -253,7 +253,7 @@ void DictionaryBar::actionWasTriggered( QAction * action )
     // For solo, all dictionaries must be unchecked, since we're handling
     // the result of the dictionary being (un)checked, and in case we were
     // in solo, now we would end up with no dictionaries being checked at all.
-    for ( const auto & dictAction : std::as_const(dictActions) ) {
+    for ( const auto & dictAction : std::as_const( dictActions ) ) {
       if ( dictAction->isChecked() ) {
         isSolo = false;
         break;
@@ -275,13 +275,13 @@ void DictionaryBar::actionWasTriggered( QAction * action )
       }
 
       if ( isSolo ) {
-        for ( const auto & dictAction : std::as_const(dictActions) ) {
+        for ( const auto & dictAction : std::as_const( dictActions ) ) {
           mutedDictionaries->remove( dictAction->data().toString() );
         }
       }
       else {
         // Make dictionary solo
-        for ( const auto & dictAction : std::as_const(dictActions) ) {
+        for ( const auto & dictAction : std::as_const( dictActions ) ) {
           QString const dictId = dictAction->data().toString();
 
           if ( dictId == id ) {
@@ -325,7 +325,7 @@ void DictionaryBar::dictsPaneClicked( const QString & id )
     return;
   }
 
-  for ( const auto & dictAction : std::as_const(dictActions) ) {
+  for ( const auto & dictAction : std::as_const( dictActions ) ) {
     QString const dictId = dictAction->data().toString();
     if ( dictId == id ) {
       dictAction->activate( QAction::Trigger );

--- a/src/ui/favoritespanewidget.cc
+++ b/src/ui/favoritespanewidget.cc
@@ -1211,7 +1211,7 @@ bool FavoritesModel::setDataFromTxt( QString const & dataStr )
     rootItem = new TreeItem( QVariant(), 0, TreeItem::Root );
   }
 
-  for ( auto const & word : std::as_const(words) ) {
+  for ( auto const & word : std::as_const( words ) ) {
     rootItem->appendChild( new TreeItem( word, rootItem, TreeItem::Word ) );
   }
   endResetModel();

--- a/src/ui/favoritespanewidget.cc
+++ b/src/ui/favoritespanewidget.cc
@@ -1211,7 +1211,7 @@ bool FavoritesModel::setDataFromTxt( QString const & dataStr )
     rootItem = new TreeItem( QVariant(), 0, TreeItem::Root );
   }
 
-  for ( auto const & word : words ) {
+  for ( auto const & word : std::as_const(words) ) {
     rootItem->appendChild( new TreeItem( word, rootItem, TreeItem::Word ) );
   }
   endResetModel();

--- a/src/ui/historypanewidget.cc
+++ b/src/ui/historypanewidget.cc
@@ -104,7 +104,7 @@ void HistoryPaneWidget::copySelectedItems()
   }
 
   QStringList selectedStrings;
-  for ( const auto & id : selectedIdxs ) {
+  for ( const auto & id : std::as_const(selectedIdxs) ) {
     selectedStrings << m_historyList->model()->data( id ).toString();
   }
 
@@ -122,7 +122,7 @@ void HistoryPaneWidget::deleteSelectedItems()
 
   QList< int > idxsToDelete;
 
-  for ( const auto & id : selectedIdxs ) {
+  for ( const auto & id : std::as_const(selectedIdxs) ) {
     idxsToDelete << id.row();
   }
 
@@ -130,7 +130,7 @@ void HistoryPaneWidget::deleteSelectedItems()
   // the first deletions won't affect the indexes for subsequent deletions.
   std::sort( idxsToDelete.begin(), idxsToDelete.end(), std::greater< int >() );
 
-  for ( const auto & id : idxsToDelete ) {
+  for ( const auto & id : std::as_const(idxsToDelete) ) {
     m_history->removeItem( id );
   }
 

--- a/src/ui/historypanewidget.cc
+++ b/src/ui/historypanewidget.cc
@@ -104,7 +104,7 @@ void HistoryPaneWidget::copySelectedItems()
   }
 
   QStringList selectedStrings;
-  for ( const auto & id : std::as_const(selectedIdxs) ) {
+  for ( const auto & id : std::as_const( selectedIdxs ) ) {
     selectedStrings << m_historyList->model()->data( id ).toString();
   }
 
@@ -122,7 +122,7 @@ void HistoryPaneWidget::deleteSelectedItems()
 
   QList< int > idxsToDelete;
 
-  for ( const auto & id : std::as_const(selectedIdxs) ) {
+  for ( const auto & id : std::as_const( selectedIdxs ) ) {
     idxsToDelete << id.row();
   }
 
@@ -130,7 +130,7 @@ void HistoryPaneWidget::deleteSelectedItems()
   // the first deletions won't affect the indexes for subsequent deletions.
   std::sort( idxsToDelete.begin(), idxsToDelete.end(), std::greater< int >() );
 
-  for ( const auto & id : std::as_const(idxsToDelete) ) {
+  for ( const auto & id : std::as_const( idxsToDelete ) ) {
     m_history->removeItem( id );
   }
 

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -56,7 +56,7 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   // We need to sort by language name -- otherwise list looks really weird
   QMultiMap< QString, QString > sortedLocs;
   sortedLocs.insert( Language::languageForLocale( "en_US" ), "en_US" );
-  for ( const auto & availLoc : availLocs ) {
+  for ( const auto & availLoc : std::as_const(availLocs) ) {
     // Here we assume the xx_YY naming, where xx is language and YY is region.
     //remove .qm suffix.
     QString locale = availLoc.left( availLoc.size() - 3 );

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -56,7 +56,7 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   // We need to sort by language name -- otherwise list looks really weird
   QMultiMap< QString, QString > sortedLocs;
   sortedLocs.insert( Language::languageForLocale( "en_US" ), "en_US" );
-  for ( const auto & availLoc : std::as_const(availLocs) ) {
+  for ( const auto & availLoc : std::as_const( availLocs ) ) {
     // Here we assume the xx_YY naming, where xx is language and YY is region.
     //remove .qm suffix.
     QString locale = availLoc.left( availLoc.size() - 3 );


### PR DESCRIPTION
close https://github.com/xiaoyifang/goldendict-ng/issues/2144

We can probably add a new auto format step to enforce various Clazy auto fixes later. (or not, there should be no barrier on new incoming PRs from new persons.)

The performance impact?

miniscule 😅 