### PR TITLE
remove useless complexity from FFmpeg -> AudioOutput

### DIFF
--- a/src/audio/ffmpeg_audiooutput.cc
+++ b/src/audio/ffmpeg_audiooutput.cc
@@ -192,8 +192,8 @@ bool AudioOutput::play( const uint8_t * data, qint64 len )
   }
 
   QMutexLocker locker( &d_ptr->mutex );
-  auto *cuint = const_cast< uint8_t * >( data );
-  auto *cptr  = reinterpret_cast< char * >( cuint );
+  auto * cuint = const_cast< uint8_t * >( data );
+  auto * cptr  = reinterpret_cast< char * >( cuint );
   d_ptr->buffer.append( cptr, len );
   d_ptr->cond.wakeAll();
 

--- a/src/audio/ffmpeg_audiooutput.hh
+++ b/src/audio/ffmpeg_audiooutput.hh
@@ -14,10 +14,9 @@ public:
   void setAudioFormat( int sampleRate, int channels );
   void stop();
 
-protected:
+private:
   QScopedPointer< AudioOutputPrivate > d_ptr;
 
-private:
   Q_DISABLE_COPY( AudioOutput )
   Q_DECLARE_PRIVATE( AudioOutput )
 };

--- a/src/audio/ffmpegaudio.cc
+++ b/src/audio/ffmpegaudio.cc
@@ -1,6 +1,5 @@
 #ifdef MAKE_FFMPEG_PLAYER
 
-  #include "audiooutput.hh"
   #include "ffmpegaudio.hh"
   #include "utils.hh"
   #include <QAudioDevice>
@@ -9,8 +8,6 @@
   #include <QString>
   #include <errno.h>
   #include <vector>
-
-using std::vector;
 
 namespace Ffmpeg {
 

--- a/src/audio/ffmpegaudio.hh
+++ b/src/audio/ffmpegaudio.hh
@@ -6,9 +6,9 @@ extern "C" {
   #include <libavcodec/avcodec.h>
   #include <libavformat/avformat.h>
   #include <libavutil/avutil.h>
-  #include "libswresample/swresample.h"
+  #include <libswresample/swresample.h>
 }
-  #include "audiooutput.hh"
+  #include "ffmpeg_audiooutput.hh"
   #include <QObject>
   #include <QMutex>
   #include <QByteArray>
@@ -19,8 +19,8 @@ extern "C" {
   #include <QString>
   #include <vector>
 
-using std::vector;
 namespace Ffmpeg {
+using std::vector;
 class DecoderThread;
 class AudioService: public QObject
 {


### PR DESCRIPTION
1. remove `Q_D` macro, which is completely useless for end-user application developers.
2. remove insane naming of AudioOuptout inside AudioOutputPrivate inside AudioOutput
3. merge duplicated stop()
4. minor style fixes