### PR TITLE
feat: revise Favorites by introducing active folder to reduce ambiguity

### DIFF
--- a/icons/README.txt
+++ b/icons/README.txt
@@ -10,7 +10,7 @@ addtab.svg
 wizard.svg
 fulltext
 text2speech
-reload 
+reload
 icons/print.svg
 icons/programs.svg
 error
@@ -31,6 +31,7 @@ closetab
 folder
 reload
 menu.svg
+folder_active.svg is star.svg + folder.svg
 
 https://packages.debian.org/bullseye/gnome-icon-theme GPLv3
 lists:
@@ -38,10 +39,10 @@ clear
 
 https://commons.wikimedia.org/wiki/File:Accessories-dictionary.svg
 lists:
-icon32_sdict.svg 
+icon32_sdict.svg
 
 
-https://freesvg.org/pushpin-vector-image  public domain 
+https://freesvg.org/pushpin-vector-image  public domain
 lists:
 pushbin
 

--- a/icons/folder_active.svg
+++ b/icons/folder_active.svg
@@ -1,0 +1,418 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="48"
+   height="48"
+   version="1.0"
+   id="svg37"
+   sodipodi:docname="folder_active.svg"
+   inkscape:version="1.4 (e7c3feb1, 2024-10-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview37"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="3.3145684"
+     inkscape:cx="46.159857"
+     inkscape:cy="40.578436"
+     inkscape:current-layer="layer2" />
+  <defs
+     id="defs15">
+    <radialGradient
+       id="b"
+       cx="605.71"
+       cy="486.65"
+       r="117.14"
+       gradientTransform="matrix(-2.7744 0 0 1.9697 112.76 -872.89)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#a" />
+    <linearGradient
+       id="a">
+      <stop
+         offset="0"
+         id="stop1" />
+      <stop
+         stop-opacity="0"
+         offset="1"
+         id="stop2" />
+    </linearGradient>
+    <radialGradient
+       id="c"
+       cx="605.71"
+       cy="486.65"
+       r="117.14"
+       gradientTransform="matrix(2.7744 0 0 1.9697 -1891.6 -872.89)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#a" />
+    <linearGradient
+       id="f"
+       x1="302.86"
+       x2="302.86"
+       y1="366.65"
+       y2="609.51"
+       gradientTransform="matrix(2.7744 0 0 1.9697 -1892.2 -872.89)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-opacity="0"
+         offset="0"
+         id="stop3" />
+      <stop
+         offset=".5"
+         id="stop4" />
+      <stop
+         stop-opacity="0"
+         offset="1"
+         id="stop5" />
+    </linearGradient>
+    <radialGradient
+       id="d"
+       cx="20.706"
+       cy="37.518"
+       r="30.905"
+       gradientTransform="matrix(1.055 -.027345 .1777 1.1909 -3.5722 -7.1253)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#202020"
+         offset="0"
+         id="stop6" />
+      <stop
+         stop-color="#b9b9b9"
+         offset="1"
+         id="stop7" />
+    </radialGradient>
+    <linearGradient
+       id="g"
+       x1="6.2298"
+       x2="9.8981"
+       y1="13.773"
+       y2="66.834"
+       gradientTransform="matrix(1.5168 0 0 .70898 -.87957 -1.3182)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#fff"
+         stop-opacity=".87629"
+         offset="0"
+         id="stop8" />
+      <stop
+         stop-color="#fffffe"
+         stop-opacity="0"
+         offset="1"
+         id="stop9" />
+    </linearGradient>
+    <linearGradient
+       id="h"
+       x1="13.036"
+       x2="12.854"
+       y1="32.567"
+       y2="46.689"
+       gradientTransform="matrix(1.3175 0 0 .81626 -.87957 -1.3182)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#fff"
+         offset="0"
+         id="stop10" />
+      <stop
+         stop-color="#fff"
+         stop-opacity="0"
+         offset="1"
+         id="stop11" />
+    </linearGradient>
+    <linearGradient
+       id="i"
+       x1="18.113"
+       x2="15.515"
+       y1="31.368"
+       y2="6.1803"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#424242"
+         offset="0"
+         id="stop12" />
+      <stop
+         stop-color="#777"
+         offset="1"
+         id="stop13" />
+    </linearGradient>
+    <linearGradient
+       id="e"
+       x1="22.176"
+       x2="22.065"
+       y1="36.988"
+       y2="32.05"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#6194cb"
+         offset="0"
+         id="stop14" />
+      <stop
+         stop-color="#729fcf"
+         offset="1"
+         id="stop15" />
+    </linearGradient>
+    <radialGradient
+       id="b-9"
+       cx="24"
+       cy="22"
+       r="22"
+       gradientTransform="matrix(0.71981261,-0.14396252,0.14396252,0.71981261,10.795521,9.1530262)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#e6cf00"
+         offset="0"
+         id="stop3-9" />
+      <stop
+         stop-color="#fde94a"
+         offset="1"
+         id="stop4-1" />
+    </radialGradient>
+    <linearGradient
+       id="c-7"
+       x1="14.66"
+       x2="24.031"
+       y1="7.0243001"
+       y2="34.826"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71981261,0,0,0.71981261,13.530811,4.2582997)">
+      <stop
+         stop-color="#fcf9fb"
+         offset="0"
+         id="stop1-2" />
+      <stop
+         stop-color="#fcf9fb"
+         stop-opacity="0"
+         offset="1"
+         id="stop2-3" />
+    </linearGradient>
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="folder">
+    <g
+       id="g39">
+      <g
+         transform="matrix(0.022624,0,0,0.020868,43.383,36.37)"
+         id="g16">
+        <rect
+           x="-1559.3"
+           y="-150.7"
+           width="1339.6"
+           height="478.36"
+           fill="url(#f)"
+           opacity=".40206"
+           id="rect15" />
+        <path
+           d="m-219.62-150.68v478.33c142.88 0.9 345.4-107.17 345.4-239.2 0-132.02-159.44-239.13-345.4-239.13z"
+           fill="url(#c)"
+           opacity=".40206"
+           id="path15" />
+        <path
+           d="m-1559.3-150.68v478.33c-142.8 0.9-345.4-107.17-345.4-239.2 0-132.02 159.5-239.13 345.4-239.13z"
+           fill="url(#b)"
+           opacity=".40206"
+           id="path16" />
+      </g>
+      <path
+         d="m4.5218 38.687c0.0218 0.417 0.4599 0.833 0.8762 0.833h31.327c0.416 0 0.811-0.416 0.789-0.833l-0.936-27.226c-0.022-0.417-0.46-0.833-0.877-0.833h-13.27c-0.486 0-1.235-0.316-1.402-1.1066l-0.612-2.893c-0.155-0.7357-0.882-1.0379-1.298-1.0379h-14.779c-0.4162 0-0.8107 0.4163-0.7889 0.8326l0.9707 32.264z"
+         fill="url(#d)"
+         stroke="url(#i)"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         id="path17" />
+      <path
+         d="m5.2266 22.562h30.265"
+         fill="#729fcf"
+         opacity=".11364"
+         stroke="#000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         id="path18" />
+      <path
+         d="m5.0422 18.562h30.447"
+         fill="#729fcf"
+         opacity=".11364"
+         stroke="#000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         id="path19" />
+      <path
+         d="m4.9807 12.562h30.507"
+         fill="#729fcf"
+         opacity=".11364"
+         stroke="#000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         id="path20" />
+      <path
+         d="m5.3862 32.562h30.109"
+         fill="#729fcf"
+         opacity=".11364"
+         stroke="#000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         id="path21" />
+      <path
+         d="m5.5091 34.562h29.988"
+         fill="#729fcf"
+         opacity=".11364"
+         stroke="#000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         id="path22" />
+      <path
+         d="m5.0422 16.562h30.447"
+         fill="#729fcf"
+         opacity=".11364"
+         stroke="#000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         id="path23" />
+      <path
+         d="m5.0114 14.562h30.478"
+         fill="#729fcf"
+         opacity=".11364"
+         stroke="#000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         id="path24" />
+      <path
+         d="m4.9221 10.562h15.281"
+         fill="#729fcf"
+         opacity=".11364"
+         stroke="#000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         id="path25" />
+      <path
+         d="m4.8738 8.5625h14.783"
+         fill="#729fcf"
+         opacity=".11364"
+         stroke="#000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         id="path26" />
+      <path
+         d="m5.3247 28.562h30.169"
+         fill="#729fcf"
+         opacity=".11364"
+         stroke="#000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         id="path27" />
+      <path
+         d="m5.2881 26.562h30.205"
+         fill="#729fcf"
+         opacity=".11364"
+         stroke="#000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         id="path28" />
+      <path
+         d="m5.2266 24.562h30.265"
+         fill="#729fcf"
+         opacity=".11364"
+         stroke="#000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         id="path29" />
+      <path
+         d="m5.1959 20.562h30.296"
+         fill="#729fcf"
+         opacity=".11364"
+         stroke="#000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         id="path30" />
+      <path
+         d="m5.3247 30.562h30.169"
+         fill="#729fcf"
+         opacity=".11364"
+         stroke="#000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         id="path31" />
+      <path
+         d="m5.5091 36.562h29.988"
+         fill="#729fcf"
+         opacity=".11364"
+         stroke="#000"
+         stroke-linecap="round"
+         stroke-linejoin="round"
+         id="path32" />
+      <path
+         d="m6.0683 38.864c0.0164 0.312-0.1809 0.52-0.4985 0.416-0.3177-0.104-0.5368-0.312-0.5531-0.624l-0.9477-32.065c-0.0164-0.3118 0.1651-0.5004 0.4774-0.5004l14.422-0.0477c0.313 0 0.932 0.3005 1.133 1.3222l0.574 2.8159c-0.427-0.4656-0.419-0.48-0.638-1.1571l-0.406-1.2592c-0.219-0.7276-0.698-0.8319-1.01-0.8319h-12.888c-0.3122 0-0.5095 0.2082-0.4931 0.5204l0.938 31.515-0.1096-0.104z"
+         display="block"
+         fill="url(#g)"
+         opacity=".45143"
+         id="path33" />
+      <g
+         transform="matrix(1.0408,0,0.054493,1.0408,-8.6702,2.6706)"
+         fill="#fff"
+         fill-opacity=".75706"
+         id="g34">
+        <path
+           d="m42.417 8.5152c5e-3 -0.0971-0.128-0.247-0.235-0.247l-13.031-0.0021s0.911 0.5879 2.201 0.5962l11.054 0.071c0.011-0.2117 3e-3 -0.256 0.011-0.4181z"
+           fill="#fff"
+           fill-opacity=".50847"
+           id="path34" />
+      </g>
+      <path
+         d="m39.784 39.511c1.143-0.044 1.963-1.097 2.047-2.321 0.791-11.549 1.659-21.232 1.659-21.232 0.072-0.248-0.168-0.495-0.48-0.495h-34.371c-4e-4 0-1.8507 21.867-1.8507 21.867-0.1145 0.982-0.466 1.804-1.5498 2.183l34.546-2e-3z"
+         display="block"
+         fill="url(#e)"
+         stroke="#3465a4"
+         stroke-linejoin="round"
+         id="path35" />
+      <path
+         d="m9.6202 16.464 32.791 0.065-1.574 20.002c-0.084 1.071-0.45 1.428-1.872 1.428-1.872 0-28.678-0.032-31.395-0.032 0.2335-0.321 0.3337-0.989 0.335-1.005l1.7152-20.458z"
+         fill="none"
+         opacity=".46591"
+         stroke="url(#h)"
+         stroke-linecap="round"
+         stroke-width="1px"
+         id="path36" />
+      <path
+         d="m9.6202 16.223-1.1666 15.643s8.2964-4.148 18.666-4.148 15.555-11.495 15.555-11.495h-33.055z"
+         fill="#fff"
+         fill-opacity=".089286"
+         fill-rule="evenodd"
+         id="path37" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="star">
+    <g
+       id="g38"
+       transform="translate(-0.60339682,1.508492)">
+      <path
+         d="m 40.387738,34.130524 -9.559112,-4.803958 -9.570628,4.783372 1.838618,-10.150798 -7.729348,-7.198846 10.695695,-1.469857 4.793161,-9.232317 4.771493,9.242395 10.692097,1.492748 -7.746625,7.182144 1.814721,10.155117 z"
+         fill="url(#b)"
+         stroke="#c4a000"
+         id="path7"
+         style="fill:url(#b-9);stroke-width:0.719813" />
+      <path
+         d="m 26.294527,15.624863 4.557782,-8.7845956 4.538922,8.7874736 10.128483,1.415656 -2.605577,2.41857 c -11.83228,-2.654309 -6.806117,5.197407 -19.844514,6.653372 l 0.408889,-2.289291 -7.312576,-6.813459 10.128483,-1.387655 z"
+         fill="url(#c)"
+         opacity="0.8"
+         id="path8"
+         style="fill:url(#c-7);stroke-width:0.719813" />
+      <path
+         d="m 39.425348,32.84422 -8.598161,-4.321324 -8.598881,4.296489 1.641315,-9.120025 -6.899474,-6.433902 9.557671,-1.311713 4.323699,-8.328233 4.306207,8.333271 9.557671,1.336909 -6.916895,6.421952 1.626776,9.125784 z"
+         fill="none"
+         opacity="0.69"
+         stroke="#ffffff"
+         id="path9"
+         style="stroke-width:0.719813" />
+    </g>
+  </g>
+</svg>

