### PR TITLE
fix: revert "clean: reduce implicit `int` -> `(q)sizetype` conversion warnings (#2127)"

### DIFF
--- a/src/article_maker.cc
+++ b/src/article_maker.cc
@@ -535,13 +535,13 @@ void ArticleRequest::altSearchFinished()
 int ArticleRequest::findEndOfCloseDiv( const QString & str, int pos )
 {
   for ( ;; ) {
-    const auto n1 = str.indexOf( "</div>", pos );
+    const int n1 = str.indexOf( "</div>", pos );
     if ( n1 <= 0 ) {
       return n1;
     }
 
     // will there be some custom tags starts with <div but not <div> ,such as <divider>
-    const auto n2 = str.indexOf( RX::Html::startDivTag, pos );
+    const int n2 = str.indexOf( RX::Html::startDivTag, pos );
     if ( n2 <= 0 || n2 > n1 ) {
       return n1 + 6;
     }
@@ -569,7 +569,7 @@ bool ArticleRequest::isCollapsable( Dictionary::DataRequest & req, QString const
       if ( !needExpandOptionalParts ) {
         // Strip DSL optional parts
         for ( ;; ) {
-          const auto pos = text.indexOf( "<div class=\"dsl_opt\"" );
+          const int pos = text.indexOf( "<div class=\"dsl_opt\"" );
           if ( pos > 0 ) {
             const int endPos = findEndOfCloseDiv( text, pos + 1 );
             if ( endPos > pos ) {
@@ -792,7 +792,7 @@ int ArticleRequest::htmlTextSize( QString html )
     html.remove( QRegularExpression( "<link\\s*[^>]*>", QRegularExpression::CaseInsensitiveOption ) )
       .remove( QRegularExpression( R"(<script[\s\S]*?>[\s\S]*?<\/script>)",
                                    QRegularExpression::CaseInsensitiveOption | QRegularExpression::MultilineOption ) );
-  auto size = QTextDocumentFragment::fromHtml( stripStyleSheet ).toPlainText().length();
+  int size = QTextDocumentFragment::fromHtml( stripStyleSheet ).toPlainText().length();
 
   return size;
 }

--- a/src/common/utils.hh
+++ b/src/common/utils.hh
@@ -31,7 +31,8 @@ inline bool isCJKChar( ushort ch )
  */
 inline QString rstrip( const QString & str )
 {
-  for ( auto n = str.size() - 1; n >= 0; --n ) {
+  int n = str.size() - 1;
+  for ( ; n >= 0; --n ) {
     if ( !str.at( n ).isSpace() ) {
       return str.left( n + 1 );
     }
@@ -63,7 +64,8 @@ bool endsWithIgnoreCase( QByteArrayView str, QByteArrayView extension );
 inline QString trimNonChar( const QString & str )
 {
   QString remain;
-  for ( auto n = str.size() - 1; n >= 0; --n ) {
+  int n = str.size() - 1;
+  for ( ; n >= 0; --n ) {
     auto c = str.at( n );
     if ( !c.isSpace() && !c.isSymbol() && !c.isNonCharacter() && !c.isPunct() && !c.isNull() ) {
       remain = str.left( n + 1 );
@@ -71,7 +73,8 @@ inline QString trimNonChar( const QString & str )
     }
   }
 
-  for ( auto n = 0; n < remain.size(); n++ ) {
+  n = 0;
+  for ( ; n < remain.size(); n++ ) {
     auto c = remain.at( n );
     if ( !c.isSpace() && !c.isSymbol() && !c.isNonCharacter() && !c.isPunct() ) {
       return remain.mid( n );
@@ -89,7 +92,8 @@ inline QString trimNonChar( const QString & str )
  */
 inline QString rstripnull( const QString & str )
 {
-  for ( auto n = str.size() - 1; n >= 0; --n ) {
+  int n = str.size() - 1;
+  for ( ; n >= 0; --n ) {
     auto c = str.at( n );
     if ( !c.isSpace() && !c.isNull() ) {
       return str.left( n + 1 );
@@ -294,7 +298,7 @@ inline QString getHostBase( QString const & host )
 {
   QStringList domains = host.split( '.' );
 
-  auto left = domains.size();
+  int left = domains.size();
 
   // Skip last <=3-letter domain name
   if ( left && domains[ left - 1 ].size() <= 3 )

--- a/src/dict/bgl.cc
+++ b/src/dict/bgl.cc
@@ -117,7 +117,7 @@ void trimWs( string & word )
       word.clear();
     }
     else {
-      auto end = word.size();
+      unsigned end = word.size();
 
       // Doesn't consist of ws entirely, so must end with just isspace()
       // condition.
@@ -611,7 +611,8 @@ void BglArticleRequest::fixHebString( string & hebStr ) // Hebrew support - conv
 
 void BglArticleRequest::fixHebArticle( string & hebArticle ) // Hebrew support - remove extra chars at the end
 {
-  std::size_t nulls;
+  unsigned nulls;
+
   for ( nulls = hebArticle.size(); nulls > 0
         && ( ( hebArticle[ nulls - 1 ] <= 32 && hebArticle[ nulls - 1 ] >= 0 )
              || ( hebArticle[ nulls - 1 ] >= 65 && hebArticle[ nulls - 1 ] <= 90 ) );
@@ -937,7 +938,7 @@ void BglDictionary::replaceCharsetEntities( string & text )
 
   QRegularExpression oneValueExp( "\\s*([0-9a-fA-F]+)\\s*;" );
   QString result;
-  qsizetype pos = 0;
+  int pos = 0;
 
   QRegularExpressionMatchIterator it = charsetExp.globalMatch( str );
   while ( it.hasNext() ) {

--- a/src/dict/btreeidx.cc
+++ b/src/dict/btreeidx.cc
@@ -231,7 +231,7 @@ void BtreeWordSearchRequest::findMatches()
     }
   }
 
-  auto initialFoldedSize = folded.size();
+  int initialFoldedSize = folded.size();
 
   int charsLeftToChop = 0;
 
@@ -637,7 +637,7 @@ char const * BtreeIndex::findChainOffsetExactOrPrefix( std::u32string const & ta
       // string lands.
 
       char const ** window = &chainOffsets.front();
-      auto windowSize      = chainOffsets.size();
+      unsigned windowSize  = chainOffsets.size();
 
       for ( ;; ) {
         //qDebug( "window = %u, ws = %u", window - &chainOffsets.front(), windowSize );
@@ -762,7 +762,7 @@ void BtreeIndex::antialias( std::u32string const & str, vector< WordArticleLink 
     caseFolded = Folding::trimWhitespaceOrPunct( caseFolded );
   }
 
-  for ( auto x = chain.size(); x--; ) {
+  for ( unsigned x = chain.size(); x--; ) {
     // If after applying case folding to each word they wouldn't match, we
     // drop the entry.
     std::u32string entry =
@@ -896,7 +896,7 @@ static uint32_t buildBtreeNode( IndexedWords::const_iterator & nextIndex,
     abort();
   }
 
-  auto offset = file.tell();
+  uint32_t offset = file.tell();
 
   file.write< uint32_t >( uncompressedData.size() );
   file.write< uint32_t >( compressedSize );
@@ -908,7 +908,7 @@ static uint32_t buildBtreeNode( IndexedWords::const_iterator & nextIndex,
 
     file.write( (uint32_t)0 );
 
-    auto here = file.tell();
+    uint32_t here = file.tell();
 
     if ( lastLeafLinkOffset ) {
       // Update the previous leaf to have the offset of this one.

--- a/src/dict/dictdfiles.cc
+++ b/src/dict/dictdfiles.cc
@@ -339,7 +339,7 @@ sptr< Dictionary::DataRequest > DictdDictionary::getArticle( std::u32string cons
                                   .replace( refs, R"(<a href="gdlookup://localhost/\1">\1</a>)" );
         convertedText.erase();
 
-        qsizetype pos = 0;
+        int pos = 0;
 
         QString articleNewString;
         QRegularExpressionMatchIterator it = links.globalMatch( articleString );

--- a/src/dict/dictionary.cc
+++ b/src/dict/dictionary.cc
@@ -376,7 +376,7 @@ void Class::isolateCSS( QString & css, QString const & wrapperSelector )
   QRegularExpression reg3( "[,;\\{]" );
 
 
-  qsizetype currentPos = 0;
+  int currentPos = 0;
   QString newCSS;
   QString prefix( "#gdfrom-" );
   prefix += QString::fromLatin1( getId().c_str() );
@@ -399,14 +399,14 @@ void Class::isolateCSS( QString & css, QString const & wrapperSelector )
     if ( ch == '@' ) {
       // @ rules
 
-      qsizetype n = currentPos;
+      int n = currentPos;
       if ( css.mid( currentPos, 7 ).compare( "@import", Qt::CaseInsensitive ) == 0
            || css.mid( currentPos, 10 ).compare( "@font-face", Qt::CaseInsensitive ) == 0
            || css.mid( currentPos, 10 ).compare( "@namespace", Qt::CaseInsensitive ) == 0
            || css.mid( currentPos, 8 ).compare( "@charset", Qt::CaseInsensitive ) == 0 ) {
         // Copy rule as is.
         n      = css.indexOf( ';', currentPos );
-        auto n2 = css.indexOf( '{', currentPos );
+        int n2 = css.indexOf( '{', currentPos );
         if ( n2 > 0 && n > n2 ) {
           n = n2 - 1;
         }
@@ -444,7 +444,7 @@ void Class::isolateCSS( QString & css, QString const & wrapperSelector )
       // Selector declaration block.
       // We copy it up to '}' as is.
 
-      auto n = css.indexOf( '}', currentPos );
+      int n = css.indexOf( '}', currentPos );
       newCSS.append( css.mid( currentPos, n == -1 ? n : n - currentPos + 1 ) );
       if ( n < 0 ) {
         break;
@@ -457,7 +457,7 @@ void Class::isolateCSS( QString & css, QString const & wrapperSelector )
       if ( ch.isLetter() || ch == '*' ) {
         // Check for namespace prefix
         QChar chr;
-        for ( auto i = currentPos; i < css.length(); i++ ) {
+        for ( int i = currentPos; i < css.length(); i++ ) {
           chr = css[ i ];
           if ( chr.isLetterOrNumber() || chr.isMark() || chr == '_' || chr == '-'
                || ( chr == '*' && i == currentPos ) ) {
@@ -479,7 +479,7 @@ void Class::isolateCSS( QString & css, QString const & wrapperSelector )
       // This is some selector.
       // We must to add the isolate prefix to it.
 
-      auto n    = css.indexOf( reg2, currentPos + 1 );
+      int n     = css.indexOf( reg2, currentPos + 1 );
       QString s = css.mid( currentPos, n < 0 ? n : n - currentPos );
       if ( n < 0 ) {
         newCSS.append( s );

--- a/src/dict/dictserver.cc
+++ b/src/dict/dictserver.cc
@@ -79,7 +79,7 @@ public:
 
   void run( std::function< void() > callback )
   {
-    auto pos = url.indexOf( "://" );
+    int pos = url.indexOf( "://" );
     if ( pos < 0 ) {
       url = "dict://" + url;
     }
@@ -121,7 +121,7 @@ public:
           QString authCommand = QString( "AUTH " );
           QString authString  = msgId;
 
-          auto pos = serverUrl.userInfo().indexOf( QRegularExpression( "[:;]" ) );
+          int pos = serverUrl.userInfo().indexOf( QRegularExpression( "[:;]" ) );
           if ( pos > 0 ) {
             authCommand += serverUrl.userInfo().left( pos );
             authString += serverUrl.userInfo().mid( pos + 1 );
@@ -202,7 +202,7 @@ public:
 
     dictionaryName = name_;
 
-    auto pos = url.indexOf( "://" );
+    int pos = url.indexOf( "://" );
     if ( pos < 0 ) {
       url = "dict://" + url;
     }
@@ -242,7 +242,7 @@ public:
 
         if ( reply.left( 3 ) == "110" ) {
           state        = DictServerState::DB_DATA;
-          auto countPos = reply.indexOf( ' ', 4 );
+          int countPos = reply.indexOf( ' ', 4 );
           // Get databases count
           int count = reply.mid( 4, countPos > 4 ? countPos - 4 : -1 ).toInt();
 
@@ -525,7 +525,7 @@ void DictServerWordSearchRequest::readMatchData( QByteArray & reply )
       continue;
     }
 
-    auto pos = reply.indexOf( ' ' );
+    int pos = reply.indexOf( ' ' );
     if ( pos >= 0 ) {
       QString word = reply.mid( pos + 1 );
       if ( word.endsWith( '\"' ) ) {
@@ -654,7 +654,7 @@ public:
       }
 
       _articleText = QString::fromUtf8( articleStr.c_str(), articleStr.size() );
-      qsizetype pos;
+      int pos;
       if ( !contentInHtml ) {
         _articleText = _articleText.replace( refs, R"(<a href="gdlookup://localhost/\1">\1</a>)" );
 
@@ -784,7 +784,7 @@ void DictServerArticleRequest::run()
       auto code = reply.left( 3 );
       if ( reply.left( 3 ) == "150" ) {
         // Articles found
-        auto countPos = reply.indexOf( ' ', 4 );
+        int countPos = reply.indexOf( ' ', 4 );
         // Get articles count,
         // todo ,how to use this count?
         int count = reply.mid( 4, countPos > 4 ? countPos - 4 : -1 ).toInt();
@@ -818,8 +818,8 @@ void DictServerArticleRequest::readData( QByteArray reply )
   }
 
   if ( reply.left( 3 ) == "151" ) {
-    qsizetype pos = 4;
-    qsizetype endPos;
+    int pos = 4;
+    int endPos;
 
     // Skip requested word
     if ( reply[ pos ] == '\"' ) {

--- a/src/dict/dsl.cc
+++ b/src/dict/dsl.cc
@@ -724,9 +724,9 @@ string DslDictionary::getNodeLink( ArticleDom::Node const & node )
   string link;
   if ( !node.tagAttrs.empty() ) {
     QString attrs = QString::fromStdU32String( node.tagAttrs );
-    auto n        = attrs.indexOf( "target=\"" );
+    int n         = attrs.indexOf( "target=\"" );
     if ( n >= 0 ) {
-      auto n_end     = attrs.indexOf( '\"', n + 8 );
+      int n_end      = attrs.indexOf( '\"', n + 8 );
       QString target = attrs.mid( n + 8, n_end > n + 8 ? n_end - ( n + 8 ) : -1 );
       link           = Html::escape( Filetype::simplifyString( string( target.toUtf8().data() ), false ) );
     }
@@ -916,7 +916,7 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
       // Find ISO 639-1 code
       string langcode;
       QString attr = QString::fromStdU32String( node.tagAttrs );
-      auto n       = attr.indexOf( "id=" );
+      int n        = attr.indexOf( "id=" );
       if ( n >= 0 ) {
         int id = attr.mid( n + 3 ).toInt();
         if ( id ) {
@@ -926,7 +926,7 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
       else {
         n = attr.indexOf( "name=\"" );
         if ( n >= 0 ) {
-          auto n2 = attr.indexOf( '\"', n + 6 );
+          int n2 = attr.indexOf( '\"', n + 6 );
           if ( n2 > 0 ) {
             quint32 id = dslLanguageToId( attr.mid( n + 6, n2 - n - 6 ).toStdU32String() );
             langcode   = LangCoder::intToCode2( id ).toStdString();
@@ -950,7 +950,7 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
     url.setPath( Utils::Url::ensureLeadingSlash( QString::fromStdU32String( nodeStr ) ) );
     if ( !node.tagAttrs.empty() ) {
       QString attr = QString::fromStdU32String( node.tagAttrs ).remove( '\"' );
-      auto n       = attr.indexOf( '=' );
+      int n        = attr.indexOf( '=' );
       if ( n > 0 ) {
         QList< std::pair< QString, QString > > query;
         query.append( std::pair< QString, QString >( attr.left( n ), attr.mid( n + 1 ) ) );
@@ -1295,7 +1295,7 @@ void DslDictionary::getArticleText( uint32_t articleAddress, QString & headword,
     static QString stripTags[ stripTagsNumber ]    = { "s", "url", "!trs", "video", "preview" };
     static QString stripEndTags[ stripTagsNumber ] = { "[/s]", "[/url]", "[/!trs]", "[/video]", "[/preview]" };
 
-    qsizetype pos = 0;
+    int pos = 0;
     while ( pos >= 0 ) {
       pos = text.indexOf( '[', pos, Qt::CaseInsensitive );
       if ( pos >= 0 ) {
@@ -1305,7 +1305,7 @@ void DslDictionary::getArticleText( uint32_t articleAddress, QString & headword,
           continue;
         }
 
-        auto pos2 = text.indexOf( ']', pos + 1, Qt::CaseInsensitive );
+        int pos2 = text.indexOf( ']', pos + 1, Qt::CaseInsensitive );
         if ( pos2 < 0 ) {
           break;
         }
@@ -1840,17 +1840,17 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
               idxHeader.hasAbrv     = 1;
               idxHeader.abrvAddress = chunks.startNewBlock();
 
-              uint32_t sz = (uint32_t)abrv.size();
+              uint32_t sz = abrv.size();
 
               chunks.addToBlock( &sz, sizeof( uint32_t ) );
 
               for ( const auto & i : abrv ) {
                 //              qDebug( "%s:%s", i->first.c_str(), i->second.c_str() );
 
-                sz = (uint32_t)i.first.size();
+                sz = i.first.size();
                 chunks.addToBlock( &sz, sizeof( uint32_t ) );
                 chunks.addToBlock( i.first.data(), sz );
-                sz = (uint32_t)i.second.size();
+                sz = i.second.size();
                 chunks.addToBlock( &sz, sizeof( uint32_t ) );
                 chunks.addToBlock( i.second.data(), sz );
               }

--- a/src/dict/gls.cc
+++ b/src/dict/gls.cc
@@ -686,7 +686,7 @@ QString & GlsDictionary::filterResource( QString & article )
   QRegularExpression linksReg( R"(<a(\s+[^>]*)href\s*=\s*['"](bword://)?([^'"]+)['"])",
                                QRegularExpression::CaseInsensitiveOption );
 
-  qsizetype pos = 0;
+  int pos = 0;
   QString articleNewText;
   QRegularExpressionMatchIterator it = linksReg.globalMatch( article );
   while ( it.hasNext() ) {
@@ -1111,8 +1111,7 @@ void GlsResourceRequest::run()
       // Correct some url's
 
       QString id = QString::fromUtf8( dict.getId().c_str() );
-
-      qsizetype pos = 0;
+      int pos    = 0;
 
       QRegularExpression links( R"(url\(\s*(['"]?)([^'"]*)(['"]?)\s*\))", QRegularExpression::CaseInsensitiveOption );
 

--- a/src/dict/hunspell.cc
+++ b/src/dict/hunspell.cc
@@ -541,7 +541,7 @@ void getSuggestionsForExpression( std::u32string const & expression,
     }
     else {
       QList< std::u32string > sugg = suggest( word, hunspellMutex, hunspell );
-      int suggNum           = sugg.size() + 1;
+      int suggNum                  = sugg.size() + 1;
       if ( suggNum > 3 ) {
         suggNum = 3;
       }

--- a/src/dict/hunspell.cc
+++ b/src/dict/hunspell.cc
@@ -370,7 +370,7 @@ QList< std::u32string > suggest( std::u32string & word, QMutex & hunspellMutex, 
         QString suggestion = QString::fromStdU32String( decodeFromHunspell( hunspell, x.c_str() ) );
 
         // Strip comments
-        auto n = suggestion.indexOf( '#' );
+        int n = suggestion.indexOf( '#' );
         if ( n >= 0 ) {
           suggestion.chop( suggestion.length() - n );
         }
@@ -541,12 +541,11 @@ void getSuggestionsForExpression( std::u32string const & expression,
     }
     else {
       QList< std::u32string > sugg = suggest( word, hunspellMutex, hunspell );
-
-      qsizetype suggNum = sugg.size() + 1;
+      int suggNum           = sugg.size() + 1;
       if ( suggNum > 3 ) {
         suggNum = 3;
       }
-      auto resNum = results.size();
+      int resNum = results.size();
       std::u32string resultStr;
 
       if ( resNum == 0 ) {
@@ -603,7 +602,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( Config::Hunspell const & c
 
 
   for ( const auto & enabledDictionarie : cfg.enabledDictionaries ) {
-    for ( auto d = dataFiles.size(); d--; ) {
+    for ( unsigned d = dataFiles.size(); d--; ) {
       if ( dataFiles[ d ].dictId == enabledDictionarie ) {
         // Found it
 

--- a/src/dict/loaddictionaries.cc
+++ b/src/dict/loaddictionaries.cc
@@ -287,7 +287,7 @@ void loadDictionaries( QWidget * parent,
   set< string > ids;
   std::pair< std::set< string >::iterator, bool > ret;
 
-  for ( auto x = dictionaries.size(); x--; ) {
+  for ( unsigned x = dictionaries.size(); x--; ) {
     ret = ids.insert( dictionaries[ x ]->getId() );
     if ( !ret.second ) {
       qWarning( R"(Duplicate dictionary ID found: ID=%s, name="%s", path="%s")",

--- a/src/dict/mdictparser.cc
+++ b/src/dict/mdictparser.cc
@@ -607,7 +607,7 @@ QString & MdictParser::substituteStylesheet( QString & article, MdictParser::Sty
   QString articleNewText;
 
   QString endStyle;
-  qsizetype pos = 0;
+  int pos = 0;
 
   QRegularExpressionMatchIterator it = rx.globalMatch( article );
   while ( it.hasNext() ) {

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -675,7 +675,7 @@ QByteArray MddResourceRequest::isolate_css()
 
   QString css = QString::fromUtf8( data.data(), data.size() );
 
-  qsizetype pos = 0;
+  int pos = 0;
 
   QString newCSS;
   QRegularExpressionMatchIterator it = RX::Mdx::links.globalMatch( css );
@@ -875,7 +875,7 @@ QString & MdxDictionary::filterResource( QString & article )
 void MdxDictionary::replaceLinks( QString & id, QString & article )
 {
   QString articleNewText;
-  qsizetype linkPos                  = 0;
+  int linkPos                        = 0;
   QRegularExpressionMatchIterator it = RX::Mdx::allLinksRe.globalMatch( article );
   while ( it.hasNext() ) {
     QRegularExpressionMatch allLinksMatch = it.next();
@@ -1042,7 +1042,7 @@ void MdxDictionary::replaceStyleInHtml( QString & id, QString & article )
 {
   //article = article.replace( RX::Mdx::fontFace, "src:url(\"bres://" + id + "/" + "\\1\")" );
   QString articleNewText;
-  qsizetype linkPos                  = 0;
+  int linkPos                        = 0;
   QRegularExpressionMatchIterator it = RX::Mdx::styleElement.globalMatch( article );
   while ( it.hasNext() ) {
     QRegularExpressionMatch allLinksMatch = it.next();
@@ -1072,8 +1072,7 @@ void MdxDictionary::replaceFontLinks( QString & id, QString & article )
 {
   //article = article.replace( RX::Mdx::fontFace, "src:url(\"bres://" + id + "/" + "\\1\")" );
   QString articleNewText;
-  qsizetype linkPos = 0;
-
+  int linkPos                        = 0;
   QRegularExpressionMatchIterator it = RX::Mdx::fontFace.globalMatch( article );
   while ( it.hasNext() ) {
     QRegularExpressionMatch allLinksMatch = it.next();
@@ -1117,7 +1116,7 @@ QString MdxDictionary::getCachedFileName( QString filename )
   QString name = filename;
   name.replace( '/', '\\' );
   QStringList list = name.split( '\\' );
-  qsizetype subFolders = list.size() - 1;
+  int subFolders   = list.size() - 1;
   if ( subFolders > 0 ) {
     QString dirName = cacheDirName;
     for ( int i = 0; i < subFolders; i++ ) {

--- a/src/dict/mediawiki.cc
+++ b/src/dict/mediawiki.cc
@@ -45,7 +45,7 @@ public:
     netMgr( netMgr_ ),
     langId( 0 )
   {
-    auto n = url.indexOf( "." );
+    int n = url.indexOf( "." );
     if ( n == 2 || ( n > 3 && url[ n - 3 ] == '/' ) ) {
       langId = LangCoder::code2toInt( url.mid( n - 2, 2 ).toLatin1().data() );
     }
@@ -249,7 +249,7 @@ public:
   static void generateTableOfContentsIfEmpty( QDomNode const & parseNode, QString & articleString )
   {
     QString const emptyTocIndicator = "<meta property=\"mw:PageProp/toc\" />";
-    auto const emptyTocPos          = articleString.indexOf( emptyTocIndicator );
+    int const emptyTocPos           = articleString.indexOf( emptyTocIndicator );
     if ( emptyTocPos == -1 ) {
       return; // The ToC must be absent or nonempty => nothing to do.
     }
@@ -524,7 +524,7 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
             QString articleString = textNode.toElement().text();
 
             // Replace all ":" in links, remove '#' part in links to other articles
-            qsizetype pos = 0;
+            int pos = 0;
             QRegularExpression regLinks( "<a\\s+href=\"/([^\"]+)\"" );
             QString articleNewString;
             QRegularExpressionMatchIterator it = regLinks.globalMatch( articleString );
@@ -546,7 +546,7 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
                 link.replace( ':', "%3A" );
               }
 
-              auto n = link.indexOf( '#', 1 );
+              int n = link.indexOf( '#', 1 );
               if ( n > 0 ) {
                 QString anchor = link.mid( n + 1 ).replace( '_', "%5F" );
                 link.truncate( n );
@@ -620,7 +620,7 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
             it = rxLink.globalMatch( articleString );
             while ( it.hasNext() ) {
               QRegularExpressionMatch match = it.next();
-              for ( auto i = match.capturedStart() + 9; i < match.capturedEnd(); i++ ) {
+              for ( int i = match.capturedStart() + 9; i < match.capturedEnd(); i++ ) {
                 if ( articleString.at( i ) == QChar( '_' ) ) {
                   articleString[ i ] = ' ';
                 }

--- a/src/dict/programs.cc
+++ b/src/dict/programs.cc
@@ -230,7 +230,7 @@ void ProgramDataRequest::instanceFinished( QByteArray output, QString error )
             // Check BOM if present
             unsigned char * uchars = reinterpret_cast< unsigned char * >( output.data() );
             if ( output.length() >= 2 && uchars[ 0 ] == 0xFF && uchars[ 1 ] == 0xFE ) {
-              qsizetype size = output.length() - 2;
+              int size = output.length() - 2;
               if ( size & 1 ) {
                 size -= 1;
               }
@@ -238,7 +238,7 @@ void ProgramDataRequest::instanceFinished( QByteArray output, QString error )
               prog_output = QString::fromUtf8( res.c_str(), res.size() );
             }
             else if ( output.length() >= 2 && uchars[ 0 ] == 0xFE && uchars[ 1 ] == 0xFF ) {
-              qsizetype size = output.length() - 2;
+              int size = output.length() - 2;
               if ( size & 1 ) {
                 size -= 1;
               }
@@ -264,14 +264,14 @@ void ProgramDataRequest::instanceFinished( QByteArray output, QString error )
             // Check BOM if present
             unsigned char * uchars = reinterpret_cast< unsigned char * >( output.data() );
             if ( output.length() >= 2 && uchars[ 0 ] == 0xFF && uchars[ 1 ] == 0xFE ) {
-              qsizetype size = output.length() - 2;
+              int size = output.length() - 2;
               if ( size & 1 ) {
                 size -= 1;
               }
               result += Iconv::toUtf8( "UTF-16LE", output.data() + 2, size );
             }
             else if ( output.length() >= 2 && uchars[ 0 ] == 0xFE && uchars[ 1 ] == 0xFF ) {
-              qsizetype size = output.length() - 2;
+              int size = output.length() - 2;
               if ( size & 1 ) {
                 size -= 1;
               }

--- a/src/dict/sdict.cc
+++ b/src/dict/sdict.cc
@@ -260,7 +260,7 @@ string SdictDictionary::convert( string const & in )
 
   // Links handling
 
-  qsizetype n = 0;
+  int n = 0;
   for ( ;; ) {
     QRegularExpression start_link_tag( "<\\s*r\\s*>", QRegularExpression::CaseInsensitiveOption );
     QRegularExpression end_link_tag( "<\\s*/r\\s*>", QRegularExpression::CaseInsensitiveOption );
@@ -270,13 +270,13 @@ string SdictDictionary::convert( string const & in )
       break;
     }
 
-    auto end = result.indexOf( end_link_tag, n );
+    int end = result.indexOf( end_link_tag, n );
     if ( end < 0 ) {
       break;
     }
 
     QRegularExpressionMatch m = start_link_tag.match( result, 0, QRegularExpression::PartialPreferFirstMatch );
-    auto tag_len              = m.captured().length();
+    int tag_len               = m.captured().length();
     QString link_text         = result.mid( n + tag_len, end - n - tag_len );
 
     m = end_link_tag.match( result, 0, QRegularExpression::PartialPreferFirstMatch );
@@ -289,7 +289,7 @@ string SdictDictionary::convert( string const & in )
   n      = 0;
   bool b = true;
   while ( b ) {
-    auto next = result.indexOf( "<br/>", n );
+    int next = result.indexOf( "<br/>", n );
     if ( next < 0 ) {
       next = result.length();
       b    = false;

--- a/src/dict/slob.cc
+++ b/src/dict/slob.cc
@@ -235,7 +235,7 @@ QString SlobFile::readString( unsigned length )
   }
 
   char term = 0;
-  auto n    = str.indexOf( term );
+  int n     = str.indexOf( term );
   if ( n >= 0 ) {
     str.resize( n );
   }
@@ -788,9 +788,7 @@ string SlobDictionary::convert( const string & in, RefEntry const & entry )
   QRegularExpression rxLink(
     R"lit(<\s*a\s+([^>]*)href="(?!(?:\w+://|#|mailto:|tel:))(/|)([^"]*)"\s*(title="[^"]*")?[^>]*>)lit" );
   QRegularExpressionMatchIterator it = rxLink.globalMatch( text );
-
-  qsizetype pos = 0;
-
+  int pos                            = 0;
   QString newText;
   while ( it.hasNext() ) {
     QRegularExpressionMatch match = it.next();
@@ -810,7 +808,7 @@ string SlobDictionary::convert( const string & in, RefEntry const & entry )
     }
 
     // Find anchor
-    auto n = list[ 3 ].indexOf( '#' );
+    int n = list[ 3 ].indexOf( '#' );
     if ( n > 0 ) {
       anchor = QString( "?gdanchor=" ) + list[ 3 ].mid( n + 1 );
       tag.remove( list[ 3 ].mid( n ) );

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -445,7 +445,7 @@ string StardictDictionary::handleResource( char type, char const * resource, siz
                                           QRegularExpression::CaseInsensitiveOption );
 
 
-      qsizetype pos = 0;
+      int pos = 0;
       QString articleNewText;
       QRegularExpressionMatchIterator it = linksReg.globalMatch( articleText );
       while ( it.hasNext() ) {
@@ -606,14 +606,14 @@ void StardictDictionary::pangoToHtml( QString & text )
 
   text.replace( "\n", "<br>" );
 
-  qsizetype pos = 0;
+  int pos = 0;
   do {
     auto match = spanRegex.match( text, pos );
     pos        = match.capturedStart();
     if ( pos >= 0 ) {
       QString styles = match.captured( 1 );
       QString newSpan( "<span style=\"" );
-      qsizetype stylePos = 0;
+      int stylePos = 0;
       do {
         auto styleMatch = styleRegex.match( styles, stylePos );
 
@@ -627,7 +627,7 @@ void StardictDictionary::pangoToHtml( QString & text )
             // Parse font description
 
             QStringList list = styleMatch.captured( 2 ).split( " ", Qt::SkipEmptyParts );
-            qsizetype n;
+            int n;
             QString sizeStr, stylesStr, familiesStr;
             for ( n = list.size() - 1; n >= 0; n-- ) {
               QString str = list.at( n );
@@ -1589,7 +1589,7 @@ void StardictResourceRequest::run()
       // Correct some url's
 
       QString id = QString::fromUtf8( dict.getId().c_str() );
-      qsizetype pos = 0;
+      int pos    = 0;
 
       static QRegularExpression links( R"(url\(\s*(['"]?)([^'"]*)(['"]?)\s*\))",
                                        QRegularExpression::CaseInsensitiveOption );

--- a/src/dict/website.cc
+++ b/src/dict/website.cc
@@ -201,7 +201,7 @@ void WebSiteArticleRequest::requestFinished( QNetworkReply * r )
     QRegularExpression tags( R"(<\s*(a|link|img|script)\s+[^>]*(src|href)\s*=\s*['"][^>]+>)",
                              QRegularExpression::CaseInsensitiveOption );
     QRegularExpression links( R"(\b(src|href)\s*=\s*(['"])([^'"]+['"]))", QRegularExpression::CaseInsensitiveOption );
-    qsizetype pos = 0;
+    int pos = 0;
     QString articleNewString;
     QRegularExpressionMatchIterator it = tags.globalMatch( articleString );
     while ( it.hasNext() ) {
@@ -443,7 +443,7 @@ void WebSiteResourceRequest::requestFinished( QNetworkReply * r )
 sptr< Dictionary::DataRequest > WebSiteDictionary::getResource( string const & name )
 {
   QString link = QString::fromUtf8( name.c_str() );
-  auto pos     = link.indexOf( '/' );
+  int pos      = link.indexOf( '/' );
   if ( pos > 0 ) {
     link.replace( pos, 1, "://" );
   }

--- a/src/dict/xdxf.cc
+++ b/src/dict/xdxf.cc
@@ -798,7 +798,7 @@ void checkArticlePosition( GzippedFile & gzFile, uint32_t * pOffset, uint32_t * 
   }
   QString s = QString::fromUtf8( data );
   free( data );
-  auto n = s.lastIndexOf( "</ar" );
+  int n = s.lastIndexOf( "</ar" );
   if ( n > 0 ) {
     *pSize -= s.size() - n;
   }
@@ -1249,15 +1249,15 @@ vector< sptr< Dictionary::Class > > makeDictionaries( vector< string > const & f
                 idxHeader.hasAbrv     = 1;
                 idxHeader.abrvAddress = chunks.startNewBlock();
 
-                uint32_t sz = (uint32_t)abrv.size();
+                uint32_t sz = abrv.size();
 
                 chunks.addToBlock( &sz, sizeof( uint32_t ) );
 
                 for ( const auto & i : abrv ) {
-                  sz = (uint32_t)i.first.size();
+                  sz = i.first.size();
                   chunks.addToBlock( &sz, sizeof( uint32_t ) );
                   chunks.addToBlock( i.first.data(), sz );
-                  sz = (uint32_t)i.second.size();
+                  sz = i.second.size();
                   chunks.addToBlock( &sz, sizeof( uint32_t ) );
                   chunks.addToBlock( i.second.data(), sz );
                 }

--- a/src/dict/zipsounds.cc
+++ b/src/dict/zipsounds.cc
@@ -328,7 +328,7 @@ sptr< Dictionary::DataRequest > ZipSoundsDictionary::getResource( string const &
   // Find sound
 
   uint32_t dataOffset = 0;
-  for ( std::size_t x = chain.size() - 1; x >= 0; x-- ) {
+  for ( int x = chain.size() - 1; x >= 0; x-- ) {
     vector< char > chunk;
     char * nameBlock = chunks->getBlock( chain[ x ].articleOffset, chunk );
 

--- a/src/dictionary_group.cc
+++ b/src/dictionary_group.cc
@@ -38,7 +38,7 @@ const std::vector< sptr< Dictionary::Class > > * DictionaryGroup::getActiveDicti
 sptr< Dictionary::Class > DictionaryGroup::getDictionaryById( const std::string & dictId )
 {
 
-  for ( auto x = allDictionaries.size(); x--; ) {
+  for ( unsigned x = allDictionaries.size(); x--; ) {
     if ( allDictionaries[ x ]->getId() == dictId ) {
       return allDictionaries[ x ];
     }

--- a/src/instances.cc
+++ b/src/instances.cc
@@ -140,11 +140,11 @@ void complementDictionaryOrder( Group & group,
 {
   set< string, std::less<> > presentIds;
 
-  for ( auto x = group.dictionaries.size(); x--; ) {
+  for ( unsigned x = group.dictionaries.size(); x--; ) {
     presentIds.insert( group.dictionaries[ x ]->getId() );
   }
 
-  for ( auto x = inactiveDictionaries.dictionaries.size(); x--; ) {
+  for ( unsigned x = inactiveDictionaries.dictionaries.size(); x--; ) {
     presentIds.insert( inactiveDictionaries.dictionaries[ x ]->getId() );
   }
 
@@ -158,10 +158,10 @@ void complementDictionaryOrder( Group & group,
 void updateNames( Config::Group & group, vector< sptr< Dictionary::Class > > const & allDictionaries )
 {
 
-  for ( auto x = group.dictionaries.size(); x--; ) {
+  for ( unsigned x = group.dictionaries.size(); x--; ) {
     std::string const id = group.dictionaries[ x ].id.toStdString();
 
-    for ( auto y = allDictionaries.size(); y--; ) {
+    for ( unsigned y = allDictionaries.size(); y--; ) {
       if ( allDictionaries[ y ]->getId() == id ) {
         group.dictionaries[ x ].name = QString::fromUtf8( allDictionaries[ y ]->getName().c_str() );
         break;

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -1739,7 +1739,7 @@ void ArticleView::moveOneArticleUp()
   if ( current.size() ) {
     QStringList lst = getArticlesList();
 
-    auto idx = lst.indexOf( dictionaryIdFromScrollTo( current ) );
+    int idx = lst.indexOf( dictionaryIdFromScrollTo( current ) );
 
     if ( idx != -1 ) {
       --idx;
@@ -1762,7 +1762,7 @@ void ArticleView::moveOneArticleDown()
     currentDictId = lst[ 0 ];
   }
 
-  auto idx = lst.indexOf( currentDictId );
+  int idx = lst.indexOf( currentDictId );
 
   if ( idx != -1 ) {
     idx = ( idx + 1 ) % lst.size();

--- a/src/ui/edit_groups_widgets.cc
+++ b/src/ui/edit_groups_widgets.cc
@@ -368,7 +368,7 @@ void DictListModel::removeSelectedRows( QItemSelectionModel * source )
     return;
   }
 
-  for ( qsizetype i = rows.count() - 1; i >= 0; --i ) {
+  for ( int i = rows.count() - 1; i >= 0; --i ) {
     dictionaries.erase( dictionaries.begin() + rows.at( i ).row() );
   }
 

--- a/src/ui/edit_sources_models.cc
+++ b/src/ui/edit_sources_models.cc
@@ -1395,7 +1395,7 @@ QVariant HunspellDictsModel::data( QModelIndex const & index, int role ) const
   }
 
   if ( role == Qt::CheckStateRole && !index.column() ) {
-    for ( qsizetype x = enabledDictionaries.size(); x--; ) {
+    for ( unsigned x = enabledDictionaries.size(); x--; ) {
       if ( enabledDictionaries[ x ] == dataFiles[ index.row() ].dictId ) {
         return Qt::Checked;
       }
@@ -1414,7 +1414,7 @@ bool HunspellDictsModel::setData( QModelIndex const & index, const QVariant & /*
   }
 
   if ( role == Qt::CheckStateRole && !index.column() ) {
-    for ( qsizetype x = enabledDictionaries.size(); x--; ) {
+    for ( unsigned x = enabledDictionaries.size(); x--; ) {
       if ( enabledDictionaries[ x ] == dataFiles[ index.row() ].dictId ) {
         // Remove it now
         enabledDictionaries.erase( enabledDictionaries.begin() + x );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1606,7 +1606,7 @@ void MainWindow::updateStatusLine()
 {
   unsigned articleCount = 0, wordCount = 0;
 
-  for ( auto x = dictionaries.size(); x--; ) {
+  for ( unsigned x = dictionaries.size(); x--; ) {
     articleCount += dictionaries[ x ]->getArticleCount();
     wordCount += dictionaries[ x ]->getWordCount();
   }
@@ -2067,7 +2067,7 @@ void MainWindow::tabSwitched( int )
   updateFoundInDictsList();
   updateWindowTitle();
   if ( mruList.size() > 1 ) {
-    auto from = mruList.indexOf( ui.tabWidget->widget( ui.tabWidget->currentIndex() ) );
+    int from = mruList.indexOf( ui.tabWidget->widget( ui.tabWidget->currentIndex() ) );
     if ( from > 0 ) {
       mruList.move( from, 0 );
     }
@@ -2140,7 +2140,7 @@ void MainWindow::updateFoundInDictsList()
     for ( QStringList::const_iterator i = ids.constBegin(); i != ids.constEnd(); ++i ) {
       // Find this dictionary
 
-      for ( auto x = dictionaries.size(); x--; ) {
+      for ( unsigned x = dictionaries.size(); x--; ) {
         if ( dictionaries[ x ]->getId() == i->toUtf8().data() ) {
           QString dictName = QString::fromUtf8( dictionaries[ x ]->getName().c_str() );
           QString dictId   = QString::fromUtf8( dictionaries[ x ]->getId().c_str() );
@@ -3311,7 +3311,7 @@ static void filterAndCollectResources( QString & html,
                                        set< QByteArray > & resourceIncluded,
                                        vector< pair< QUrl, QString > > & downloadResources )
 {
-  qsizetype pos = 0;
+  int pos = 0;
 
   auto match = rx.match( html, pos );
   while ( match.hasMatch() ) {
@@ -3433,7 +3433,7 @@ void MainWindow::on_saveArticle_triggered()
       // Convert internal links
 
       static QRegularExpression rx3( R"lit(href="(bword:|gdlookup://localhost/)([^"]+)")lit" );
-      qsizetype pos = 0;
+      int pos = 0;
       QRegularExpression anchorRx( "(g[0-9a-f]{32}_)[0-9a-f]+_" );
       auto match = rx3.match( html, pos );
       while ( match.hasMatch() ) {
@@ -3441,7 +3441,7 @@ void MainWindow::on_saveArticle_triggered()
         QString name = QUrl::fromPercentEncoding( match.captured( 2 ).simplified().toLatin1() );
         QString anchor;
         name.replace( "?gdanchor=", "#" );
-        auto n = name.indexOf( '#' );
+        int n = name.indexOf( '#' );
         if ( n > 0 ) {
           anchor = name.mid( n );
           name.truncate( n );

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -327,7 +327,7 @@ void ScanPopup::updateFoundInDictsList()
   for ( QStringList::const_iterator i = ids.constBegin(); i != ids.constEnd(); ++i ) {
     // Find this dictionary
 
-    for ( auto x = dictionaries.size(); x--; ) {
+    for ( unsigned x = dictionaries.size(); x--; ) {
       if ( dictionaries[ x ]->getId() == i->toUtf8().data() ) {
 
         auto dictionary  = dictionaries[ x ];


### PR DESCRIPTION
Revert https://github.com/xiaoyifang/goldendict-ng/pull/2127

potentially related 
- https://github.com/xiaoyifang/goldendict-ng/issues/2113
- https://github.com/xiaoyifang/goldendict-ng/issues/2152

Still not sure what's wrong, code looks correct.

But let's revert this fast, before it causes more errors.