### PR TITLE
feat: rework "solo" "mode" to Single Selection Mode

### DIFF
--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -252,7 +252,7 @@ void DictionaryBar::actionWasTriggered( QAction * action )
   ///
 
   if ( singleSelectionInitallyMuted.has_value() ) { // (in mode)
-    if ( !mutedDictionaries->contains( id ) ) {   // dict was selected
+    if ( !mutedDictionaries->contains( id ) ) {     // dict was selected
       if ( Qt::ControlModifier & QApplication::keyboardModifiers() ) {
         mutedDictionaries->clear();
       }

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -244,39 +244,30 @@ void DictionaryBar::actionWasTriggered( QAction * action )
   }
 
   /// Real Solo Mode
-  ///
-  /// Click -> with modifier    -> dict already selected -> tempSelect -> has value -> reselect depends on Ctrl/Shift
-  ///                                                                  -> no value select that single one and memorize
-  ///                           -> dict not selected -> if tempSelect no value, then set + select single one
-  ///       -> without modifier -> tempSelect hasValue -> select that single one
-  ///                           -> normal
+  /// Click         (in mode)
+  /// tempSelect -> has value  -> dict was selected: reselect depends on Ctrl/Shift, discard memorized selection
+  ///                          -> dict was not selected: select a single one
+  ///             -> no value  -> has modifier: select a single dict + memorize
+  ///           (not in mode)  -> no modifier: normal
   ///
 
-  if ( ( Qt::ControlModifier | Qt::ShiftModifier ) & QApplication::keyboardModifiers() ) {
-    if ( !mutedDictionaries->contains( id ) ) { // clicked an selected dict
-      if ( tempSelectionInitallyMuted.has_value() ) {
-        if ( Qt::ControlModifier & QApplication::keyboardModifiers() ) {
-          mutedDictionaries->clear();
-        }
-        else if ( Qt::ShiftModifier & QApplication::keyboardModifiers() ) {
-          *mutedDictionaries = tempSelectionInitallyMuted.value();
-        }
-        tempSelectionInitallyMuted.reset();
+  if ( tempSelectionInitallyMuted.has_value() ) { // (in mode)
+    if ( !mutedDictionaries->contains( id ) ) { // dict was selected
+      if ( Qt::ControlModifier & QApplication::keyboardModifiers() ) {
+        mutedDictionaries->clear();
       }
-      else {
-        tempSelectionInitallyMuted.emplace( *mutedDictionaries );
-        selectSingleDict( id );
+      else if ( Qt::ShiftModifier & QApplication::keyboardModifiers() ) {
+        *mutedDictionaries = tempSelectionInitallyMuted.value();
       }
+      tempSelectionInitallyMuted.reset();
     }
-    else {
-      if ( !tempSelectionInitallyMuted.has_value() ) {
-        tempSelectionInitallyMuted.emplace( *mutedDictionaries );
-      }
+    else { // dict was not selected
       selectSingleDict( id );
     }
   }
-  else { // No modifiers
-    if ( tempSelectionInitallyMuted.has_value() ) {
+  else {
+    if ( ( Qt::ControlModifier | Qt::ShiftModifier ) & QApplication::keyboardModifiers() ) {
+      tempSelectionInitallyMuted.emplace( *mutedDictionaries );
       selectSingleDict( id );
     }
     else { // Normal
@@ -303,7 +294,6 @@ void DictionaryBar::selectSingleDict( const QString & id )
     }
   }
 }
-
 
 void DictionaryBar::dictsPaneClicked( const QString & id )
 {

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -243,23 +243,23 @@ void DictionaryBar::actionWasTriggered( QAction * action )
     return; // Some weird action, not our button
   }
 
-  /// Real Solo Mode
+  /// Single Selection Mode
   /// Click         (in mode)
-  /// tempSelect -> has value  -> dict was selected: reselect depends on Ctrl/Shift, discard memorized selection
-  ///                          -> dict was not selected: select a single one
-  ///             -> no value  -> has modifier: select a single dict + memorize
-  ///           (not in mode)  -> no modifier: normal
+  /// singleSelect -> has value  -> dict was selected: reselect depends on Ctrl/Shift, discard memorized selection
+  ///                           -> dict was not selected: select a single one
+  ///              -> no value  -> has modifier: select a single dict + memorize
+  ///            (not in mode)  -> no modifier: normal
   ///
 
-  if ( tempSelectionInitallyMuted.has_value() ) { // (in mode)
-    if ( !mutedDictionaries->contains( id ) ) { // dict was selected
+  if ( singleSelectionInitallyMuted.has_value() ) { // (in mode)
+    if ( !mutedDictionaries->contains( id ) ) {   // dict was selected
       if ( Qt::ControlModifier & QApplication::keyboardModifiers() ) {
         mutedDictionaries->clear();
       }
       else if ( Qt::ShiftModifier & QApplication::keyboardModifiers() ) {
-        *mutedDictionaries = tempSelectionInitallyMuted.value();
+        *mutedDictionaries = singleSelectionInitallyMuted.value();
       }
-      tempSelectionInitallyMuted.reset();
+      singleSelectionInitallyMuted.reset();
     }
     else { // dict was not selected
       selectSingleDict( id );
@@ -267,7 +267,7 @@ void DictionaryBar::actionWasTriggered( QAction * action )
   }
   else {
     if ( ( Qt::ControlModifier | Qt::ShiftModifier ) & QApplication::keyboardModifiers() ) {
-      tempSelectionInitallyMuted.emplace( *mutedDictionaries );
+      singleSelectionInitallyMuted.emplace( *mutedDictionaries );
       selectSingleDict( id );
     }
     else { // Normal

--- a/src/ui/dictionarybar.hh
+++ b/src/ui/dictionarybar.hh
@@ -62,7 +62,7 @@ private:
   Config::MutedDictionaries * mutedDictionaries;
   Config::Events & configEvents;
 
-  std::optional< Config::MutedDictionaries > tempSelectionInitallyMuted;
+  std::optional< Config::MutedDictionaries > singleSelectionInitallyMuted;
   void selectSingleDict( const QString & id );
 
   // how many dictionaries should be shown in the context menu:

--- a/src/ui/dictionarybar.hh
+++ b/src/ui/dictionarybar.hh
@@ -61,9 +61,9 @@ private:
 
   Config::MutedDictionaries * mutedDictionaries;
   Config::Events & configEvents;
-  Config::MutedDictionaries storedMutedSet;
 
-  bool enterSoloMode = false;
+  std::optional< Config::MutedDictionaries > tempSelectionInitallyMuted;
+  void selectSingleDict( const QString & id );
 
   // how many dictionaries should be shown in the context menu:
   unsigned short const & maxDictionaryRefsInContextMenu;

--- a/website/docs/ui_toolbar.md
+++ b/website/docs/ui_toolbar.md
@@ -32,13 +32,13 @@ Click the icons to select/unselect them.
 
 ### Single Selection Mode (was Solo Mode)
 
-In this mode, only a single dictionary can be selected.
+When this mode is active, only one single dictionary can be selected at a time.
 
-Enter the mode:
+Enter mode:
 
 - ++ctrl+"Click"++ or ++shift+"Click"++ a dictionary icon.
 
-Exit the mode:
+Exit mode:
 
 - ++ctrl+"Click"++ the selected dictionary will reselect all dictionaries.
 - ++shift+"Click"++ the selected dictionary will reselect dictioanries selected before entering the mode.
@@ -52,5 +52,5 @@ For example, there are 3 dictionaries A,B,C with A,B initially selected.
 | ++ctrl+"Click"++ + A --> ++"Click"++ + B --> ++ctrl+"Click"++ + B   | select A --> select B --> reselect all A,B,C                 |
 | ++shift+"Click"++ + A --> ++"Click"++ + B --> ++shift+"Click"++ + B | select A --> select B --> reselect the initally selected A,B |
 
-!!!note
+!!! note
 This can also be used in the "Found in dictionaries" panel to temporarily focus on a single dictionary.

--- a/website/docs/ui_toolbar.md
+++ b/website/docs/ui_toolbar.md
@@ -7,9 +7,9 @@ Holding Ctrl or Shift will display the translation result in a new tab.
 
 ### Wildcard matching
 
-The search line can use wildcard or glob symbols for matching words.  
+The search line can use wildcard or glob symbols for matching words.
 
-| Wildcard | Description                                                            | 
+| Wildcard | Description                                                            |
 |----------|------------------------------------------------------------------------|
 | `?`      | Matches any single character.                                          |
 | `*`      | Matches zero or more of any characters.                                |
@@ -24,31 +24,30 @@ The search line can use wildcard or glob symbols for matching words.
 
 More information about wildcard matching can be found in [Wikipedia's glob article](https://en.wikipedia.org/wiki/Glob_(programming)).
 
-
 ## Dictionary Bar
 
-The dictionary bar contains all dictionaries from the current dictionaries group. Click the icons to disable/enable them.
+The dictionary bar shows dictionaries from the current group.
 
-### "Solo" mode
+Click the icons to select/unselect them.
 
-Temporally focus on a single dictionary and restore back to all dictionaries or previously selected dictionaries.
+### Solo Mode
 
-To enter solo mode:
+Focus on a single dictionary temporarily.
 
-++ctrl+left-button++ -> Select a single dictionary.
-++ctrl+left-button++ -> Reselect all dictionaries.
+++ctrl+"Click"++ or ++strl+"Click"++ will select a single dictionary and enter solo mode, then only a single dictionary will be selected.
 
-To exit solo mode:
-++shift+left-button++ -> Reselect dictionaries that were previously selected before entering solo mode.
+++ctrl+"Click"++ the selected dictionary will reselect all dictionaries.
 
-For example, there are 4 dictionaries A,B,C,D with ABC selected.
+++shift+"Click"++ the selected dictionary will reselect dictioanries selected before entering the mode.
 
-| Cases                                    | Note                                         |
-|------------------------------------------|----------------------------------------------|
-| Ctrl+Click A                             | select A only                                |
-| Ctrl+Click A, Ctrl+Click B               | select B only                                |
-| Ctrl+Click A, Ctrl+Click A               | A,B,C,D selected (all dictionaries selected) |
-| Ctrl+Click A, Shift+Click any dictionary | A,B,C selected                               |
+For example, there are 3 dictionaries A,B,C with A,B initially selected.
 
-Note: This can also be used on the "Found in dictionaries" panel.
+| Clicking Sequence                                                  | Outcome                                |
+|--------------------------------------------------------------------|----------------------------------------|
+| ++ctrl+"Click"++ + A                                               | select A only                          |
+| ++ctrl+"Click"++ + A --> ++"Click"++ + B                           | select A --> select B                  |
+| ++ctrl+"Click"++ + A --> ++"Click"++ + A                           | select A --> reselect all A,B,C        |
+| ++ctrl+"Click"++ + A --> ++"Click"++ + B --> ++shift+"Click"++ + B | select A --> select B --> reselect A,B |
+
+Note: This can also be used in the "Found in dictionaries" panel.
 

--- a/website/docs/ui_toolbar.md
+++ b/website/docs/ui_toolbar.md
@@ -35,9 +35,9 @@ Click the icons to select/unselect them.
 In this mode, only a single dictionary can be selected.
 
 Enter the mode:
-++ctrl+"Click"++ or ++shift+"Click"++.
+++ctrl+"Click"++ or ++shift+"Click"++ a dictionary icon.
 
-Exit the mode.
+Exit the mode:
 
 ++ctrl+"Click"++ the selected dictionary will reselect all dictionaries.
 
@@ -45,12 +45,12 @@ Exit the mode.
 
 For example, there are 3 dictionaries A,B,C with A,B initially selected.
 
-| Clicking Sequence                                                  | Outcome                                      |
-|--------------------------------------------------------------------|----------------------------------------------|
-| ++ctrl+"Click"++ + A                                               | select A only                                |
-| ++ctrl+"Click"++ + A --> ++ctrl+"Click"++ + A                      | select A --> reselect all A,B,C              |
-| ++ctrl+"Click"++ + A --> ++"Click"++ + B --> ++ctrl+"Click"++ + B  | select A --> select B --> reselect all A,B,C |
-| ++ctrl+"Click"++ + A --> ++"Click"++ + B --> ++shift+"Click"++ + B | select A --> select B --> reselect A,B       |
+| Clicking Sequence                                                   | Outcome                                      |
+|---------------------------------------------------------------------|----------------------------------------------|
+| ++ctrl+"Click"++ + A                                                | select A only                                |
+| ++ctrl+"Click"++ + A --> ++ctrl+"Click"++ + A                       | select A --> reselect all A,B,C              |
+| ++ctrl+"Click"++ + A --> ++"Click"++ + B --> ++ctrl+"Click"++ + B   | select A --> select B --> reselect all A,B,C |
+| ++shift+"Click"++ + A --> ++"Click"++ + B --> ++shift+"Click"++ + B | select A --> select B --> reselect A,B       |
 
-Note: This can also be used in the "Found in dictionaries" panel.
-
+!!! note:
+This can also be used in the "Found in dictionaries" panel to temporarily focus on a single dictionary.

--- a/website/docs/ui_toolbar.md
+++ b/website/docs/ui_toolbar.md
@@ -30,27 +30,27 @@ The dictionary bar shows dictionaries from the current group.
 
 Click the icons to select/unselect them.
 
-### Solo Mode
+### Single Selection Mode (was Solo Mode)
 
 In this mode, only a single dictionary can be selected.
 
 Enter the mode:
-++ctrl+"Click"++ or ++shift+"Click"++ a dictionary icon.
+
+- ++ctrl+"Click"++ or ++shift+"Click"++ a dictionary icon.
 
 Exit the mode:
 
-++ctrl+"Click"++ the selected dictionary will reselect all dictionaries.
-
-++shift+"Click"++ the selected dictionary will reselect dictioanries selected before entering the mode.
+- ++ctrl+"Click"++ the selected dictionary will reselect all dictionaries.
+- ++shift+"Click"++ the selected dictionary will reselect dictioanries selected before entering the mode.
 
 For example, there are 3 dictionaries A,B,C with A,B initially selected.
 
-| Clicking Sequence                                                   | Outcome                                      |
-|---------------------------------------------------------------------|----------------------------------------------|
-| ++ctrl+"Click"++ + A                                                | select A only                                |
-| ++ctrl+"Click"++ + A --> ++ctrl+"Click"++ + A                       | select A --> reselect all A,B,C              |
-| ++ctrl+"Click"++ + A --> ++"Click"++ + B --> ++ctrl+"Click"++ + B   | select A --> select B --> reselect all A,B,C |
-| ++shift+"Click"++ + A --> ++"Click"++ + B --> ++shift+"Click"++ + B | select A --> select B --> reselect A,B       |
+| Clicking Sequence                                                   | Outcome                                                      |
+|---------------------------------------------------------------------|--------------------------------------------------------------|
+| ++ctrl+"Click"++ + A                                                | select A only                                                |
+| ++ctrl+"Click"++ + A --> ++ctrl+"Click"++ + A                       | select A --> reselect all A,B,C                              |
+| ++ctrl+"Click"++ + A --> ++"Click"++ + B --> ++ctrl+"Click"++ + B   | select A --> select B --> reselect all A,B,C                 |
+| ++shift+"Click"++ + A --> ++"Click"++ + B --> ++shift+"Click"++ + B | select A --> select B --> reselect the initally selected A,B |
 
-!!! note:
+!!!note
 This can also be used in the "Found in dictionaries" panel to temporarily focus on a single dictionary.

--- a/website/docs/ui_toolbar.md
+++ b/website/docs/ui_toolbar.md
@@ -32,9 +32,12 @@ Click the icons to select/unselect them.
 
 ### Solo Mode
 
-Focus on a single dictionary temporarily.
+In this mode, only a single dictionary can be selected.
 
-++ctrl+"Click"++ or ++strl+"Click"++ will select a single dictionary and enter solo mode, then only a single dictionary will be selected.
+Enter the mode:
+++ctrl+"Click"++ or ++shift+"Click"++.
+
+Exit the mode.
 
 ++ctrl+"Click"++ the selected dictionary will reselect all dictionaries.
 
@@ -42,12 +45,12 @@ Focus on a single dictionary temporarily.
 
 For example, there are 3 dictionaries A,B,C with A,B initially selected.
 
-| Clicking Sequence                                                  | Outcome                                |
-|--------------------------------------------------------------------|----------------------------------------|
-| ++ctrl+"Click"++ + A                                               | select A only                          |
-| ++ctrl+"Click"++ + A --> ++"Click"++ + B                           | select A --> select B                  |
-| ++ctrl+"Click"++ + A --> ++"Click"++ + A                           | select A --> reselect all A,B,C        |
-| ++ctrl+"Click"++ + A --> ++"Click"++ + B --> ++shift+"Click"++ + B | select A --> select B --> reselect A,B |
+| Clicking Sequence                                                  | Outcome                                      |
+|--------------------------------------------------------------------|----------------------------------------------|
+| ++ctrl+"Click"++ + A                                               | select A only                                |
+| ++ctrl+"Click"++ + A --> ++ctrl+"Click"++ + A                      | select A --> reselect all A,B,C              |
+| ++ctrl+"Click"++ + A --> ++"Click"++ + B --> ++ctrl+"Click"++ + B  | select A --> select B --> reselect all A,B,C |
+| ++ctrl+"Click"++ + A --> ++"Click"++ + B --> ++shift+"Click"++ + B | select A --> select B --> reselect A,B       |
 
 Note: This can also be used in the "Found in dictionaries" panel.
 

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -22,12 +22,13 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.superfences
   - pymdownx.keys
+  - pymdownx.smartsymbols
 
 nav:
   - Getting started: index.md
   - Download & Install: install.md
   - Dictionary Formats: dictformats.md
-  - Manage Dictionaries: 
+  - Manage Dictionaries:
       - Sources: manage_sources.md
       - Groups: manage_groups.md
   - Interface:


### PR DESCRIPTION
## Explanation
### When Not in the Mode

Ctrl/Shift+Click a dict -> Enter Mode; Select one and only one dict.

### When in the Mode

Normal Click -> Change the one and only selection to another.

Ctrl/Shift+Click the not selected one -> identical to Normal Click (Undocumented, if user noticed then they noticed, if not, doesn't matter.).

Ctrl/Shift+Click the selected one -> Exit the mode, restore selection based on Ctrl/Shift


## Compared to https://github.com/xiaoyifang/goldendict-ng/pull/2259

- This is no need for indicator because user may clicking around and notice that only a single one is selectable without the risk of losing previously selected. 
- The thing can be explained by 1 sentence because there is no functionality overloading and there is real change when in this mode. 

fix #2213 
 