### PR TITLE
bump versions in deploy_website.yml

### DIFF
--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -15,13 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - uses: actions/cache@v2
-        with:
-          key: ${{ github.ref }}
-          path: .cache
       - run: pip install mkdocs-material
       - run: |
           cd website


### PR DESCRIPTION
GitHub disabled `actions/cache@v2` https://github.com/xiaoyifang/goldendict-ng/actions/runs/13655528741

But we don't use it at all, caching is only used by some plugins. Our website is also very small.

https://squidfunk.github.io/mkdocs-material/plugins/requirements/caching/