### PR TITLE
opt:protect vector variable in wordfinder with copy-on-read

### DIFF
--- a/src/wordfinder.cc
+++ b/src/wordfinder.cc
@@ -172,7 +172,6 @@ void WordFinder::requestFinished()
   if ( !searchInProgress.load() ) {
     return;
   }
-  QMutexLocker locker( &mutex );
   // See how many new requests have finished, and if we have any new results
   // Create a snapshot of queuedRequests to avoid iterator invalidation
   auto snapshot = queuedRequests.snapshot();

--- a/src/wordfinder.cc
+++ b/src/wordfinder.cc
@@ -111,7 +111,7 @@ void WordFinder::startSearch()
   updateResultsTimer.start();
 
   // Gather all writings of the word
-  std::vector< std::u32string > allWordWritings; 
+  std::vector< std::u32string > allWordWritings;
   allWordWritings.resize( 1 );
 
   allWordWritings[ 0 ] = inputWord.toStdU32String();

--- a/src/wordfinder.cc
+++ b/src/wordfinder.cc
@@ -111,10 +111,7 @@ void WordFinder::startSearch()
   updateResultsTimer.start();
 
   // Gather all writings of the word
-  std::vector< std::u32string > allWordWritings;
-  allWordWritings.resize( 1 );
-
-  allWordWritings[ 0 ] = inputWord.toStdU32String();
+  std::vector< std::u32string > allWordWritings( 1, inputWord.toStdU32String() );
 
   for ( const auto & inputDict : *inputDicts ) {
     vector< std::u32string > writings = inputDict->getAlternateWritings( allWordWritings[ 0 ] );

--- a/src/wordfinder.cc
+++ b/src/wordfinder.cc
@@ -111,10 +111,8 @@ void WordFinder::startSearch()
   updateResultsTimer.start();
 
   // Gather all writings of the word
-
-  if ( allWordWritings.size() != 1 ) {
-    allWordWritings.resize( 1 );
-  }
+  std::vector< std::u32string > allWordWritings; 
+  allWordWritings.resize( 1 );
 
   allWordWritings[ 0 ] = inputWord.toStdU32String();
 
@@ -124,6 +122,7 @@ void WordFinder::startSearch()
     allWordWritings.insert( allWordWritings.end(), writings.begin(), writings.end() );
   }
 
+  setAllWordWritings( allWordWritings );
   // Query each dictionary for all word writings
 
   for ( const auto & inputDict : *inputDicts ) {
@@ -254,6 +253,8 @@ void WordFinder::updateResults()
   if ( updateResultsTimer.isActive() ) {
     updateResultsTimer.stop(); // Can happen when we were done before it'd expire
   }
+
+  auto allWordWritings = allWordWritings();
 
   std::u32string original = Folding::applySimpleCaseOnly( allWordWritings[ 0 ] );
 

--- a/src/wordfinder.cc
+++ b/src/wordfinder.cc
@@ -251,7 +251,7 @@ void WordFinder::updateResults()
     updateResultsTimer.stop(); // Can happen when we were done before it'd expire
   }
 
-  auto allWordWritings = allWordWritings();
+  auto allWordWritings = getAllWordWritings();
 
   std::u32string original = Folding::applySimpleCaseOnly( allWordWritings[ 0 ] );
 

--- a/src/wordfinder.hh
+++ b/src/wordfinder.hh
@@ -67,7 +67,7 @@ private:
   ResultsIndex resultsIndex;
 
   /// Mutex to protect the vector of allWordWritings
-  std::vector< std::u32string > allWordWritings()
+  std::vector< std::u32string > getAllWordWritings()
   {
     QMutexLocker locker( &mutex );
     return _allWordWritings;

--- a/src/wordfinder.hh
+++ b/src/wordfinder.hh
@@ -50,7 +50,7 @@ private:
 
   std::vector< sptr< Dictionary::Class > > const * inputDicts;
 
-  std::vector< std::u32string > allWordWritings; // All writings of the inputWord
+  std::vector< std::u32string > _allWordWritings; // All writings of the inputWord
 
   struct OneResult
   {
@@ -65,6 +65,19 @@ private:
   using ResultsIndex = std::map< std::u32string, ResultsArray::iterator >;
   ResultsArray resultsArray;
   ResultsIndex resultsIndex;
+
+  /// Mutex to protect the vector of allWordWritings
+  std::vector< std::u32string > allWordWritings()
+  {
+    QMutexLocker locker( &mutex );
+    return _allWordWritings;
+  }
+
+  void setAllWordWritings( std::vector< std::u32string > writings )
+  {
+    QMutexLocker locker( &mutex );
+    _allWordWritings = std::move( writings );
+  }
 
 public:
 


### PR DESCRIPTION
`allWordWritings` is accessed by multi-threads ,and it has no protection against race contention.

using Copy-On-Read strategy to protect the variable by private method(which has mutex guard).  method `updateResult`&`startSearch` will only use its copy.


maybe has some connection with https://github.com/xiaoyifang/goldendict-ng/issues/2113 .

