### PR TITLE
feat: split Single/Solo Selection Mode to 2 composable features

### DIFF
--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -686,6 +686,10 @@ between classic and school orthography in cyrillic)</source>
         <source>Open dictionary folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Restore selection</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>EditDictionaries</name>

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -260,7 +260,7 @@ void DictionaryBar::actionWasTriggered( QAction * action )
   //  Ctrl Click Single Selection
   if ( QApplication::keyboardModifiers().testFlag( Qt::ControlModifier ) ) {
     // Ctrl+Clicked the only one selected
-    if ( (dictActions.size() - mutedDictionaries->size()) == 1 && !action->isChecked() ) {
+    if ( ( dictActions.size() - mutedDictionaries->size() ) == 1 && !action->isChecked() ) {
       mutedDictionaries->clear();
     }
     else {

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -111,7 +111,7 @@ void DictionaryBar::showContextMenu( QContextMenuEvent * event, bool extended )
   QMenu menu( this );
 
   const QAction * restoreSelectionAction = nullptr;
-  if ( !tempSelectionCapturedMuted->isEmpty() ) {
+  if ( tempSelectionCapturedMuted.has_value() ) {
     restoreSelectionAction = menu.addAction( tr( "Restore selection" ) );
   }
 

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -208,7 +208,7 @@ void DictionaryBar::showContextMenu( QContextMenuEvent * event, bool extended )
 
   if ( result && result == restoreSelectionAction ) {
     *mutedDictionaries = tempSelectionCapturedMuted.value();
-    tempSelectionCapturedMuted->clear();
+    tempSelectionCapturedMuted.reset();
     configEvents.signalMutedDictionariesChanged();
   }
 

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -110,12 +110,20 @@ void DictionaryBar::showContextMenu( QContextMenuEvent * event, bool extended )
 {
   QMenu menu( this );
 
+  const QAction * restoreSelectionAction = nullptr;
+  if ( !tempSelectionCapturedMuted->isEmpty() ) {
+    restoreSelectionAction = menu.addAction( tr( "Restore selection" ) );
+  }
+
   const QAction * editAction = menu.addAction( QIcon( ":/icons/bookcase.svg" ), tr( "Edit this group" ) );
 
   const QAction * infoAction           = nullptr;
   const QAction * headwordsAction      = nullptr;
   const QAction * openDictFolderAction = nullptr;
+
+
   QString dictFilename;
+
 
   const QAction * dictAction = actionAt( event->x(), event->y() );
   if ( dictAction ) {
@@ -198,6 +206,12 @@ void DictionaryBar::showContextMenu( QContextMenuEvent * event, bool extended )
     showContextMenu( event, true );
   }
 
+  if ( result && result == restoreSelectionAction ) {
+    *mutedDictionaries = tempSelectionCapturedMuted.value();
+    tempSelectionCapturedMuted->clear();
+    configEvents.signalMutedDictionariesChanged();
+  }
+
   if ( result == editAction ) {
     emit editGroupRequested();
   }
@@ -243,41 +257,27 @@ void DictionaryBar::actionWasTriggered( QAction * action )
     return; // Some weird action, not our button
   }
 
-  /// Single Selection Mode
-  /// Click         (in mode)
-  /// singleSelect -> has value  -> dict was selected: reselect depends on Ctrl/Shift, discard memorized selection
-  ///                           -> dict was not selected: select a single one
-  ///              -> no value  -> has modifier: select a single dict + memorize
-  ///            (not in mode)  -> no modifier: normal
-  ///
-
-  if ( singleSelectionInitallyMuted.has_value() ) { // (in mode)
-    if ( !mutedDictionaries->contains( id ) ) {     // dict was selected
-      if ( Qt::ControlModifier & QApplication::keyboardModifiers() ) {
-        mutedDictionaries->clear();
-        singleSelectionInitallyMuted.reset();
-      }
-      else if ( Qt::ShiftModifier & QApplication::keyboardModifiers() ) {
-        *mutedDictionaries = singleSelectionInitallyMuted.value();
-        singleSelectionInitallyMuted.reset();
-      }
+  //  Ctrl Click Single Selection
+  if ( QApplication::keyboardModifiers().testFlag( Qt::ControlModifier ) ) {
+    // Ctrl+Clicked the only one selected
+    if ( (dictActions.size() - mutedDictionaries->size()) == 1 && !action->isChecked() ) {
+      mutedDictionaries->clear();
     }
-    else { // dict was not selected
+    else {
       selectSingleDict( id );
     }
   }
-  else {
-    if ( ( Qt::ControlModifier | Qt::ShiftModifier ) & QApplication::keyboardModifiers() ) {
-      singleSelectionInitallyMuted.emplace( *mutedDictionaries );
-      selectSingleDict( id );
+  ///  Shift Click Capturing
+  else if ( QApplication::keyboardModifiers().testFlag( Qt::ShiftModifier ) ) {
+    tempSelectionCapturedMuted.emplace( *mutedDictionaries );
+    selectSingleDict( id ); // Give user feedback that capturing success by select the one clicked
+  }
+  else { // Normal clicking
+    if ( action->isChecked() ) {
+      mutedDictionaries->remove( id );
     }
-    else { // Normal
-      if ( action->isChecked() ) {
-        mutedDictionaries->remove( id );
-      }
-      else {
-        mutedDictionaries->insert( id );
-      }
+    else {
+      mutedDictionaries->insert( id );
     }
   }
   configEvents.signalMutedDictionariesChanged();

--- a/src/ui/dictionarybar.hh
+++ b/src/ui/dictionarybar.hh
@@ -60,9 +60,12 @@ signals:
 private:
 
   Config::MutedDictionaries * mutedDictionaries;
+
+  // In temporary selection, shift+click capture selections.
+  std::optional< Config::MutedDictionaries > tempSelectionCapturedMuted;
+
   Config::Events & configEvents;
 
-  std::optional< Config::MutedDictionaries > singleSelectionInitallyMuted;
   void selectSingleDict( const QString & id );
 
   // how many dictionaries should be shown in the context menu:

--- a/website/docs/ui_toolbar.md
+++ b/website/docs/ui_toolbar.md
@@ -34,8 +34,7 @@ Click the icons to select/unselect them.
 
 ++ctrl+"Click"++ will focus on a single dictionary.
 
-If a dictionary is the only one selected, clicking it with ++ctrl++ will reselected all dictionaries.
-
+If a dictionary is the only one selected, clicking it with ++ctrl++ will reselect all dictionaries.
 ### Temporary Selection
 
 Temporarily capture the selection and restore it later.

--- a/website/docs/ui_toolbar.md
+++ b/website/docs/ui_toolbar.md
@@ -40,8 +40,8 @@ If a dictionary is the only one selected, clicking it with ++ctrl++ will reselec
 
 Temporarily capture the selection and restore it later.
 
-- Capture Selection <-- ++shift+"Click"++
-- Restore Selection <-- Click the "Restore selection" in the context menu
+- Capture Selection <-- ++shift+"Click"++ any dictionary icons.
+- Restore Selection <-- Click the "Restore selection" in the right click context menu
 
 !!! note
     "Found in dictionaries" panel can also uses above two special operations.

--- a/website/docs/ui_toolbar.md
+++ b/website/docs/ui_toolbar.md
@@ -30,28 +30,18 @@ The dictionary bar shows dictionaries from the current group.
 
 Click the icons to select/unselect them.
 
-### Single Selection Mode (was Solo Mode)
+### Single Selection
 
-When this mode is active, only one single dictionary can be selected at a time.
+++ctrl+"Click"++ will focus on a single dictionary.
 
-There are two ways to use this feature:
+If a dictionary is the only one selected, clicking it with ++ctrl++ will reselected all dictionaries.
 
-- ++shift+"Click"++ a dictionary icon to enter the mode
-- ++shift+"Click"++ the selected dictionary to reselect dictioanries selected before entering the mode.
+### Temporary Selection
 
-and
+Temporarily capture the selection and restore it later.
 
-- ++ctrl+"Click"++ a dictionary icon to enter the mode
-- ++ctrl+"Click"++ the selected dictionary to reselect all dictionaries
-
-For example, there are 3 dictionaries A,B,C with A,B initially selected.
-
-| Clicking Sequence                                                   | Outcome                                                      |
-|---------------------------------------------------------------------|--------------------------------------------------------------|
-| ++ctrl+"Click"++ + A                                                | select A only                                                |
-| ++ctrl+"Click"++ + A --> ++ctrl+"Click"++ + A                       | select A --> reselect all A,B,C                              |
-| ++ctrl+"Click"++ + A --> ++"Click"++ + B --> ++ctrl+"Click"++ + B   | select A --> select B --> reselect all A,B,C                 |
-| ++shift+"Click"++ + A --> ++"Click"++ + B --> ++shift+"Click"++ + B | select A --> select B --> reselect the initally selected A,B |
+- Capture Selection <-- ++shift+"Click"++
+- Restore Selection <-- Click the "Restore selection" in the context menu
 
 !!! note
-    This can also be used in the "Found in dictionaries" panel to temporarily focus on a single dictionary.
+    "Found in dictionaries" panel can also uses above two special operations.


### PR DESCRIPTION
https://github.com/xiaoyifang/goldendict-ng/issues/2213

Major Difference: No "Mode" anymore.

### Ctrl+Click Focus Selection

Select a single dict.

If a dict is selected and is the only one left, then reselect all.

This retains all the previous features except restoration.

### Temporary Selection mode.

Shift+Click -> Capture the current selection, and add a right click menu item "restore selection".

This is better than all previous designs because 
1. there is no mode anymore.
2. capturing could happen in anytime a user want to
3. restoration will never will be lost unless capturing again or after restoration

### Overall

The composition of those two features covers all previously mentioned needs.

Doc is much simpler, there is no need for a cases table anymore.

### Potential flaw/feature

+ Restore now needs two click (Not a flaw, because modifier + clicking requires a "mode" to know when to restore, now restore is restore.)
+ Shift+Click Capture will select single one. Accidently double shift-click is possible. (Not a flaw, because not giving feedback for user interaction is sinful. Selecting the one that's got shift+clicked is a good feedback. Also, selecting a single one is a good starting point of temporary selection.)
+ Restoration also clears previous selection but doesn't have to. Personal preference, I don't like a temporary menu sticking around.