--- a/icons/folder_active.svg
+++ b/icons/folder_active.svg
@@ -20,9 +20,9 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
-     inkscape:zoom="3.3145684"
-     inkscape:cx="46.159857"
-     inkscape:cy="40.578436"
+     inkscape:zoom="7.2873674"
+     inkscape:cx="33.757047"
+     inkscape:cy="37.119029"
      inkscape:current-layer="layer2" />
   <defs
      id="defs15">
@@ -393,7 +393,7 @@
      inkscape:label="star">
     <g
        id="g38"
-       transform="translate(-0.60339682,1.508492)">
+       transform="matrix(1.1559684,0,0,1.1559684,-7.4038015,-2.2652448)">
       <path
          d="m 40.387738,34.130524 -9.559112,-4.803958 -9.570628,4.783372 1.838618,-10.150798 -7.729348,-7.198846 10.695695,-1.469857 4.793161,-9.232317 4.771493,9.242395 10.692097,1.492748 -7.746625,7.182144 1.814721,10.155117 z"
          fill="url(#b)"

--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -821,10 +821,6 @@ between classic and school orthography in cyrillic)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Active folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Make this folder the target of adding/removing words actions.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -825,7 +825,7 @@ between classic and school orthography in cyrillic)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Make this folder the target adding/removing words actions.</source>
+        <source>Make this folder the target of adding/removing words actions.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2643,6 +2643,10 @@ To find &apos;*&apos;, &apos;?&apos;, &apos;[&apos;, &apos;]&apos; symbols use &
     </message>
     <message>
         <source>Remove headword &quot;%1&quot; from Favorites?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -820,6 +820,14 @@ between classic and school orthography in cyrillic)</source>
         <source>Are you sure you want to clear all items?</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Active folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Make this folder the target adding/removing words actions.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Forvo::ForvoArticleRequest</name>
