### PR TITLE
fix: corner cases of translation loading by attempting filename based gd_ts loading first

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -478,17 +478,16 @@ int main( int argc, char ** argv )
   auto * qt_ts        = new QTranslator( &app );
   auto * webengine_ts = new QTranslator( &app );
 
-
   auto loadTranslation_qlocale = []( QTranslator & qtranslator,
                                      const QString & filename,
                                      const QString & prefix,
                                      const QString & directory ) -> bool {
     if ( qtranslator.load( QLocale(), filename, prefix, directory ) ) {
-      qDebug() << "Loaded translator: " << qtranslator.filePath();
+      qDebug() << "TS loaded: " << qtranslator.filePath();
       return true;
     }
     else {
-      qDebug() << "Failed to load: " << filename << prefix << " from " << directory;
+      qDebug() << "TS failed to load: " << QLocale().uiLanguages() << filename << prefix << " from " << directory;
       return false;
     }
   };
@@ -511,7 +510,7 @@ int main( int argc, char ** argv )
   //  only load qt & webengine translators if GD's translation loading succeed to avoid inconsistency
   if ( gd_ts_loaded ) {
     QCoreApplication::installTranslator( gd_ts );
-    qDebug() << "gd_ts loaded: " << gd_ts->filePath();
+    qDebug() << "TS loaded: " << gd_ts->filePath();
 
     // For macOS bundle, the QLibraryInfo::TranslationsPath is overriden by GD.app/Contents/Resources/qt.conf
 
@@ -528,6 +527,9 @@ int main( int argc, char ** argv )
                                   QLibraryInfo::path( QLibraryInfo::TranslationsPath ) ) ) {
       QCoreApplication::installTranslator( webengine_ts );
     }
+  }
+  else {
+    qDebug() << "GD_TS not loaded.";
   }
 
 


### PR DESCRIPTION
Should fix https://github.com/xiaoyifang/goldendict-ng/issues/2247

Change GD's translator loading from QLocale based method only to

1. try the filename based method if interfaceLanguage is present
2. try the QLocale based method if interfaceLanguage is emptry

The 2. sometimes doesn't work because of https://github.com/xiaoyifang/goldendict-ng/issues/2120

Root issue: `QTranslator` & `QLocale` have tricky behaviors. Note that the 3 major operating systems do the Locale thing slightly differently.


Previous:

- https://github.com/xiaoyifang/goldendict-ng/pull/2119 
  - That PR switched gd_ts to QLocale so that when interfaceLanguage is empty, uses system's QLocale.
  - This PR reverted it partially because exactly what will the constructed QLocale do is tricky.
- https://github.com/xiaoyifang/goldendict-ng/pull/2119
- https://github.com/xiaoyifang/goldendict-ng/issues/530