### PR TITLE
Fixes issue #2272, minor changes fixing compilation against Qt 6.9.0

### DIFF
--- a/src/audio/audiooutput.cc
+++ b/src/audio/audiooutput.cc
@@ -9,6 +9,9 @@
 #include <QtGlobal>
 #include <QBuffer>
 
+// fixes #2272 issue's error on use of qWarning for compiling against qt 6.9.0
+#include <QDebug>
+
 // take reference from this file (https://github.com/valbok/QtAVPlayer/blob/6cc30e484b354d59511c9a60fabced4cb7c57c8e/src/QtAVPlayer/qavaudiooutput.cpp)
 // and make some changes.
 

--- a/src/dict/dictserver.cc
+++ b/src/dict/dictserver.cc
@@ -956,5 +956,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries( Config::DictServers const 
 
   return result;
 }
-#include "dictserver.moc"
+
 } // namespace DictServer
+
+// fixes #2272
+// automoc include for Q_OBJECT should be at the very end of source code file, not inside a namespace
+#include "dictserver.moc"

--- a/src/dict/forvo.cc
+++ b/src/dict/forvo.cc
@@ -389,5 +389,8 @@ makeDictionaries( Dictionary::Initializing &, Config::Forvo const & forvo, QNetw
   return result;
 }
 
-#include "forvo.moc"
 } // namespace Forvo
+
+// fixes #2272
+// automoc include for Q_OBJECT should be at the very end of source code file, not inside a namespace
+#include "forvo.moc"

--- a/src/dict/lingualibre.cc
+++ b/src/dict/lingualibre.cc
@@ -382,5 +382,8 @@ void LinguaArticleRequest::requestFinished( QNetworkReply * r )
   }
 }
 
-#include "lingualibre.moc"
 } // end namespace Lingua
+
+// fixes #2272
+// automoc include for Q_OBJECT should be at the very end of source code file, not inside a namespace
+#include "lingualibre.moc"

--- a/src/dict/mediawiki.cc
+++ b/src/dict/mediawiki.cc
@@ -746,5 +746,8 @@ makeDictionaries( Dictionary::Initializing &, Config::MediaWikis const & wikis, 
   return result;
 }
 
-#include "mediawiki.moc"
 } // namespace MediaWiki
+
+// fixes #2272
+// automoc include for Q_OBJECT should be at the very end of source code file, not inside a namespace
+#include "mediawiki.moc"

--- a/src/dict/website.cc
+++ b/src/dict/website.cc
@@ -489,5 +489,8 @@ vector< sptr< Dictionary::Class > > makeDictionaries( Config::WebSites const & w
   return result;
 }
 
-#include "website.moc"
 } // namespace WebSite
+
+// fixes #2272
+// automoc include for Q_OBJECT should be at the very end of source code file, not inside a namespace
+#include "website.moc"


### PR DESCRIPTION
Details of the errors encountered are listed in [the issue](https://github.com/xiaoyifang/goldendict-ng/issues/2272) mentioned in PR's title.

This just adds an include of QDebug to one file, and moves the includes of AUTOMOC generated headers to the very last line of five files that contain such includes.