### PR TITLE
fix: multimedia memleak and #2210

### DIFF
--- a/src/audio/multimediaaudioplayer.cc
+++ b/src/audio/multimediaaudioplayer.cc
@@ -33,7 +33,7 @@ QString MultimediaAudioPlayer::play( const char * data, int size )
   player.setSourceDevice( &audioBuffer );
 
   audioOutput.setDevice( QMediaDevices::defaultAudioOutput() );
-  player.setAudioOutput( &audioOutput );
+  // player.setAudioOutput( &audioOutput );
 
   player.play();
   return {};
@@ -42,8 +42,9 @@ QString MultimediaAudioPlayer::play( const char * data, int size )
 void MultimediaAudioPlayer::stop()
 {
   player.stop();
-  audioBuffer.close();
+  player.setSource( QUrl() );
   audioBuffer.setData( QByteArray() ); // Free memory.
+  audioBuffer.close();
 }
 
 void MultimediaAudioPlayer::onMediaPlayerError()

--- a/src/audio/multimediaaudioplayer.cc
+++ b/src/audio/multimediaaudioplayer.cc
@@ -26,12 +26,11 @@ void MultimediaAudioPlayer::audioOutputChange()
 QString MultimediaAudioPlayer::play( const char * data, int size )
 {
   stop();
-  audioBuffer = new QBuffer();
-  audioBuffer->setData( data, size );
-  if ( !audioBuffer->open( QIODevice::ReadOnly ) ) {
+  audioBuffer.setData( data, size );
+  if ( !audioBuffer.open( QIODevice::ReadOnly ) ) {
     return tr( "Couldn't open audio buffer for reading." );
   }
-  player.setSourceDevice( audioBuffer );
+  player.setSourceDevice( &audioBuffer );
 
   audioOutput.setDevice( QMediaDevices::defaultAudioOutput() );
   player.setAudioOutput( &audioOutput );
@@ -43,12 +42,8 @@ QString MultimediaAudioPlayer::play( const char * data, int size )
 void MultimediaAudioPlayer::stop()
 {
   player.stop();
-
-  if ( audioBuffer ) {
-    audioBuffer->close();
-    audioBuffer->setData( QByteArray() ); // Free memory.
-    audioBuffer.clear();
-  }
+  audioBuffer.close();
+  audioBuffer.setData( QByteArray() ); // Free memory.
 }
 
 void MultimediaAudioPlayer::onMediaPlayerError()

--- a/src/audio/multimediaaudioplayer.hh
+++ b/src/audio/multimediaaudioplayer.hh
@@ -28,7 +28,7 @@ private slots:
 
 
 private:
-  QPointer< QBuffer > audioBuffer;
+  QBuffer audioBuffer;
   QMediaPlayer player; ///< Depends on audioBuffer.
   QAudioOutput audioOutput;
   QMediaDevices mediaDevices;

--- a/src/audio/multimediaaudioplayer.hh
+++ b/src/audio/multimediaaudioplayer.hh
@@ -10,7 +10,6 @@
   #include <QBuffer>
   #include <QMediaDevices>
   #include <QMediaPlayer>
-  #include <QPointer>
 
 class MultimediaAudioPlayer: public AudioPlayerInterface
 {


### PR DESCRIPTION
> revert . cause #2210

My bad, forgot to reset `player`. Seems `player` keeps referring to the old buffer, so resetting its source can fix this.

https://github.com/user-attachments/assets/a6bcd276-c906-4d7c-a7ec-30b80fbd758e