### PR TITLE
opt: DataRequest was managed by shared_ptr

### DIFF
--- a/src/dict/dictionary.hh
+++ b/src/dict/dictionary.hh
@@ -53,10 +53,6 @@ class Request: public QObject
   Q_OBJECT
 
 public:
-  Request( QObject * parent = nullptr ):
-    QObject( parent )
-  {
-  }
   /// Returns whether the request has been processed in full and finished.
   /// This means that the data accumulated is final and won't change anymore.
   bool isFinished();
@@ -213,16 +209,11 @@ public:
   /// done, this can only be called after the request has finished.
   vector< char > & getFullData();
 
-  DataRequest( QObject * parent = 0 ):
-    Request( 0 ),
-    hasAnyData( false )
-  {
-  }
 signals:
   void finishedArticle( QString articleText );
 
 protected:
-  bool hasAnyData; // With this being false, dataSize() always returns -1
+  bool hasAnyData = false; // With this being false, dataSize() always returns -1
   vector< char > data;
 };
 

--- a/src/dict/dictionary.hh
+++ b/src/dict/dictionary.hh
@@ -214,7 +214,7 @@ public:
   vector< char > & getFullData();
 
   DataRequest( QObject * parent = 0 ):
-    Request( parent ),
+    Request( 0 ),
     hasAnyData( false )
   {
   }

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -644,7 +644,6 @@ class MddResourceRequest: public Dictionary::DataRequest
 public:
 
   MddResourceRequest( MdxDictionary & dict_, string const & resourceName_ ):
-    Dictionary::DataRequest( &dict_ ),
     dict( dict_ ),
     resourceName( Text::toUtf32( resourceName_ ) )
   {


### PR DESCRIPTION
there is no need to pass parent to the QObject.

After pass parent to QObject, it will also be managed by QObject .
which will lead to double-release the memory.