### PR TITLE
delete FFmpeg version < 7 conditionally compiled code

### DIFF
--- a/.github/workflows/PR-check-cmake.yml
+++ b/.github/workflows/PR-check-cmake.yml
@@ -39,9 +39,11 @@ jobs:
           submodules: false
       - name: Run build
         run: |
+          export CXXFLAGS="-Wall"
           mkdir build_dir
           cmake -S . \
             -B ./build_dir \
+            -DCMAKE_COMPILE_WARNING_AS_ERROR=ON \
             -G Ninja
           cmake --build ./build_dir
   job_macos_build_check:

--- a/src/audio/ffmpegaudio.cc
+++ b/src/audio/ffmpegaudio.cc
@@ -191,7 +191,6 @@ bool DecoderContext::openCodec( QString & errorString )
   }
 
 
-
   if ( !swr_ || swr_init( swr_ ) < 0 ) {
     av_log( nullptr, AV_LOG_ERROR, "Cannot create sample rate converter \n" );
     swr_free( &swr_ );

--- a/src/audio/ffmpegaudio.cc
+++ b/src/audio/ffmpegaudio.cc
@@ -167,8 +167,6 @@ bool DecoderContext::openCodec( QString & errorString )
     return false;
   }
 
-  // 61 = FFmpeg 7.0 -> https://github.com/FFmpeg/FFmpeg/blob/release/7.0/libavcodec/version_major.h
-  #if LIBAVCODEC_VERSION_MAJOR >= 61
   qDebug( "Codec open: %s: channels: %d, rate: %d, format: %s",
           codec_->long_name,
           codecContext_->ch_layout.nb_channels,
@@ -191,29 +189,7 @@ bool DecoderContext::openCodec( QString & errorString )
        != 0 ) {
     qDebug() << "swr_alloc_set_opts2 failed.";
   }
-  #else
-  qDebug( "Codec open: %s: channels: %d, rate: %d, format: %s",
-          codec_->long_name,
-          codecContext_->channels,
-          codecContext_->sample_rate,
-          av_get_sample_fmt_name( codecContext_->sample_fmt ) );
 
-  auto layout = codecContext_->channel_layout;
-  if ( !layout ) {
-    layout                        = av_get_default_channel_layout( codecContext_->channels );
-    codecContext_->channel_layout = layout;
-  }
-
-  swr_ = swr_alloc_set_opts( nullptr,
-                             layout,
-                             AV_SAMPLE_FMT_S16,
-                             44100,
-                             layout,
-                             codecContext_->sample_fmt,
-                             codecContext_->sample_rate,
-                             0,
-                             nullptr );
-  #endif
 
 
   if ( !swr_ || swr_init( swr_ ) < 0 ) {
@@ -279,11 +255,7 @@ bool DecoderContext::openOutputDevice( QString & errorString )
     errorString += QStringLiteral( "Failed to create audioOutput." );
     return false;
   }
-  #if LIBAVCODEC_VERSION_MAJOR >= 61
   audioOutput->setAudioFormat( 44100, codecContext_->ch_layout.nb_channels );
-  #else
-  audioOutput->setAudioFormat( 44100, codecContext_->channels );
-  #endif
   return true;
 }
 
@@ -346,11 +318,7 @@ bool DecoderContext::normalizeAudio( AVFrame * frame, vector< uint8_t > & sample
 {
   auto dst_freq = 44100;
 
-  #if LIBAVCODEC_VERSION_MAJOR >= 61
   auto dst_channels = codecContext_->ch_layout.nb_channels;
-  #else
-  auto dst_channels = codecContext_->channels;
-  #endif
 
   int out_count = (int64_t)frame->nb_samples * dst_freq / frame->sample_rate + 256;
   int out_size  = av_samples_get_buffer_size( nullptr, dst_channels, out_count, AV_SAMPLE_FMT_S16, 1 );


### PR DESCRIPTION
Those code works since at least FFmpeg 5 (I tested with FFmpeg@5 from homebrew. They may work even earlier, but we don't care).

There will be no warnings in Ubuntu build now. Enable warnings_as_error for it too.