### PR TITLE
opt:remove the not used parameter

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -170,11 +170,6 @@ void processCommandLine( QCoreApplication * app, GDOptions * result )
   qcmd.addOption( notts );
   qcmd.addOption( resetState );
   qcmd.addOption( printVersion );
-
-  QCommandLineOption doNothingOption( "disable-web-security" ); // ignore the --disable-web-security
-  doNothingOption.setFlags( QCommandLineOption::HiddenFromHelp );
-  qcmd.addOption( doNothingOption );
-
   qcmd.process( *app );
 
   if ( qcmd.isSet( logFileOption ) ) {


### PR DESCRIPTION
`disable-web-security`  should have not taken effect for a while .

can be removed.
