### PR TITLE
fix: ffmpeg backend crash when clicking play audio too fast

### DIFF
--- a/src/audio/audiooutput.cc
+++ b/src/audio/audiooutput.cc
@@ -111,7 +111,8 @@ public:
     if ( !audioOutput || ( fmt.isValid() && audioOutput->format() != fmt )
          || audioOutput->state() == QAudio::StoppedState ) {
       if ( audioOutput ) {
-        audioOutput->deleteLater();
+        delete audioOutput;
+        audioOutput = nullptr;
       }
       audioOutput = new AudioOutput( fmt );
       QObject::connect( audioOutput, &AudioOutput::stateChanged, audioOutput, [ & ]( QAudio::State state ) {
@@ -151,7 +152,7 @@ public:
     }
     if ( audioOutput ) {
       audioOutput->stop();
-      audioOutput->deleteLater();
+      delete audioOutput;
     }
     audioOutput = nullptr;
   }

--- a/src/audio/ffmpegaudio.cc
+++ b/src/audio/ffmpegaudio.cc
@@ -308,7 +308,7 @@ void DecoderContext::stop()
 {
   if ( audioOutput ) {
     audioOutput->stop();
-    audioOutput->deleteLater();
+    delete audioOutput;
     audioOutput = nullptr;
   }
 }


### PR DESCRIPTION
Fix this crash with no obvious back trace. No idea exactly what's wrong.

To reproduce: clicking insanely fast.

<img width="1177" alt="a" src="https://github.com/user-attachments/assets/003c3cee-6403-4445-80f4-624460617b41" />

Combination is Qt6.9.1 + FFmpeg@5 + M1 macOS.

---

Random thought:

We rarely need `deleteLater()` because most of the objects are small and deleting is cheap. Keeping objects slightly longer only causes problems.

---

https://doc.qt.io/qt-6/qobject.html#dtor.QObject

> Deleting a [QObject](https://doc.qt.io/qt-6/qobject.html) while it is handling an event delivered to it can cause a crash. You must not delete the [QObject](https://doc.qt.io/qt-6/qobject.html) directly if it exists in a different thread than the one currently executing. Use [deleteLater](https://doc.qt.io/qt-6/qobject.html#deleteLater)() instead, which will cause the event loop to delete the object after all pending events have been delivered to it.