@@ -2330,10 +2338,6 @@ between classic and school orthography in cyrillic)</source>
     </message>
     <message>
         <source>F1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/resources.qrc
+++ b/resources.qrc
@@ -53,6 +53,7 @@
         <file>icons/folder-sound.svg</file>
         <file>icons/filesave.png</file>
         <file>icons/folder.svg</file>
+        <file>icons/folder_active.svg</file>
         <file>icons/folders.svg</file>
         <file>icons/home.svg</file>
         <file>icons/hotkeys.svg</file>

--- a/src/common/globalbroadcaster.hh
+++ b/src/common/globalbroadcaster.hh
@@ -39,8 +39,9 @@ public:
   QString translateLineText{};
   //hold the dictionary id;
   QSet< QString > collapsedDicts;
-  QMap< QString, QSet< QString > > folderFavoritesMap;
-  QMap< unsigned, QString > groupFolderMap;
+
+  std::function< bool( const QString & ) > isWordPresentedInFavorites;
+
   PronounceEngine pronounce_engine;
   QString getAbbrName( QString const & text );
 signals:

--- a/src/ui/favoritespanewidget.cc
+++ b/src/ui/favoritespanewidget.cc
@@ -23,7 +23,7 @@
 
 /************************************************** FavoritesPaneWidget *********************************************/
 
