### PR TITLE
delete doc about darkreader.js customization

### DIFF
--- a/website/docs/topic_userstyle.md
+++ b/website/docs/topic_userstyle.md
@@ -11,21 +11,6 @@ By creating `article-style.css` or `article-script.js` in GoldenDict's configura
 
 The `article-style.css` is just standard HTML [Style Sheets](https://developer.mozilla.org/docs/Web/CSS). To know class or id names used in article, you can open inspector by right click article's body and click `Inspect (F12)`. The inspector's documentation can be found at [Chrome DevTools](https://developer.chrome.com/docs/devtools/)
 
-You can adjust dark reader mode's parameter by add those lines to `article-script.js`
-
-```javascript
-DarkReader.enable({
-    brightness: 100,
-    contrast: 100,
-    sepia: 0,
-    grayscale: 0,
-    darkSchemeBackgroundColor: "#181a1b",
-    darkSchemeTextColor: "#e8e6e3",
-    lightSchemeBackgroundColor: "#dcdad7",
-    lightSchemeTextColor: "#181a1b",
-});
-```
-
 Also, you can tune GoldenDict's interface by creating `qt-style.css` style sheet file in GoldenDict configuration folder. It is a [Qt Style Sheet](https://doc.qt.io/qt-6/stylesheet-reference.html) loaded during startup.
 
 Samples of `article-style.css` and `qt-style.css` files can found in GoldenDict's source code at [/src/stylesheets](https://github.com/xiaoyifang/goldendict-ng/tree/staged/src/stylesheets)


### PR DESCRIPTION
Related
- https://github.com/xiaoyifang/goldendict-ng/issues/2102

I find it is not proper and potentially misleading.

Problem:

In GD we make the webpage's header like

```html
<script>
DarkReader.enable({})
</script>

Then, in user's article-script.js file, a second
DarkReader.enable({})

what could happen here ? This is either undefined or not well tested by upstream.
```

Though, in user's `article-script.js`, they can `disable` first, but that will causes a "flash" from a dark theme to a slightly different dark theme.

The proper way is provide someway to modify the first `DarkReader.enable({})`