### PR TITLE
feat: rework "solo" "mode" to Temporary Selection

### DIFF
--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -249,30 +249,31 @@ void DictionaryBar::actionWasTriggered( QAction * action )
   ///                                      \-> False -> Change current single selection
   if ( QApplication::keyboardModifiers() & ( Qt::ControlModifier | Qt::ShiftModifier ) ) {
     if ( tempSelection == true ) {
+
       if ( mutedDictionaries->contains( id ) ) { // Ctrl/Shift+Clicked an unselected dict
         selectSingleDict( id );
       }
       else { // Click/Shift+Clicked an selected dict
-        tempSelection = false;
 
-        // Restore all selection
         if ( QApplication::keyboardModifiers() & ( Qt::ControlModifier ) ) {
+          // Restore all selection
           mutedDictionaries->clear();
-          tempSelectionInitallyMuted.clear();
+        }
+        else if ( QApplication::keyboardModifiers() & ( Qt::ShiftModifier ) ) {
+          //Restore the inital selection
+          *mutedDictionaries = tempSelectionInitallyMuted;
         }
 
-        //Restore the inital selection
-        else if ( QApplication::keyboardModifiers() & ( Qt::ShiftModifier ) ) {
-          *mutedDictionaries = tempSelectionInitallyMuted;
-          tempSelectionInitallyMuted.clear();
-        }
+        tempSelection = false;
+        tempSelectionInitallyMuted.clear();
       }
     }
     else if ( tempSelection == false ) {
       // Memorize selection list and focus on single dict
+      tempSelection              = true;
       tempSelectionInitallyMuted = *mutedDictionaries;
+
       selectSingleDict( id );
-      tempSelection = true;
     }
   }
   else { // No modifiers

--- a/src/ui/dictionarybar.hh
+++ b/src/ui/dictionarybar.hh
@@ -61,9 +61,10 @@ private:
 
   Config::MutedDictionaries * mutedDictionaries;
   Config::Events & configEvents;
-  Config::MutedDictionaries storedMutedSet;
 
-  bool enterSoloMode = false;
+  Config::MutedDictionaries tempSelectionInitallyMuted;
+  bool tempSelection = false;
+  void selectSingleDict( const QString & id );
 
   // how many dictionaries should be shown in the context menu:
   unsigned short const & maxDictionaryRefsInContextMenu;

--- a/src/ui/dictionarybar.hh
+++ b/src/ui/dictionarybar.hh
@@ -62,8 +62,7 @@ private:
   Config::MutedDictionaries * mutedDictionaries;
   Config::Events & configEvents;
 
-  Config::MutedDictionaries tempSelectionInitallyMuted;
-  bool tempSelection = false;
+  std::optional< Config::MutedDictionaries > tempSelectionInitallyMuted;
   void selectSingleDict( const QString & id );
 
   // how many dictionaries should be shown in the context menu:

--- a/website/docs/ui_toolbar.md
+++ b/website/docs/ui_toolbar.md
@@ -7,9 +7,9 @@ Holding Ctrl or Shift will display the translation result in a new tab.
 
 ### Wildcard matching
 
-The search line can use wildcard or glob symbols for matching words.  
+The search line can use wildcard or glob symbols for matching words.
 
-| Wildcard | Description                                                            | 
+| Wildcard | Description                                                            |
 |----------|------------------------------------------------------------------------|
 | `?`      | Matches any single character.                                          |
 | `*`      | Matches zero or more of any characters.                                |
@@ -27,28 +27,29 @@ More information about wildcard matching can be found in [Wikipedia's glob artic
 
 ## Dictionary Bar
 
-The dictionary bar contains all dictionaries from the current dictionaries group. Click the icons to disable/enable them.
+The dictionary bar shows dictionaries from the current group.
 
-### "Solo" mode
+Click the icons to select/unselect them.
 
-Temporally focus on a single dictionary and restore back to all dictionaries or previously selected dictionaries.
+### Temporary Selection (was Solo Mode)
 
-To enter solo mode:
+Focus on a single dictionary temporally.
 
-++ctrl+left-button++ -> Select a single dictionary.
-++ctrl+left-button++ -> Reselect all dictionaries.
++ ++ctrl+"Click"++ a dictionary --> select a single dictionary.
++ ++ctrl+"Click"++ again on another unselected dictionary --> select that single dictionary.
++ ++ctrl+"Click"++ again on the selected dictionary --> reselect all dictionaries.
 
-To exit solo mode:
-++shift+left-button++ -> Reselect dictionaries that were previously selected before entering solo mode.
+To reselect the initially selected dictionaries before the continous clicking with ++ctrl++ or ++shift++, uses ++shift+"Click"++ instead .
 
-For example, there are 4 dictionaries A,B,C,D with ABC selected.
+For example, there are 3 dictionaries A,B,C with A,B initially selected.
 
-| Cases                                    | Note                                         |
-|------------------------------------------|----------------------------------------------|
-| Ctrl+Click A                             | select A only                                |
-| Ctrl+Click A, Ctrl+Click B               | select B only                                |
-| Ctrl+Click A, Ctrl+Click A               | A,B,C,D selected (all dictionaries selected) |
-| Ctrl+Click A, Shift+Click any dictionary | A,B,C selected                               |
+| Clicking Sequence                                                       | Outcome                                                     |
+|-------------------------------------------------------------------------|-------------------------------------------------------------|
+| ++ctrl+"Click"++ + A                                                    | select A only                                               |
+| ++ctrl+"Click"++ + A --> ++ctrl+"Click"++ + A                           | select A first --> all A,B,C reselected                     |
+| ++ctrl+"Click"++ + A --> ++shift+"Click"++ + A                          | select A first --> reselect the inital selection A,B        |
+| ++ctrl+"Click"++ + A --> ++ctrl+"Click"++ + B --> ++ctrl+"Click"++ + B  | select A --> select B --> then reselect all                 |
+| ++ctrl+"Click"++ + A --> ++ctrl+"Click"++ + C --> ++shift+"Click"++ + A | select A --> select C --> reselect the inital selection A,B |
 
 Note: This can also be used on the "Found in dictionaries" panel.
 

--- a/website/docs/ui_toolbar.md
+++ b/website/docs/ui_toolbar.md
@@ -38,15 +38,15 @@ Focus on a single dictionary temporarily.
 + ++ctrl+"Click"++ again on another unselected dictionary --> select that single dictionary.
 + ++ctrl+"Click"++ again on the selected dictionary --> reselect all dictionaries.
 
-To reselect the initially selected dictionaries before the continous clicking with ++ctrl++ or ++shift++, uses ++shift+"Click"++ instead .
+To reselect the initially selected dictionaries, use ++shift+"Click"++ instead.
 
 For example, there are 3 dictionaries A,B,C with A,B initially selected.
 
 | Clicking Sequence                                                         | Outcome                                                     |
 |---------------------------------------------------------------------------|-------------------------------------------------------------|
 | ++ctrl+"Click"++ + A                                                      | select A only                                               |
-| ++ctrl+"Click"++ + A --> ++ctrl+"Click"++ + A                             | select A first --> all A,B,C reselected                     |
-| ++shift+"Click"++ + A --> ++shift+"Click"++ + A                           | select A first --> reselect the inital selection A,B        |
+| ++ctrl+"Click"++ + A --> ++ctrl+"Click"++ + A                             | select A --> all A,B,C reselected                           |
+| ++shift+"Click"++ + A --> ++shift+"Click"++ + A                           | select A --> reselect the inital selection A,B              |
 | ++ctrl+"Click"++ + A --> ++ctrl+"Click"++ + B --> ++ctrl+"Click"++ + B    | select A --> select B --> reselect all                      |
 | ++shift+"Click"++ + A --> ++shift+"Click"++ + C --> ++shift+"Click"++ + C | select A --> select C --> reselect the inital selection A,B |
 

--- a/website/docs/ui_toolbar.md
+++ b/website/docs/ui_toolbar.md
@@ -24,7 +24,6 @@ The search line can use wildcard or glob symbols for matching words.
 
 More information about wildcard matching can be found in [Wikipedia's glob article](https://en.wikipedia.org/wiki/Glob_(programming)).
 
-
 ## Dictionary Bar
 
 The dictionary bar shows dictionaries from the current group.
@@ -33,7 +32,7 @@ Click the icons to select/unselect them.
 
 ### Temporary Selection (was Solo Mode)
 
-Focus on a single dictionary temporally.
+Focus on a single dictionary temporarily.
 
 + ++ctrl+"Click"++ a dictionary --> select a single dictionary.
 + ++ctrl+"Click"++ again on another unselected dictionary --> select that single dictionary.
@@ -48,8 +47,8 @@ For example, there are 3 dictionaries A,B,C with A,B initially selected.
 | ++ctrl+"Click"++ + A                                                    | select A only                                               |
 | ++ctrl+"Click"++ + A --> ++ctrl+"Click"++ + A                           | select A first --> all A,B,C reselected                     |
 | ++ctrl+"Click"++ + A --> ++shift+"Click"++ + A                          | select A first --> reselect the inital selection A,B        |
-| ++ctrl+"Click"++ + A --> ++ctrl+"Click"++ + B --> ++ctrl+"Click"++ + B  | select A --> select B --> then reselect all                 |
-| ++ctrl+"Click"++ + A --> ++ctrl+"Click"++ + C --> ++shift+"Click"++ + A | select A --> select C --> reselect the inital selection A,B |
+| ++ctrl+"Click"++ + A --> ++ctrl+"Click"++ + B --> ++ctrl+"Click"++ + B  | select A --> select B --> reselect all                      |
+| ++ctrl+"Click"++ + A --> ++ctrl+"Click"++ + C --> ++shift+"Click"++ + C | select A --> select C --> reselect the inital selection A,B |
 
-Note: This can also be used on the "Found in dictionaries" panel.
+Note: This can also be used in the "Found in dictionaries" panel.
 

--- a/website/docs/ui_toolbar.md
+++ b/website/docs/ui_toolbar.md
@@ -42,13 +42,13 @@ To reselect the initially selected dictionaries before the continous clicking wi
 
 For example, there are 3 dictionaries A,B,C with A,B initially selected.
 
-| Clicking Sequence                                                       | Outcome                                                     |
-|-------------------------------------------------------------------------|-------------------------------------------------------------|
-| ++ctrl+"Click"++ + A                                                    | select A only                                               |
-| ++ctrl+"Click"++ + A --> ++ctrl+"Click"++ + A                           | select A first --> all A,B,C reselected                     |
-| ++ctrl+"Click"++ + A --> ++shift+"Click"++ + A                          | select A first --> reselect the inital selection A,B        |
-| ++ctrl+"Click"++ + A --> ++ctrl+"Click"++ + B --> ++ctrl+"Click"++ + B  | select A --> select B --> reselect all                      |
-| ++ctrl+"Click"++ + A --> ++ctrl+"Click"++ + C --> ++shift+"Click"++ + C | select A --> select C --> reselect the inital selection A,B |
+| Clicking Sequence                                                         | Outcome                                                     |
+|---------------------------------------------------------------------------|-------------------------------------------------------------|
+| ++ctrl+"Click"++ + A                                                      | select A only                                               |
+| ++ctrl+"Click"++ + A --> ++ctrl+"Click"++ + A                             | select A first --> all A,B,C reselected                     |
+| ++shift+"Click"++ + A --> ++shift+"Click"++ + A                           | select A first --> reselect the inital selection A,B        |
+| ++ctrl+"Click"++ + A --> ++ctrl+"Click"++ + B --> ++ctrl+"Click"++ + B    | select A --> select B --> reselect all                      |
+| ++shift+"Click"++ + A --> ++shift+"Click"++ + C --> ++shift+"Click"++ + C | select A --> select C --> reselect the inital selection A,B |
 
 Note: This can also be used in the "Found in dictionaries" panel.
 

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -22,12 +22,13 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.superfences
   - pymdownx.keys
+  - pymdownx.smartsymbols
 
 nav:
   - Getting started: index.md
   - Download & Install: install.md
   - Dictionary Formats: dictformats.md
-  - Manage Dictionaries: 
+  - Manage Dictionaries:
       - Sources: manage_sources.md
       - Groups: manage_groups.md
   - Interface:


### PR DESCRIPTION
- fix https://github.com/xiaoyifang/goldendict-ng/issues/1070
- close https://github.com/xiaoyifang/goldendict-ng/issues/2213

### Context:

Original GD's solo "mode" has an unintuitive edge case when ctrl+click 2 different dicts.

The initial selection is A,B,C. 

```
A,B,C selected ->Ctrl+Click A -> Ctrl+Click B -> Shift+Click B -> OutCome: A selected
                              ^                                      |
                              |-------restore to here----------------v
```
The expectation is reselecting the initial selection.

The fix
- https://github.com/xiaoyifang/goldendict-ng/pull/1073

was toward a right direction by moving the restoration point early, but the mode is sticky and need to quit first to use it again which created the need to check the status first like https://github.com/xiaoyifang/goldendict-ng/pull/2259. I feel it to be less ideal.


### This PR

+ Change restoration pointing goes to the initial selection before the sequence of clicking.
+ Make this functionality not sticky.
   + Click without modifier -> No restore and remove memorized inital selection 
   + Click with a modifier -> Restore all or inital selection, also remove memorized inital selection 
```
A,B,C selected ->Ctrl+Click A -> Ctrl+Click B -> Shift+Click B -> OutCome: A,B,C selected
        ^                                                                       |
        |-------restore to here-------------------------------------------------v
```

+ Also update user doc.