-void FavoritesPaneWidget::setUp( Config::Class * cfg, QMenu * mainMenuFav )
+void FavoritesPaneWidget::setUp( Config::Class * cfg, std::initializer_list< QAction * > actionsFromMainWindow )
 {
   m_cfg                       = cfg;
   m_favoritesTree             = findChild< QTreeView * >( "favoritesTree" );
@@ -70,7 +70,7 @@ void FavoritesPaneWidget::setUp( Config::Class * cfg, QMenu * mainMenuFav )
   m_favoritesMenu = new QMenu( this );
   m_separator     = m_favoritesMenu->addSeparator();
 
-  for ( const auto & a : mainMenuFav->actions() ) {
+  for ( const auto & a : actionsFromMainWindow ) {
     m_favoritesMenu->addAction( a );
   }
 

--- a/src/ui/favoritespanewidget.cc
+++ b/src/ui/favoritespanewidget.cc
@@ -1000,6 +1000,7 @@ TreeItem * FavoritesModel::getItemByFullPath( const QStringList & fullPath ) con
         if ( item->data().toString() == fullPath[ fullPathPos ] ) {
           if ( fullPathPos == ( fullPath.count() - 1 ) ) {
             targetFolder = item;
+            return targetFolder;
           }
           else {
             parentItem = item;

--- a/src/ui/favoritespanewidget.cc
+++ b/src/ui/favoritespanewidget.cc
@@ -32,7 +32,6 @@ void FavoritesPaneWidget::setUp( Config::Class * cfg, std::initializer_list< QAc
 
   // Active the current folder for favoriate controlling
   m_activeFolderForFav = new QAction( this );
-  m_activeFolderForFav->setText( tr( "Active folder" ) );
   m_activeFolderForFav->setToolTip( tr( "Make this folder the target of adding/removing words actions." ) );
   m_activeFolderForFav->setShortcutContext( Qt::WidgetWithChildrenShortcut );
   addAction( m_activeFolderForFav );
@@ -135,6 +134,10 @@ void FavoritesPaneWidget::setUp( Config::Class * cfg, std::initializer_list< QAc
            &FavoritesPaneWidget::onSelectionChanged );
 
   connect( m_favoritesTree, &QWidget::customContextMenuRequested, this, &FavoritesPaneWidget::showCustomMenu );
+
+  connect( m_favoritesModel, &FavoritesModel::itemDropped, this, [ this ] {
+    emit activeFavChange();
+  } );
 }
 
 FavoritesPaneWidget::~FavoritesPaneWidget()
@@ -221,10 +224,10 @@ void FavoritesPaneWidget::showCustomMenu( QPoint const & pos )
     m_favoritesMenu->addAction( m_activeFolderForFav );
 
     if ( m_favoritesModel->getItem( selectedIdxs.first() )->fullPath() == m_favoritesModel->activeFolderFullPath ) {
-      m_activeFolderForFav->setText( "Deactive folder" );
+      m_activeFolderForFav->setText( "Deactivate folder" );
     }
     else {
-      m_activeFolderForFav->setText( "Active folder" );
+      m_activeFolderForFav->setText( "Activate folder" );
     }
   }
 
@@ -949,6 +952,7 @@ bool FavoritesModel::dropMimeData(
         endInsertRows();
 
         dirty = true;
+        emit itemDropped();
 
         return true;
       }

--- a/src/ui/favoritespanewidget.hh
+++ b/src/ui/favoritespanewidget.hh
@@ -42,7 +42,7 @@ public:
     return QSize( 204, 204 );
   }
 
-  void setUp( Config::Class * cfg, std::initializer_list<QAction *> actionsFromMainWindow);
+  void setUp( Config::Class * cfg, std::initializer_list< QAction * > actionsFromMainWindow );
 
   void addWordToActiveFav( const QString & word );
   bool removeWordFromActiveFav( const QString & word );

--- a/src/ui/favoritespanewidget.hh
+++ b/src/ui/favoritespanewidget.hh
@@ -42,7 +42,7 @@ public:
     return QSize( 204, 204 );
   }
 
-  void setUp( Config::Class * cfg, QMenu * mainMenuFav );
+  void setUp( Config::Class * cfg, std::initializer_list<QAction *> actionsFromMainWindow);
 
   void addWordToActiveFav( const QString & word );
   bool removeWordFromActiveFav( const QString & word );

--- a/src/ui/favoritespanewidget.hh
+++ b/src/ui/favoritespanewidget.hh
@@ -138,6 +138,10 @@ public:
   void deleteChild( int row );
 
   TreeItem * child( int row ) const;
+  QList< TreeItem * > & children()
+  {
+    return childItems;
+  };
   int childCount() const;
   QVariant data() const;
   void setData( const QVariant & newData );

--- a/src/ui/favoritespanewidget.hh
+++ b/src/ui/favoritespanewidget.hh
@@ -42,12 +42,13 @@ public:
     return QSize( 204, 204 );
   }
 
-  void setUp( Config::Class * cfg, QMenu * menu );
+  void setUp( Config::Class * cfg, QMenu * mainMenuFav );
 
-  void addHeadword( QString const & path, QString const & headword );
+  void addWordToActiveFav( const QString & word );
+  bool removeWordFromActiveFav( const QString & word );
 
-  bool removeHeadword( QString const & path, QString const & headword );
-
+  /// @return success
+  bool trySetCurrentActiveFav( const QStringList & fullpath );
   // Export/import Favorites
   void getDataInXml( QByteArray & dataStr );
   void getDataInPlainText( QString & dataStr );
@@ -63,12 +64,14 @@ public:
   void setSaveInterval( unsigned interval );
 
   // Return true if headwors is already presented in Favorites
-  bool isHeadwordPresent( QString const & path, QString const & headword );
+  // Fully specified via TreeItem::fullpath
+  bool isWordPresentInActiveFolder( QString const & headword );
 
   void saveData();
 
 signals:
   void favoritesItemRequested( QString const & word, QString const & faforitesFolder );
+  void activeFavChange();
 
 protected:
   virtual void timerEvent( QTimerEvent * ev );
@@ -79,15 +82,21 @@ private slots:
   void onItemClicked( QModelIndex const & idx );
   void showCustomMenu( QPoint const & pos );
   void deleteSelectedItems();
+  void folderActivation();
   void copySelectedItems();
   void addFolder();
   void clearAllItems();
+public slots:
+  /// Add if exist, remove if not
+  void addRemoveWordInActiveFav( const QString & word );
 
 private:
   virtual bool eventFilter( QObject *, QEvent * );
   Config::Class * m_cfg               = nullptr;
   QTreeView * m_favoritesTree         = nullptr;
+
   QMenu * m_favoritesMenu             = nullptr;
+  QAction * m_activeFolderForFav      = nullptr;
   QAction * m_deleteSelectedAction    = nullptr;
   QAction * m_separator               = nullptr;
   QAction * m_copySelectedToClipboard = nullptr;
@@ -153,7 +162,7 @@ public:
   }
 
   // Full path from root folder
-  QString fullPath() const;
+  QStringList fullPath() const;
 
   // Duplicate item with all childs
   TreeItem * duplicateItem( TreeItem * newParent ) const;
@@ -217,14 +226,14 @@ public:
 
   // Add new headword to given folder
   // return false if it already exists there
-  bool addNewHeadword( QString const & path, QString const & headword );
+  bool addNewWordFullPath( const QString & headword );
 
   // Remove headword from given folder
   // return false if failed
-  bool removeHeadword( QString const & path, QString const & headword );
+  bool removeWordFullPath( const QString & headword );
 
   // Return true if headwors is already presented in Favorites
-  bool isHeadwordPresent( QString const & path, QString const & headword );
+  bool isWordPresentFullPath( const QString & headword );
 
   // Return path in the tree to item
   QString pathToItem( QModelIndex const & idx );
@@ -242,6 +251,15 @@ public:
 
   void saveData();
 
+  TreeItem * getItem( const QModelIndex & index ) const;
+  /// @return nullable!
+  TreeItem * getItemByFullPath( const QStringList & fullpath ) const;
+  /// @return check isValid!
+  QModelIndex getModelIndexByFullPath( const QStringList & fullpath ) const;
+
+  /// a fullPath -> the current active folder
+  QStringList activeFolderFullPath;
+
 public slots:
   void itemCollapsed( const QModelIndex & index );
   void itemExpanded( const QModelIndex & index );
@@ -258,7 +276,6 @@ protected:
   // Find item in folder
   QModelIndex findItemInFolder( QString const & itemName, TreeItem::Type itemType, QModelIndex const & parentIdx );
 
