### PR TITLE
ui: make info pane less weird by adjusting layout and buttons placement

### DIFF
--- a/src/ui/dictinfo.ui
+++ b/src/ui/dictinfo.ui
@@ -23,34 +23,107 @@
       <string/>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="3">
-       <widget class="QLabel" name="dictionaryTranslatesTo">
+      <item row="0" column="1">
+       <widget class="QLabel" name="dictionaryTotalArticles">
         <property name="text">
          <string notr="true"/>
         </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="enableFullindex">
-        <property name="text">
-         <string/>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
         </property>
        </widget>
       </item>
-      <item row="2" column="4">
-       <widget class="QPushButton" name="openIndexFolder">
-        <property name="text">
-         <string>Open index folder</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
+      <item row="2" column="1" colspan="3">
        <widget class="QLabel" name="dictionaryId">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string/>
         </property>
         <property name="textInteractionFlags">
          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="4">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Total words:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Total articles:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLabel" name="label_8">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Translates to:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Index filename:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="label_4">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Translates from:</string>
         </property>
        </widget>
       </item>
@@ -64,48 +137,16 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Total articles:</string>
+      <item row="3" column="0" colspan="2">
+       <widget class="QLabel" name="enableFullindex">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_3">
         <property name="text">
-         <string>Index filename:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Total words:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="4">
-       <widget class="QPushButton" name="openFolder">
-        <property name="text">
-         <string>Open folder</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLabel" name="dictionaryTotalArticles">
-        <property name="text">
-         <string notr="true"/>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Translates from:</string>
+         <string/>
         </property>
        </widget>
       </item>
@@ -116,10 +157,10 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
-       <widget class="QLabel" name="label_8">
+      <item row="1" column="3">
+       <widget class="QLabel" name="dictionaryTranslatesTo">
         <property name="text">
-         <string>Translates to:</string>
+         <string notr="true"/>
         </property>
        </widget>
       </item>
@@ -136,7 +177,7 @@
    <item>
     <widget class="QPlainTextEdit" name="dictionaryFileList">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
        <horstretch>0</horstretch>
        <verstretch>70</verstretch>
       </sizepolicy>
@@ -183,7 +224,7 @@
       <string notr="true"/>
      </property>
      <property name="horizontalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOff</enum>
+      <enum>Qt::ScrollBarAsNeeded</enum>
      </property>
      <property name="readOnly">
       <bool>true</bool>
@@ -192,16 +233,6 @@
    </item>
    <item>
     <layout class="QHBoxLayout" name="buttonsLayout">
-     <item>
-      <widget class="QPushButton" name="headwordsButton">
-       <property name="toolTip">
-        <string>Show all unique dictionary headwords</string>
-       </property>
-       <property name="text">
-        <string>Headwords</string>
-       </property>
-      </widget>
-     </item>
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
@@ -216,6 +247,30 @@
       </spacer>
      </item>
      <item>
+      <widget class="QPushButton" name="openIndexFolder">
+       <property name="text">
+        <string>Open index folder</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="openFolder">
+       <property name="text">
+        <string>Open folder</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="headwordsButton">
+       <property name="toolTip">
+        <string>Show all unique dictionary headwords</string>
+       </property>
+       <property name="text">
+        <string>Headwords</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="OKButton">
        <property name="text">
         <string notr="true">OK</string>
@@ -224,19 +279,6 @@
         <bool>true</bool>
        </property>
       </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
- Fix the random placement of buttons.
- Fix layout when the dialog is stretched.

---

Before:
<img width="400" src="https://github.com/user-attachments/assets/6ca3c24f-c13d-4418-81af-e7031dbb7de2" />

---
After:
<img height="400" src="https://github.com/user-attachments/assets/5f5090fa-8f28-44c7-8b75-b30cf6f3f2b7" />
<img width="400" src="https://github.com/user-attachments/assets/1feac7c8-944c-4299-b08a-db72109b2a17" />

