### PR TITLE
opt:remove deprecated window.event variable

### DIFF
--- a/src/scripts/gd-builtin.js
+++ b/src/scripts/gd-builtin.js
@@ -88,35 +88,51 @@ function emitClickedEvent(link) {
 
 function gdExpandArticle(id) {
   emitClickedEvent();
-  elem = document.getElementById("gdarticlefrom-" + id);
-  ico = document.getElementById("expandicon-" + id);
-  art = document.getElementById("gdfrom-" + id);
-  if (elem.style.display == "inline") {
-    elem.style.display = "none";
-    ico.className = "gdexpandicon";
-    art.className = art.className + " gdcollapsedarticle";
-    nm = document.getElementById("gddictname-" + id);
-    nm.style.cursor = "pointer";
-    nm.title = "";
+
+  const articleContent = document.getElementById("gdarticlefrom-" + id);
+  const expandIcon = document.getElementById("expandicon-" + id);
+  const articleElement = document.getElementById("gdfrom-" + id);
+  const dictNameElement = document.getElementById("gddictname-" + id);
+
+  if (!articleContent || !expandIcon || !articleElement || !dictNameElement) {
+    console.warn("One or more required elements not found for id:", id);
+    return;
+  }
+
+  const isExpanded = articleContent.style.display === "inline";
+
+  if (isExpanded) {
+    articleContent.style.display = "none";
+    expandIcon.className = "gdexpandicon";
+    articleElement.classList.add("gdcollapsedarticle");
+
+    dictNameElement.style.cursor = "pointer";
+    dictNameElement.title = "";
+
     articleview.collapseInHtml(id, true);
-  } else if (elem.style.display == "none") {
-    elem.style.display = "inline";
-    ico.className = "gdcollapseicon";
-    art.className = art.className.replace(" gdcollapsedarticle", "");
-    nm = document.getElementById("gddictname-" + id);
-    nm.style.cursor = "default";
-    nm.title = "";
+  } else {
+    articleContent.style.display = "inline";
+    expandIcon.className = "gdcollapseicon";
+    articleElement.classList.remove("gdcollapsedarticle");
+
+    dictNameElement.style.cursor = "default";
+    dictNameElement.title = "";
+
     articleview.collapseInHtml(id, false);
   }
 }
 
 function gdCheckArticlesNumber() {
-  elems = document.getElementsByClassName("gddictname");
-  if (elems.length == 1) {
-    el = elems.item(0);
-    s = el.id.replace("gddictname-", "");
-    el = document.getElementById("gdfrom-" + s);
-    if (el && el.className.search("gdcollapsedarticle") > 0) gdExpandArticle(s);
+  const dictNameElements = document.getElementsByClassName("gddictname");
+
+  if (dictNameElements.length === 1) {
+    const dictNameElement = dictNameElements[0];
+    const articleId = dictNameElement.id.replace("gddictname-", "");
+    const articleElement = document.getElementById("gdfrom-" + articleId);
+
+    if (articleElement && articleElement.className.includes("gdcollapsedarticle")) {
+      gdExpandArticle(articleId);
+    }
   }
 }
 

--- a/src/scripts/gd-builtin.js
+++ b/src/scripts/gd-builtin.js
@@ -130,7 +130,10 @@ function gdCheckArticlesNumber() {
     const articleId = dictNameElement.id.replace("gddictname-", "");
     const articleElement = document.getElementById("gdfrom-" + articleId);
 
-    if (articleElement && articleElement.className.includes("gdcollapsedarticle")) {
+    if (
+      articleElement &&
+      articleElement.className.includes("gdcollapsedarticle")
+    ) {
       gdExpandArticle(articleId);
     }
   }

--- a/src/scripts/gd-builtin.js
+++ b/src/scripts/gd-builtin.js
@@ -91,16 +91,12 @@ function gdExpandArticle(id) {
   elem = document.getElementById("gdarticlefrom-" + id);
   ico = document.getElementById("expandicon-" + id);
   art = document.getElementById("gdfrom-" + id);
-  ev = window.event;
-  t = null;
-  if (ev) t = ev.target || ev.srcElement;
   if (elem.style.display == "inline") {
     elem.style.display = "none";
     ico.className = "gdexpandicon";
     art.className = art.className + " gdcollapsedarticle";
     nm = document.getElementById("gddictname-" + id);
     nm.style.cursor = "pointer";
-    if (ev) ev.stopPropagation();
     nm.title = "";
     articleview.collapseInHtml(id, true);
   } else if (elem.style.display == "none") {
@@ -145,6 +141,8 @@ function gdAttachEventHandlers() {
         ?.getAttribute("data-gd-id");
 
       gdExpandArticle(articleId);
+
+      event.stopPropagation();
     }
   });
 


### PR DESCRIPTION
https://developer.mozilla.org/zh-CN/docs/Web/API/Window/event

 [use const variable instead](https://github.com/xiaoyifang/goldendict-ng/pull/2312/commits/e91fb27854022c1eda04089b6d20cbffba5754f2)