-  TreeItem * getItem( const QModelIndex & index ) const;
 
   // Find folder with given name or create it if folder not exist
   QModelIndex forceFolder( QString const & name, QModelIndex const & parentIdx );

--- a/src/ui/favoritespanewidget.hh
+++ b/src/ui/favoritespanewidget.hh
@@ -270,6 +270,7 @@ public slots:
 
 signals:
   void expandItem( const QModelIndex & index );
+  void itemDropped();
 
 protected:
   void readData();

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -587,7 +587,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   // Favorites
 
-  ui.favoritesPaneWidget->setUp( &cfg, ui.menuFavorites );
+  ui.favoritesPaneWidget->setUp( &cfg, { ui.showHideFavorites, ui.importFavorites, ui.exportFavorites } );
   ui.favoritesPaneWidget->setSaveInterval( cfg.preferences.favoritesStoreInterval );
 
   connect( ui.favoritesPane, &QDockWidget::visibilityChanged, this, &MainWindow::updateFavoritesMenu );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -598,6 +598,12 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
            this,
            &MainWindow::headwordFromFavorites );
 
+  connect( ui.favoritesPaneWidget, &FavoritesPaneWidget::activeFavChange, this, &MainWindow::updateFavIconSlot );
+
+  GlobalBroadcaster::instance()->isWordPresentedInFavorites = [ this ]( const QString & word ) {
+    return this->ui.favoritesPaneWidget->isWordPresentInActiveFolder( word );
+  };
+
   // History
   ui.historyPaneWidget->setUp( &cfg, &history, ui.menuHistory );
   history.enableAdd( cfg.preferences.storeHistory );
@@ -806,7 +812,10 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   connect( scanPopup, &ScanPopup::openDictionaryFolder, this, &MainWindow::openDictionaryFolder );
   connect( scanPopup, &ScanPopup::sendWordToHistory, this, &MainWindow::addWordToHistory );
   connect( this, &MainWindow::setPopupGroupByName, scanPopup, &ScanPopup::setGroupByName );
-  connect( scanPopup, &ScanPopup::sendWordToFavorites, this, &MainWindow::addWordToFavorites );
+  connect( scanPopup,
+           &ScanPopup::sendWordToFavorites,
+           ui.favoritesPaneWidget,
+           &FavoritesPaneWidget::addRemoveWordInActiveFav );
 
 #ifdef Q_OS_MAC
   macClipboard = new gd_clipboard( this );
@@ -1633,10 +1642,8 @@ void MainWindow::updateGroupList( bool reload )
     groupInstances.push_back( g );
   }
 
-  GlobalBroadcaster::instance()->groupFolderMap.clear();
   for ( auto & group : cfg.groups ) {
     groupInstances.push_back( Instances::Group( group, dictionaries, cfg.inactiveDictionaries ) );
-    GlobalBroadcaster::instance()->groupFolderMap.insert( group.id, group.favoritesFolder );
   }
 
   // Update names for dictionaries that are present, so that they could be
@@ -1996,15 +2003,7 @@ void MainWindow::titleChanged( ArticleView * view, QString const & title )
   }
 
   if ( index == ui.tabWidget->currentIndex() ) {
-    // Set icon for "Add to Favorites" action
-    if ( isWordPresentedInFavorites( title, cfg.lastMainGroupId ) ) {
-      addToFavorites->setIcon( blueStarIcon );
-      addToFavorites->setToolTip( tr( "Remove current tab from Favorites" ) );
-    }
-    else {
-      addToFavorites->setIcon( starIcon );
-      addToFavorites->setToolTip( tr( "Add current tab to Favorites" ) );
-    }
+    updateFavIcon( title );
 
     updateWindowTitle();
   }
@@ -2066,14 +2065,8 @@ void MainWindow::tabSwitched( int )
   if ( view ) {
     headword = view->getCurrentWord();
   }
-  if ( isWordPresentedInFavorites( headword, cfg.lastMainGroupId ) ) {
-    addToFavorites->setIcon( blueStarIcon );
-    addToFavorites->setToolTip( tr( "Remove current tab from Favorites" ) );
-  }
-  else {
-    addToFavorites->setIcon( starIcon );
-    addToFavorites->setToolTip( tr( "Add current tab to Favorites" ) );
-  }
+
+  updateFavIcon( headword );
 
   if ( view ) {
     groupList->setCurrentGroup( view->getCurrentGroupId() );
@@ -2416,6 +2409,10 @@ void MainWindow::currentGroupChanged( int )
 
   if ( ftsDlg ) {
     ftsDlg->setCurrentGroup( grg_id );
+  }
+
+  if ( igrp ) {
+    ui.favoritesPaneWidget->trySetCurrentActiveFav( igrp->favoritesFolder.split( '/' ) );
   }
 }
 
