### PR TITLE
 Update main.cc to ensure correctly setting Wayland app_id

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -276,8 +276,9 @@ int main( int argc, char ** argv )
 
   QHotkeyApplication app( "GoldenDict-ng", argc, argv );
 
+  app.setDesktopFileName( "io.github.xiaoyifang.goldendict_ng" );
   QHotkeyApplication::setApplicationName( "GoldenDict-ng" );
-  QHotkeyApplication::setOrganizationDomain( "https://github.com/xiaoyifang/goldendict-ng" );
+  QHotkeyApplication::setOrganizationDomain( "xiaoyifang.github.io" );
 #ifndef Q_OS_MACOS
   // macOS icon is defined in Info.plist
   QHotkeyApplication::setWindowIcon( QIcon( ":/icons/programicon.png" ) );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -3079,7 +3079,7 @@ void MainWindow::trayIconActivated( QSystemTrayIcon::ActivationReason r )
 
 void MainWindow::visitHomepage()
 {
-  QDesktopServices::openUrl( QUrl( "https://github.com/xiaoyifang/goldendict-ng" ) );
+  QDesktopServices::openUrl( QUrl( "https://xiaoyifang.github.io/goldendict-ng/" ) );
 }
 
 void MainWindow::openConfigFolder()

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -3079,7 +3079,7 @@ void MainWindow::trayIconActivated( QSystemTrayIcon::ActivationReason r )
 
 void MainWindow::visitHomepage()
 {
-  QDesktopServices::openUrl( QUrl( QApplication::organizationDomain() ) );
+  QDesktopServices::openUrl( QUrl( "https://github.com/xiaoyifang/goldendict-ng" ) );
 }
 
 void MainWindow::openConfigFolder()


### PR DESCRIPTION
This is a small PR.

It does two things which mainly concern correctness on Linux Wayland platform:

1. It calls `setDesktopFileName` (available since Qt 5.7) so that app_id under Wayland is set to a value which allows compositors and other applications to find the `.desktop` file supplied and through that the correct application icon.
2. It corrects the argument to `setOrganizationDomain` to a value which is conceptually sound (the actual domain name, distinct from a URL) and does not get mangled on processing due to containing backslashes.