### PR TITLE
reorder and document hotkeywrapper

### DIFF
--- a/cmake/Deps_Linux.cmake
+++ b/cmake/Deps_Linux.cmake
@@ -14,7 +14,7 @@ if (WITH_FFMPEG_PLAYER)
     list(APPEND Optional_Pkgs "libavcodec;libavformat;libavutil;libswresample")
 endif ()
 
-set(X11_Pkgs "x11;xtst") # TODO: maybe xtst only is enough.
+set(X11_Pkgs "x11;xtst")
 target_compile_definitions(${GOLDENDICT} PUBLIC HAVE_X11)
 
 pkg_check_modules(DEPS REQUIRED IMPORTED_TARGET

--- a/src/hotkeywrapper.cc
+++ b/src/hotkeywrapper.cc
@@ -1,3 +1,5 @@
+#include <QtSystemDetection>
+#ifndef Q_OS_MACOS
 #include "hotkeywrapper.hh"
 #include <QTimer>
 #include <QSessionManager>
@@ -7,21 +9,6 @@
   #include "windows/winhotkeyapplication.hh"
 #endif
 
-
-//////////////////////////////////////////////////////////////////////////
-
-HotkeyStruct::HotkeyStruct( quint32 key_, quint32 key2_, quint32 modifier_, int handle_, int id_ ):
-  key( key_ ),
-  key2( key2_ ),
-  modifier( modifier_ ),
-  handle( handle_ ),
-  id( id_ )
-{
-}
-
-//////////////////////////////////////////////////////////////////////////
-
-#if !defined( Q_OS_MAC )
 HotkeyWrapper::HotkeyWrapper( QObject * parent ):
   QThread( parent ),
   state2( false )

--- a/src/hotkeywrapper.cc
+++ b/src/hotkeywrapper.cc
@@ -1,13 +1,13 @@
 #include <QtSystemDetection>
 #ifndef Q_OS_MACOS
-#include "hotkeywrapper.hh"
-#include <QTimer>
-#include <QSessionManager>
-#include <QWidget>
-#ifdef Q_OS_WIN
-  #include <windows.h>
-  #include "windows/winhotkeyapplication.hh"
-#endif
+  #include "hotkeywrapper.hh"
+  #include <QTimer>
+  #include <QSessionManager>
+  #include <QWidget>
+  #ifdef Q_OS_WIN
+    #include <windows.h>
+    #include "windows/winhotkeyapplication.hh"
+  #endif
 
 HotkeyWrapper::HotkeyWrapper( QObject * parent ):
   QThread( parent ),

--- a/src/hotkeywrapper.cc
+++ b/src/hotkeywrapper.cc
@@ -1,4 +1,4 @@
-#include <QtSystemDetection>
+#include <QtGlobal>
 #ifndef Q_OS_MACOS
   #include "hotkeywrapper.hh"
   #include <QTimer>

--- a/src/hotkeywrapper.hh
+++ b/src/hotkeywrapper.hh
@@ -79,7 +79,7 @@ public:
 signals:
   void hotkeyActivated( int handle );
 
-/*
+  /*
  *
  * Every Below should NOT be accessed from outside.
  *
@@ -105,6 +105,7 @@ private slots:
 #endif
 
 #ifdef Q_OS_MAC
+
 private:
   void sendCmdC();
 

--- a/src/hotkeywrapper.hh
+++ b/src/hotkeywrapper.hh
@@ -37,7 +37,12 @@
 struct HotkeyStruct
 {
   HotkeyStruct() = default;
-  HotkeyStruct( quint32 key, quint32 key2, quint32 modifier, int handle, int id );
+  HotkeyStruct( quint32 key, quint32 key2, quint32 modifier, int handle, int id ):
+    key( key ),
+    key2( key2 ),
+    modifier( modifier ),
+    handle( handle ),
+    id( id ) {};
 
   quint32 key      = 0;
   quint32 key2     = 0;
@@ -45,12 +50,10 @@ struct HotkeyStruct
   int handle       = 0;
   int id           = 0;
 #ifdef Q_OS_MAC
-  EventHotKeyRef hkRef  = 0;
-  EventHotKeyRef hkRef2 = 0;
+  EventHotKeyRef hkRef  = nullptr;
+  EventHotKeyRef hkRef2 = nullptr;
 #endif
 };
-
-//////////////////////////////////////////////////////////////////////////
 
 class HotkeyWrapper: public QThread // Thread is actually only used on X11
 {
@@ -62,32 +65,30 @@ public:
 
   DEF_EX( exInit, "Hotkey wrapper failed to init", std::exception )
 
-  HotkeyWrapper( QObject * parent );
-  virtual ~HotkeyWrapper();
+  explicit HotkeyWrapper( QObject * parent );
 
-  /// The handle is passed back in hotkeyActivated() to inform which hotkey
-  /// was activated.
-  bool setGlobalKey( QKeySequence const &, int );
+  /// The handle will be passed back in hotkeyActivated() to inform which hotkey was activated.
+  /// 2 possible handles:
+  /// 0 -> Invoke main window
+  /// 1 -> translate clipboard
+  bool setGlobalKey( QKeySequence const &, int handle );
 
   /// Unregisters everything
   void unregister();
 
 signals:
+  void hotkeyActivated( int handle );
 
-  void hotkeyActivated( int );
+/*
+ *
+ * Every Below should NOT be accessed from outside.
+ *
+ */
 
 protected slots:
-
   void waitKey2();
 
-#ifndef Q_OS_MAC
-private slots:
-
-  bool checkState( quint32 vk, quint32 mod );
-#endif
-
 private:
-
   void init();
   quint32 nativeKey( int key );
 
@@ -99,19 +100,22 @@ private:
 #ifdef Q_OS_WIN32
   virtual bool winEvent( MSG * message, qintptr * result );
   HWND hwnd;
+private slots:
+  bool checkState( quint32 vk, quint32 mod );
 #endif
 
 #ifdef Q_OS_MAC
-
-public:
-  void activated( int hkId );
-
 private:
   void sendCmdC();
 
   static EventHandlerUPP hotKeyFunction;
   quint32 keyC;
   EventHandlerRef handlerRef;
+
+public:
+  void activated( int hkId );
+  ~HotkeyWrapper() override;
+
 #endif
 
 #ifdef HAVE_X11
@@ -158,5 +162,7 @@ signals:
   /// Emitted from the thread
   void keyRecorded( quint32 vk, quint32 mod );
 
+private slots:
+  bool checkState( quint32 vk, quint32 mod );
 #endif
 };

--- a/src/hotkeywrapper.hh
+++ b/src/hotkeywrapper.hh
@@ -66,6 +66,7 @@ public:
   DEF_EX( exInit, "Hotkey wrapper failed to init", std::exception )
 
   explicit HotkeyWrapper( QObject * parent );
+  ~HotkeyWrapper() override;
 
   /// The handle will be passed back in hotkeyActivated() to inform which hotkey was activated.
   /// 2 possible handles:
@@ -115,7 +116,6 @@ private:
 
 public:
   void activated( int hkId );
-  ~HotkeyWrapper() override;
 
 #endif
 


### PR DESCRIPTION
There are only 4 methods (Constructor, SetHotKey, UnRegister, Signal->Activated) that should be public.

Everything else is platform implementation details.

Reorder code so that things for each platform together can be found together.