@@ -4245,19 +4242,13 @@ void MainWindow::showFTSIndexingName( QString const & name )
 
 void MainWindow::addCurrentTabToFavorites()
 {
-  QString folder;
-  Instances::Group const * igrp = groupInstances.findGroup( cfg.lastMainGroupId );
-  if ( igrp ) {
-    folder = igrp->favoritesFolder;
-  }
-
   auto view = getCurrentArticleView();
   if ( !view ) {
     return;
   }
   auto headword = view->getCurrentWord();
 
-  ui.favoritesPaneWidget->addHeadword( folder, headword );
+  ui.favoritesPaneWidget->addWordToActiveFav( headword );
 
   addToFavorites->setIcon( blueStarIcon );
   addToFavorites->setToolTip( tr( "Remove current tab from Favorites" ) );
@@ -4265,52 +4256,32 @@ void MainWindow::addCurrentTabToFavorites()
 
 void MainWindow::handleAddToFavoritesButton()
 {
-  QString folder;
-  Instances::Group const * igrp = groupInstances.findGroup( cfg.lastMainGroupId );
-  if ( igrp ) {
-    folder = igrp->favoritesFolder;
-  }
   auto view = getCurrentArticleView();
   if ( !view ) {
     return;
   }
   auto headword = view->getCurrentWord();
 
-  if ( ui.favoritesPaneWidget->isHeadwordPresent( folder, headword ) ) {
+  if ( ui.favoritesPaneWidget->isWordPresentInActiveFolder( headword ) ) {
     QMessageBox mb( QMessageBox::Question,
                     "GoldenDict",
                     tr( "Remove headword \"%1\" from Favorites?" ).arg( headword ),
                     QMessageBox::Yes | QMessageBox::No,
                     this );
     if ( mb.exec() == QMessageBox::Yes ) {
-      if ( ui.favoritesPaneWidget->removeHeadword( folder, headword ) ) {
+      if ( ui.favoritesPaneWidget->removeWordFromActiveFav( headword ) ) {
         addToFavorites->setIcon( starIcon );
         addToFavorites->setToolTip( tr( "Add current tab to Favorites" ) );
       }
     }
   }
   else {
-    ui.favoritesPaneWidget->addHeadword( folder, headword );
+    ui.favoritesPaneWidget->addWordToActiveFav( headword );
     addToFavorites->setIcon( blueStarIcon );
     addToFavorites->setToolTip( tr( "Remove current tab from Favorites" ) );
   }
 }
 
-void MainWindow::addWordToFavorites( QString const & word, unsigned groupId, bool exist )
-{
-  QString folder;
-  Instances::Group const * igrp = groupInstances.findGroup( groupId );
-  if ( igrp ) {
-    folder = igrp->favoritesFolder;
-  }
-
-  if ( !exist ) {
-    ui.favoritesPaneWidget->addHeadword( folder, word );
-  }
-  else {
-    ui.favoritesPaneWidget->removeHeadword( folder, word );
-  }
-}
 
 void MainWindow::addBookmarkToFavorite( QString const & text )
 {
@@ -4322,7 +4293,7 @@ void MainWindow::addBookmarkToFavorite( QString const & text )
   auto word           = view->getCurrentWord();
   const auto bookmark = QString( "%1~~~%2" ).arg( word, text );
 
-  ui.favoritesPaneWidget->addHeadword( nullptr, bookmark );
+  ui.favoritesPaneWidget->addWordToActiveFav( bookmark );
 }
 
 void MainWindow::addAllTabsToFavorites()
@@ -4339,24 +4310,35 @@ void MainWindow::addAllTabsToFavorites()
       continue;
     }
     auto headword = view->getCurrentWord();
-    ui.favoritesPaneWidget->addHeadword( folder, headword );
+    ui.favoritesPaneWidget->addWordToActiveFav( headword );
   }
   addToFavorites->setIcon( blueStarIcon );
   addToFavorites->setToolTip( tr( "Remove current tab from Favorites" ) );
 }
 
-bool MainWindow::isWordPresentedInFavorites( QString const & word, unsigned groupId )
+bool MainWindow::updateFavIcon( QString const & word )
 {
+
+  if ( ui.favoritesPaneWidget->isWordPresentInActiveFolder( word ) ) {
+    addToFavorites->setIcon( blueStarIcon );
+    addToFavorites->setToolTip( tr( "Remove current tab from Favorites" ) );
+  }
+  else {
+    addToFavorites->setIcon( starIcon );
+    addToFavorites->setToolTip( tr( "Add current tab to Favorites" ) );
+  }
+
   if ( word.isEmpty() ) {
     return false;
   }
-  QString folder;
-  Instances::Group const * igrp = groupInstances.findGroup( groupId );
-  if ( igrp ) {
-    folder = igrp->favoritesFolder;
-  }
 
-  return ui.favoritesPaneWidget->isHeadwordPresent( folder, word );
+  return ui.favoritesPaneWidget->isWordPresentInActiveFolder( word );
+}
+
+
+void MainWindow::updateFavIconSlot()
+{
+  updateFavIcon( getCurrentArticleView()->getCurrentWord() );
 }
 
 void MainWindow::setGroupByName( QString const & name, bool main_window )

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -4360,12 +4360,12 @@ void MainWindow::setGroupByName( QString const & name, bool main_window )
   }
 }
 
