### PR TITLE
fix: update mutedDictioanries for dictionaryBar first, or it will crash

### DIFF
--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -1090,7 +1090,7 @@ void ScanPopup::updateDictionaryBar()
 
   unsigned currentId           = groupList->getCurrentGroup();
   Instances::Group const * grp = groups.findGroup( currentId );
-  Q_ASSERT( grp!=nullptr ); // should never be nullptr, or the code in next few lines are invalid
+  Q_ASSERT( grp != nullptr ); // should never be nullptr, or the code in next few lines are invalid
 
   if ( currentId == GroupId::AllGroupId ) {
     dictionaryBar.setMutedDictionaries( &cfg.popupMutedDictionaries );

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -1090,10 +1090,7 @@ void ScanPopup::updateDictionaryBar()
 
   unsigned currentId           = groupList->getCurrentGroup();
   Instances::Group const * grp = groups.findGroup( currentId );
-
-  if ( grp ) { // Should always be !0, but check as a safeguard
-    dictionaryBar.setDictionaries( grp->dictionaries );
-  }
+  Q_ASSERT( grp!=nullptr ); // should never be nullptr, or the code in next few lines are invalid
 
   if ( currentId == GroupId::AllGroupId ) {
     dictionaryBar.setMutedDictionaries( &cfg.popupMutedDictionaries );
@@ -1102,6 +1099,8 @@ void ScanPopup::updateDictionaryBar()
     Config::Group * group = cfg.getGroup( currentId );
     dictionaryBar.setMutedDictionaries( group ? &group->popupMutedDictionaries : nullptr );
   }
+
+  dictionaryBar.setDictionaries( grp->dictionaries );
 
   setDictionaryIconSize();
 }


### PR DESCRIPTION
close: https://github.com/xiaoyifang/goldendict-ng/issues/2409

The `dictionaryBar.setDictionaries` internally uses `mutedDictionaries` which is a pointer.

There are many codes in `DictionaryBar.cc` checking null of `mutedDictionaries` but all of them are useless, because those pointers can totally point to invalid states.

For the record, I don't like the crash, this fix, the related code. None of them are reliable.