-void MainWindow::headwordFromFavorites( QString const & headword, QString const & favoritesFolder )
+void MainWindow::headwordFromFavorites( QString const & headword, QString const & favFolderFullPath )
 {
-  if ( !favoritesFolder.isEmpty() ) {
+  if ( !favFolderFullPath.isEmpty() ) {
     // Find group by it Favorites folder
     for ( Instances::Groups::size_type i = 0; i < groupInstances.size(); i++ ) {
-      if ( groupInstances[ i ].favoritesFolder == favoritesFolder ) {
+      if ( groupInstances[ i ].favoritesFolder == favFolderFullPath ) {
         // Group found. Select it and stop search.
         if ( groupList->currentIndex() != (int)i ) {
           groupList->setCurrentIndex( i );

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -263,11 +263,14 @@ private:
   void setInputLineText( QString text, WildcardPolicy wildcardPolicy, TranslateBoxPopup popupAction );
 
   void changeWebEngineViewFont() const;
-  bool isWordPresentedInFavorites( QString const & word, unsigned groupId );
+
   void errorMessageOnStatusBar( const QString & errStr );
   int getIconSize();
 
+  bool updateFavIcon( QString const & word );
+
 private slots:
+  void updateFavIconSlot();
 
   /// Try check new release, popup a dialog, and update the check time & skippedRelease version
   void checkNewRelease();
@@ -433,8 +436,6 @@ private slots:
   /// Add word to history even if history is disabled in options
   void forceAddWordToHistory( const QString & word );
 
-
-  void addWordToFavorites( QString const & word, unsigned groupId, bool );
 
   void addBookmarkToFavorite( QString const & text );
 

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -67,7 +67,7 @@ public slots:
   void messageFromAnotherInstanceReceived( QString const & );
   void showStatusBarMessage( QString const &, int, QPixmap const & );
   void wordReceived( QString const & );
-  void headwordFromFavorites( QString const &, QString const & );
+  void headwordFromFavorites( QString const & word, QString const & favFolderFullPath );
   /// Save config and states...
   void commitData();
   void quitApp();

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -1118,10 +1118,10 @@ void ScanPopup::on_sendWordToFavoritesButton_clicked()
     return;
   }
   unsigned groupId   = ui.groupList->getCurrentGroup();
-  auto current_exist = isWordPresentedInFavorites( definition->getTitle(), groupId );
+  auto current_exist = isWordPresentedInFavorites( definition->getTitle() );
   //if current_exist=false( not exist ),  after click ,the word should be in the favorite which is blueStar
   ui.sendWordToFavoritesButton->setIcon( !current_exist ? blueStarIcon : starIcon );
-  emit sendWordToFavorites( definition->getTitle(), cfg.lastPopupGroupId, current_exist );
+  emit sendWordToFavorites( definition->getTitle() );
 }
 
 void ScanPopup::switchExpandOptionalPartsMode()
@@ -1202,14 +1202,12 @@ void ScanPopup::titleChanged( ArticleView *, QString const & title ) const
   unsigned groupId = ui.groupList->getCurrentGroup();
 
   // Set icon for "Add to Favorites" button
-  ui.sendWordToFavoritesButton->setIcon( isWordPresentedInFavorites( title, groupId ) ? blueStarIcon : starIcon );
+  ui.sendWordToFavoritesButton->setIcon( isWordPresentedInFavorites( title ) ? blueStarIcon : starIcon );
 }
 
-bool ScanPopup::isWordPresentedInFavorites( QString const & word, unsigned groupId ) const
+bool ScanPopup::isWordPresentedInFavorites( QString const & word ) const
 {
-  QString folder = GlobalBroadcaster::instance()->groupFolderMap[ groupId ];
-
-  return GlobalBroadcaster::instance()->folderFavoritesMap[ folder ].contains( word );
+  return GlobalBroadcaster::instance()->isWordPresentedInFavorites( word );
 }
 
 #ifdef HAVE_X11

--- a/src/ui/scanpopup.hh
+++ b/src/ui/scanpopup.hh
@@ -80,7 +80,7 @@ signals:
   /// Put translated word into history
   void sendWordToHistory( QString const & word );
   /// Put translated word into Favorites
-  void sendWordToFavorites( QString const & word, unsigned groupId, bool );
+  void sendWordToFavorites( QString const & word );
 
 #ifdef Q_OS_WIN32
   /// Ask for source window is current translate tab
@@ -122,7 +122,7 @@ private:
 
   void updateDictionaryBar();
   /// Check is word already presented in Favorites
-  bool isWordPresentedInFavorites( QString const & word, unsigned groupId ) const;
+  bool isWordPresentedInFavorites( QString const & word ) const;
 
   Config::Class & cfg;
   std::vector< sptr< Dictionary::Class > > const & allDictionaries;

--- a/website/docs/manage_groups.md
+++ b/website/docs/manage_groups.md
@@ -122,12 +122,12 @@ The structure above will be auto grouped into three groups:
 
 Note: Dictionaries without `metadata.toml` won't be auto-grouped.
 
-## Active favoriate folder
+## Favoriates folder
 
-A group can have a specified target folder for saving favvoriates.
+A group can have an existing folder as target for saving favoriates.
 
-When stiching groups, the target folder will be automatically activated.
+When switching groups, the target folder will be automatically activated.
 
 For simple use cases, just type the name of an existing folder name.
 
-If folder is nested, then use `/` as seprator, such as `english/food/spicy` or `spanish/greetings`.
+If a folder is nested, then use `/` as a separator, such as `english/food/spicy` or `spanish/greetings`.

--- a/website/docs/manage_groups.md
+++ b/website/docs/manage_groups.md
@@ -7,8 +7,8 @@ Additionally, multiple strategies of automatic grouping are provided:
 * based on the language info embedded within dictionary files
 * based on the folder structure
 * based on customizable metadata files
-## Auto grouping
-### Auto groups by dictionary language
+
+## Auto groups by dictionary language
 
 For formats like DSL, which has embedded language from / to metadata, GD will use the dictionary's built-in metadata.
 
@@ -16,7 +16,7 @@ For other formats, GD will try finding the last `{id}-{id}` pair delimited by no
 
 Groups created in this method also include a context menu when right-click the group name, in which you can do additional dictionaries grouping by source or target language and combine dictionaries in more large groups.
 
-### Auto groups by folders
+## Auto groups by folders
 
 Click the "Group by folders" will group your dicts based on folder structure.
 
@@ -69,7 +69,7 @@ More levels of folder nesting are not supported.
 |          └─ DictB Files
 ```
 
-### Auto groups by `metadata.toml`
+## Auto groups by `metadata.toml`
 
 Click the "group by metadata" will group your dicts based on `metadata.toml`.
 
@@ -121,13 +121,3 @@ The structure above will be auto grouped into three groups:
 * `汉英词典` with `Cambridge`,`Collins`
 
 Note: Dictionaries without `metadata.toml` won't be auto-grouped.
-
-## Favoriates folder
-
-A group can have an existing folder as target for saving favoriates.
-
-When switching groups, the target folder will be automatically activated.
-
-For simple use cases, just type the name of an existing folder name.
-
-If a folder is nested, then use `/` as a separator, such as `english/food/spicy` or `spanish/greetings`.

--- a/website/docs/manage_groups.md
+++ b/website/docs/manage_groups.md
@@ -7,8 +7,8 @@ Additionally, multiple strategies of automatic grouping are provided:
 * based on the language info embedded within dictionary files
 * based on the folder structure
 * based on customizable metadata files
-
-## Auto groups by dictionary language
+## Auto grouping
+### Auto groups by dictionary language
 
 For formats like DSL, which has embedded language from / to metadata, GD will use the dictionary's built-in metadata.
 
@@ -16,7 +16,7 @@ For other formats, GD will try finding the last `{id}-{id}` pair delimited by no
 
 Groups created in this method also include a context menu when right-click the group name, in which you can do additional dictionaries grouping by source or target language and combine dictionaries in more large groups.
 
-## Auto groups by folders
+### Auto groups by folders
 
 Click the "Group by folders" will group your dicts based on folder structure.
 
@@ -66,10 +66,10 @@ More levels of folder nesting are not supported.
 ├─Mastameta
 │   └─Japanese   <- Group
 |       └─DictB  <- Dict Files's container folder
-|          └─ DictB Files  
+|          └─ DictB Files
 ```
 
-## Auto groups by `metadata.toml`
+### Auto groups by `metadata.toml`
 
 Click the "group by metadata" will group your dicts based on `metadata.toml`.
 
@@ -96,11 +96,11 @@ For example,
 │    ├── Cambridge.idx
 │    ├── Cambridge.info
 │    ├── Cambridge.syn
-│    └── Cambridge.dict.dz    
+│    └── Cambridge.dict.dz
 └── Collins
      ├── metadata.toml
      ├── res.zip
-     └── Collins.dsl       (B)  
+     └── Collins.dsl       (B)
 
 ```
 
@@ -121,3 +121,13 @@ The structure above will be auto grouped into three groups:
 * `汉英词典` with `Cambridge`,`Collins`
 
 Note: Dictionaries without `metadata.toml` won't be auto-grouped.
+
+## Active favoriate folder
+
+A group can have a specified target folder for saving favvoriates.
+
+When stiching groups, the target folder will be automatically activated.
+
+For simple use cases, just type the name of an existing folder name.
+
+If folder is nested, then use `/` as seprator, such as `english/food/spicy` or `spanish/greetings`.

--- a/website/docs/ui_favorites.md
+++ b/website/docs/ui_favorites.md
@@ -1,20 +1,24 @@
 ![favoriates](img/fav.webp)
 
-Favorites is a hierarchical structure of folders and words in them.
+Favorites is a hierarchical structure of folders and words in them. You could create folders manually via context menu.
 
-You could create folders manually via context menu.
+By default, the ⭐ icon on the toolbar will indiciate if word is in top most level.
 
-By default the ⭐icon on the toolbar will add/remove word from the top most level.
+You can "active" a folder via context menu. Then the ⭐ icon will indiciate if a word is in this folder and clicking the ⭐ icon will add/remove words to/from this folder.
 
-To add/remove word from a specific folder, you can "active" a folder via context menu,
-then clicking the ⭐icon will add/remove words from this folder.
+A group can have a associated folder.
+When switching groups, the associated folder will be automatically activated. For simple use cases, just use the name of an existing folder.
+If a folder is nested, then use `/` as a separator, such as `english/food/spicy` or `spanish/greetings`.
 
-Group can be associated with specific folders.
-When switching groups, the associated folder will be automatically activated.
+The entries can be moved simply by dragging and dropping. The entries can be deleted via context menu or by pressing the "Delete" key.
 
-The entries can be moved simply by dragging and dropping. The entries can be deleted via context menu or by pressing the "Del" key.
+## Import & Export
 
 In addition to adding and removing items to/from the Favorites you can perform the following operations via context menu or the main menu:
 
-* "Export" - the Favorites contents will be exported to the specified XML file while preserving the entire structure.
-* "Export to plain list" - all headwords stored in the Favorites will be saved to the specified text file as plain list without saving the folder structure.* * "Import" - the current contents of the Favorites will be replaced by the contents of the specified XML file.
+* "Export" - Export the all favoriates to a plain text or XML file.
+* "Import" - The current favorites will be **replaced** by the content of XML or plain text.
+
+!!! info
+    Currently, XML will perserve folder structure but plain text won't!
+

--- a/website/docs/ui_favorites.md
+++ b/website/docs/ui_favorites.md
@@ -4,7 +4,7 @@ Favorites is a hierarchical structure of folders and words in them. You could cr
 
 By default, the ⭐ icon on the toolbar will indiciate if word is in top most level.
 
-You can "active" a folder via context menu. Then the ⭐ icon will indiciate if a word is in this folder and clicking the ⭐ icon will add/remove words to/from this folder.
+You can "activate" a folder via context menu. Then the ⭐ icon will indiciate if a word is in this folder and clicking the ⭐ icon will add/remove words to/from this folder.
 
 A group can have a associated folder.
 When switching groups, the associated folder will be automatically activated. For simple use cases, just use the name of an existing folder.

--- a/website/docs/ui_favorites.md
+++ b/website/docs/ui_favorites.md
@@ -1,8 +1,18 @@
 ![favoriates](img/fav.webp)
 
-Favorites is a hierarchical structure of folders and headers in them. Folders can be bound to specific groups of dictionaries. The folder is bound to the group if it is specified in the settings of the corresponding group. The headwords opened in that group will be stored to this folder. Accordingly headwords from this folder will be opened in that group. If the folder is not bound to any group of dictionaries then headwords from it will be opened in the current group.
+Favorites is a hierarchical structure of folders and words in them.
 
-Favorites allows you to create folders manually via context menu, to move/add items to them simply by dragging and dropping as well as to delete selected items via context menu or by pressing the "Del" key.
+You could create folders manually via context menu.
+
+By default the ⭐icon on the toolbar will add/remove word from the top most level.
+
+To add/remove word from a specific folder, you can "active" a folder via context menu,
+then clicking the ⭐icon will add/remove words from this folder.
+
+Group can be associated with specific folders.
+When switching groups, the associated folder will be automatically activated.
+
+The entries can be moved simply by dragging and dropping. The entries can be deleted via context menu or by pressing the "Del" key.
 
 In addition to adding and removing items to/from the Favorites you can perform the following operations via context menu or the main menu:
 


### PR DESCRIPTION
Implement https://github.com/xiaoyifang/goldendict-ng/pull/2178#issuecomment-2675986213

---

Breakage / Enhancement:

Original GD's folder is ambiguous, group->folder mapping only maps the name.

```perl
a & b->a are considered the same.
|
| -> a
| -> b -> a
|    | -> c
```

Now requires the path fully specified like `b/a` for b->a folder and `a` is for folder a that is directly under top level only.

The group->folder is now only used when switching groups. Switching to a new group -> auto active folder of chosen.

---

Coding:

The central data is just a QStringList hat represents the nested folder.

Then various accompanying methods to utilize it.

---

Main idea: the 🌟  now associated with **the active folder <img width="24" src="https://github.com/user-attachments/assets/4c0f39ff-f85e-43ff-8c5f-8ad4c9140f8e" />** and consider the top level as the default folder.

- Add a new icon <img width="24" src="https://github.com/user-attachments/assets/4c0f39ff-f85e-43ff-8c5f-8ad4c9140f8e" /> to indicate **the active folder** that is associated with the 🌟  
- 🌟 -> word in <img width="24" src="https://github.com/user-attachments/assets/4c0f39ff-f85e-43ff-8c5f-8ad4c9140f8e" />
  - click -> remove word from current active folder.
- ⚪ -> word not in <img width="24" src="https://github.com/user-attachments/assets/4c0f39ff-f85e-43ff-8c5f-8ad4c9140f8e" />
  - click -> add word to current active folder
- Add a new action: Double click folder icon to make it **the active folder <img width="24" src="https://github.com/user-attachments/assets/4c0f39ff-f85e-43ff-8c5f-8ad4c9140f8e" />** 
  - Edit: it is occupied by folding 😅 
- If old Group->Folder association exists, then set that folder to **the active folder <img width="24" src="https://github.com/user-attachments/assets/4c0f39ff-f85e-43ff-8c5f-8ad4c9140f8e" />** 




