### PR TITLE
refactor: chop the `ResourceRequest` from the insane inheritance tree of `Request`

### DIFF
--- a/src/article_maker.cc
+++ b/src/article_maker.cc
@@ -289,7 +289,7 @@ string ArticleMaker::makeWelcomeHtml() const
   return result;
 }
 
-sptr< Dictionary::DataRequest > ArticleMaker::makeDefinitionFor( const QString & word,
+sptr< ResourceRequest > ArticleMaker::makeDefinitionFor( const QString & word,
                                                                  unsigned groupId,
                                                                  const QMap< QString, QString > & contexts,
                                                                  const QSet< QString > & mutedDicts,
@@ -323,14 +323,14 @@ sptr< Dictionary::DataRequest > ArticleMaker::makeDefinitionFor( const QString &
   if ( groupId == GroupId::HelpGroupId ) {
     if ( word == tr( "Welcome!" ) ) {
       string welcome                           = makeWelcomeHtml();
-      sptr< Dictionary::DataRequestInstant > r = std::make_shared< Dictionary::DataRequestInstant >( true );
+      sptr< ResourceRequest > r = ResourceRequest::NoDataFinished(true);
 
       r->appendString( welcome );
       return r;
     }
     else {
       // Not found
-      return makeNotFoundTextFor( word, "help" );
+      return makeNotFoundTextForResourceRequest( word, "help" );
     }
   }
 
@@ -397,6 +397,15 @@ sptr< Dictionary::DataRequest > ArticleMaker::makeNotFoundTextFor( const QString
   return r;
 }
 
+sptr< ResourceRequest > ArticleMaker::makeNotFoundTextForResourceRequest( const QString & word, const QString & group ) const
+{
+  string result = makeHtmlHeader( word, QString(), true ) + makeNotFoundBody( word, group ) + "</body></html>";
+  sptr< ResourceRequest > r = ResourceRequest::NoDataFinished(true);
+  r->appendString( result );
+  return r;
+}
+
+
 sptr< Dictionary::DataRequest > ArticleMaker::makeEmptyPage() const
 {
   string result                            = makeUntitleHtml();
@@ -405,6 +414,18 @@ sptr< Dictionary::DataRequest > ArticleMaker::makeEmptyPage() const
   r->appendString( result );
   return r;
 }
+
+sptr< ResourceRequest > ArticleMaker::makeEmptyPageResourceRequest() const
+{
+  string result  = makeUntitleHtml();
+
+
+  sptr<ResourceRequest > r = ResourceRequest::NoDataFinished(true);
+
+  r->appendString( result );
+  return r;
+}
+
 
 string ArticleMaker::makeUntitleHtml() const
 {

--- a/src/article_maker.hh
+++ b/src/article_maker.hh
@@ -39,7 +39,7 @@ public:
   /// the keys are dictionary ids.
   /// If mutedDicts is not empty, the search would be limited only to those
   /// dictionaries in group which aren't listed there.
-  sptr< Dictionary::DataRequest > makeDefinitionFor( const QString & word,
+  sptr< ResourceRequest > makeDefinitionFor( const QString & word,
                                                      unsigned groupId,
                                                      const QMap< QString, QString > & contexts,
                                                      const QSet< QString > & mutedDicts = QSet< QString >(),
@@ -50,9 +50,11 @@ public:
   /// was found. Sometimes it's better to call this directly when it's already
   /// known that there's no translation.
   sptr< Dictionary::DataRequest > makeNotFoundTextFor( const QString & word, const QString & group ) const;
+  sptr< ResourceRequest > makeNotFoundTextForResourceRequest( const QString & word, const QString & group ) const;
 
   /// Creates an 'untitled' page. The result is guaranteed to be instant.
   sptr< Dictionary::DataRequest > makeEmptyPage() const;
+  sptr< ResourceRequest > makeEmptyPageResourceRequest() const;
 
   /// Create page with one picture
   sptr< Dictionary::DataRequest > makePicturePage( const std::string & url ) const;
@@ -77,7 +79,7 @@ private:
 
 /// The request specific to article maker. This should really be private,
 /// but we need it to be handled by moc.
-class ArticleRequest: public Dictionary::DataRequest
+class ArticleRequest: public ResourceRequest
 {
   Q_OBJECT
 

--- a/src/article_netmgr.hh
+++ b/src/article_netmgr.hh
@@ -148,7 +148,7 @@ public:
   /// If it succeeds, the result is a dictionary request object. Otherwise, an
   /// empty pointer is returned.
   /// The function can optionally set the Content-Type header correspondingly.
-  sptr< Dictionary::DataRequest > getResource( const QUrl & url, QString & contentType );
+  sptr< ResourceRequest > getResource( const QUrl & url, QString & contentType );
 
   virtual QNetworkReply * getArticleReply( const QNetworkRequest & req );
   string getHtml( ResourceType resourceType );
@@ -158,7 +158,7 @@ class ArticleResourceReply: public QNetworkReply
 {
   Q_OBJECT
 
-  sptr< Dictionary::DataRequest > req;
+  sptr< ResourceRequest > req;
   qint64 alreadyRead;
 
   QAtomicInt finishSignalSent;
@@ -167,7 +167,7 @@ public:
 
   ArticleResourceReply( QObject * parent,
                         const QNetworkRequest &,
-                        const sptr< Dictionary::DataRequest > &,
+                        const sptr< ResourceRequest > &,
                         const QString & contentType );
 
   ~ArticleResourceReply();

--- a/src/dict/dictionary.cc
+++ b/src/dict/dictionary.cc
@@ -205,10 +205,10 @@ QString Class::getContainingFolder() const
   return {};
 }
 
-sptr< DataRequest > Class::getResource( const string & /*name*/ )
+sptr< ResourceRequest > Class::getResource( const string & /*name*/ )
 
 {
-  return std::make_shared< DataRequestInstant >( false );
+  return ResourceRequest::NoDataFinished(false);
 }
 
 sptr< DataRequest > Class::getSearchResults( const QString &, int, bool, bool )

--- a/src/dict/dictionary.hh
+++ b/src/dict/dictionary.hh
@@ -19,6 +19,7 @@
 #include "sptr.hh"
 #include "utils.hh"
 #include <QtGlobal>
+#include "dict/utils/resourcerequest.hh"
 
 /// Abstract dictionary-related stuff
 namespace Dictionary {
@@ -469,7 +470,7 @@ public:
   /// usually a picture file referenced in the article or something like that.
   /// The default implementation always returns the non-existing resource
   /// response.
-  virtual sptr< DataRequest > getResource( const string & /*name*/ );
+  virtual sptr< ResourceRequest > getResource( const string & /*name*/ );
 
   /// Returns a results of full-text search of given string similar getArticle().
   virtual sptr< DataRequest >

--- a/src/dict/gls.cc
+++ b/src/dict/gls.cc
@@ -371,7 +371,7 @@ public:
                                               const std::u32string &,
                                               bool ignoreDiacritics ) override;
 
-  sptr< Dictionary::DataRequest > getResource( const string & name ) override;
+  sptr< ResourceRequest > getResource( const string & name ) override;
 
   const QString & getDescription() override;
 
@@ -1019,15 +1019,13 @@ sptr< Dictionary::DataRequest > GlsDictionary::getArticle( const std::u32string 
 
 //////////////// GlsDictionary::getResource()
 
-class GlsResourceRequest: public Dictionary::DataRequest
+class GlsResourceRequest: public ResourceRequest
 {
 
   GlsDictionary & dict;
 
   string resourceName;
 
-  QAtomicInt isCancelled;
-  QFuture< void > f;
 
 public:
 
@@ -1042,25 +1040,11 @@ public:
 
   void run();
 
-  void cancel() override
-  {
-    isCancelled.ref();
-  }
-
-  ~GlsResourceRequest()
-  {
-    isCancelled.ref();
-    f.waitForFinished();
-  }
 };
 
 void GlsResourceRequest::run()
 {
-  // Some runnables linger enough that they are cancelled before they start
-  if ( Utils::AtomicInt::loadAcquire( isCancelled ) ) {
-    finish();
-    return;
-  }
+
 
   try {
     string n = dict.getContainingFolder().toStdString() + Utils::Fs::separator() + resourceName;
@@ -1160,7 +1144,7 @@ void GlsResourceRequest::run()
   finish();
 }
 
-sptr< Dictionary::DataRequest > GlsDictionary::getResource( const string & name )
+sptr<ResourceRequest > GlsDictionary::getResource( const string & name )
 
 {
   return std::make_shared< GlsResourceRequest >( *this, name );

--- a/src/dict/lsa.cc
+++ b/src/dict/lsa.cc
@@ -173,7 +173,7 @@ public:
                                               const std::u32string &,
                                               bool ignoreDiacritics ) override;
 
-  sptr< Dictionary::DataRequest > getResource( const string & name ) override;
+  sptr< ResourceRequest > getResource( const string & name ) override;
 
 protected:
 
@@ -384,7 +384,7 @@ __attribute__( ( packed ) )
 #endif
 ;
 
-sptr< Dictionary::DataRequest > LsaDictionary::getResource( const string & name )
+sptr< ResourceRequest > LsaDictionary::getResource( const string & name )
 
 {
   // See if the name ends in .wav. Remove that extension then
@@ -394,7 +394,7 @@ sptr< Dictionary::DataRequest > LsaDictionary::getResource( const string & name 
   vector< WordArticleLink > chain = findArticles( Text::toUtf32( strippedName ) );
 
   if ( chain.empty() ) {
-    return std::make_shared< Dictionary::DataRequestInstant >( false ); // No such resource
+    return ResourceRequest::NoDataFinished(false); // No such resource
   }
 
   File::Index f( getDictionaryFilenames()[ 0 ], QIODevice::ReadOnly );
@@ -426,9 +426,10 @@ sptr< Dictionary::DataRequest > LsaDictionary::getResource( const string & name 
     throw exFailedToRetrieveVorbisInfo();
   }
 
-  sptr< Dictionary::DataRequestInstant > dr = std::make_shared< Dictionary::DataRequestInstant >( true );
+  sptr< ResourceRequest > dr = ResourceRequest::NoDataFinished(true);
+  QMutexLocker locker(&dr->dataMutex);
 
-  vector< char > & data = dr->getData();
+  vector< char > & data = dr->data;
 
   data.resize( sizeof( WavHeader ) + e.samplesLength * 2 );
 

--- a/src/dict/slob.cc
+++ b/src/dict/slob.cc
@@ -633,7 +633,7 @@ public:
                                               const std::u32string &,
                                               bool ignoreDiacritics ) override;
 
-  sptr< Dictionary::DataRequest > getResource( const string & name ) override;
+  sptr< ResourceRequest > getResource( const string & name ) override;
 
   const QString & getDescription() override;
 
@@ -1135,15 +1135,13 @@ sptr< Dictionary::DataRequest > SlobDictionary::getArticle( const std::u32string
 
 //// SlobDictionary::getResource()
 
-class SlobResourceRequest: public Dictionary::DataRequest
+class SlobResourceRequest: public ResourceRequest
 {
 
   SlobDictionary & dict;
 
   string resourceName;
 
-  QAtomicInt isCancelled;
-  QFuture< void > f;
 
 public:
 
@@ -1158,26 +1156,11 @@ public:
 
   void run();
 
-  void cancel() override
-  {
-    isCancelled.ref();
-  }
-
-  ~SlobResourceRequest()
-  {
-    isCancelled.ref();
-    f.waitForFinished();
-  }
 };
 
 
 void SlobResourceRequest::run()
 {
-  // Some runnables linger enough that they are cancelled before they start
-  if ( Utils::AtomicInt::loadAcquire( isCancelled ) ) {
-    finish();
-    return;
-  }
 
   try {
     string resource;
@@ -1221,7 +1204,7 @@ void SlobResourceRequest::run()
   finish();
 }
 
-sptr< Dictionary::DataRequest > SlobDictionary::getResource( const string & name )
+sptr<ResourceRequest > SlobDictionary::getResource( const string & name )
 
 {
   return std::make_shared< SlobResourceRequest >( *this, name );

--- a/src/dict/utils/resourcerequest.cc
+++ b/src/dict/utils/resourcerequest.cc
@@ -1,0 +1,86 @@
+#include "resourcerequest.hh"
+
+std::shared_ptr< ResourceRequest > ResourceRequest::NoDataFinished( bool succeed )
+{
+  auto ret        = std::make_shared< ResourceRequest >();
+  ret->hasAnyData = succeed;
+  ret->finish();
+  return ret;
+}
+
+void ResourceRequest::cancel()
+{
+  f.cancel();
+}
+
+void ResourceRequest::finish()
+{
+  f.waitForFinished();
+  emit finished();
+}
+
+bool ResourceRequest::isFinished()
+{
+  return f.isCanceled() || f.isFinished();
+}
+
+qsizetype ResourceRequest::dataSize()
+{
+  return data.size();
+}
+
+void ResourceRequest::setErrorString( const QString & str )
+{
+  this->errorString = str;
+}
+
+void ResourceRequest::appendString( std::string_view str )
+{
+  QMutexLocker _( &dataMutex );
+  data.reserve( data.size() + str.size() );
+  data.insert( data.end(), str.begin(), str.end() );
+}
+
+void ResourceRequest::appendDataSlice( const void * buffer, size_t size )
+{
+  QMutexLocker _( &dataMutex );
+
+  size_t offset = data.size();
+
+  data.resize( data.size() + size );
+
+  memcpy( &data.front() + offset, buffer, size );
+}
+
+void ResourceRequest::getDataSlice( size_t offset, size_t size, void * buffer )
+{
+  if ( size == 0 ) {
+    return;
+  }
+  QMutexLocker _( &dataMutex );
+
+  if ( !hasAnyData ) {
+    throw std::runtime_error( "index out of range" ); // FIXME: shuold we follow old GD?
+  }
+
+  memcpy( buffer, &data[ offset ], size );
+}
+
+std::vector< char > & ResourceRequest::getFullData()
+{
+  if ( !isFinished() ) {
+    throw std::runtime_error( "Full data not finished" );
+  }
+
+  return data;
+}
+
+void ResourceRequest::update()
+{
+  emit updated();
+}
+
+ResourceRequest::~ResourceRequest()
+{
+  f.waitForFinished();
+}

--- a/src/dict/utils/resourcerequest.hh
+++ b/src/dict/utils/resourcerequest.hh
@@ -1,0 +1,48 @@
+#pragma once
+#include <QtConcurrentRun>
+
+/// Asynchronous Dictionary Request helper.
+/// Pretty much a wrapper of QFuture
+/// This can be used syn
+class ResourceRequest: public QObject
+{
+  Q_OBJECT
+
+public:
+  QFuture< void > f;
+  QMutex dataMutex;
+  std::vector< char > data;
+  bool hasAnyData = false;
+  QString errorString;
+
+  /// A bloated data holder invented because of OOP.
+  /// It simply has a cancelled QFuture that indicates that it is finished.
+  /// The user is supposed to fill in data synchronously.
+  /// @return
+  static std::shared_ptr< ResourceRequest > NoDataFinished( bool succeed );
+
+  virtual ~ResourceRequest();
+
+  virtual void cancel();
+  virtual void finish();
+  virtual bool isFinished();
+  void update();
+
+  /// TODO: is this useful?
+  virtual void setErrorString( const QString & str );
+
+
+  qsizetype dataSize();
+  void appendString( std::string_view str );
+  void appendDataSlice( const void * buffer, size_t size );
+  void getDataSlice( size_t offset, size_t size, void * buffer );
+  std::vector< char > & getFullData();
+signals:
+  void finished();
+
+  /// This signal is emitted when more data becomes available. Local
+  /// dictionaries don't call this, since it is preferred that all
+  /// data would be available from them at once, but network dictionaries
+  /// might call this.
+  void updated();
+};

--- a/src/dict/website.cc
+++ b/src/dict/website.cc
@@ -60,7 +60,7 @@ public:
                                   const std::u32string & context,
                                   bool ) override;
 
-  sptr< DataRequest > getResource( const string & name ) override;
+  sptr< ResourceRequest > getResource( const string & name ) override;
 
   Features getFeatures() const noexcept override
   {
@@ -327,9 +327,9 @@ sandbox="allow-same-origin allow-scripts allow-popups allow-forms"></iframe>)",
 }
 
 
-sptr< DataRequest > WebSiteDictionary::getResource( const string & /*name*/ )
+sptr< ResourceRequest > WebSiteDictionary::getResource( const string & /*name*/ )
 {
-  return std::make_shared< DataRequestInstant >( false );
+  return ResourceRequest::NoDataFinished( false );
 }
 
 void WebSiteDictionary::loadIcon() noexcept

--- a/src/dict/xdxf.cc
+++ b/src/dict/xdxf.cc
@@ -20,6 +20,8 @@
 #include "filetype.hh"
 #include "tiff.hh"
 #include "ftshelpers.hh"
+#include "resourcerequest.hh"
+
 #include <QIODevice>
 #include <QXmlStreamReader>
 #include <QFileInfo>
@@ -162,7 +164,7 @@ public:
                                               const std::u32string &,
                                               bool ignoreDiacritics ) override;
 
-  sptr< Dictionary::DataRequest > getResource( const string & name ) override;
+  sptr< ResourceRequest > getResource( const string & name ) override;
 
   const QString & getDescription() override;
 
@@ -886,7 +888,7 @@ void indexArticle( GzippedFile & gzFile,
 
 //// XdxfDictionary::getResource()
 
-class XdxfResourceRequest: public Dictionary::DataRequest
+class XdxfResourceRequest: public ResourceRequest
 {
 
   XdxfDictionary & dict;
@@ -991,7 +993,7 @@ void XdxfResourceRequest::run()
   finish();
 }
 
-sptr< Dictionary::DataRequest > XdxfDictionary::getResource( const string & name )
+sptr<ResourceRequest > XdxfDictionary::getResource( const string & name )
 
 {
   return std::make_shared< XdxfResourceRequest >( *this, name );

--- a/src/dict/zipsounds.cc
+++ b/src/dict/zipsounds.cc
@@ -122,7 +122,7 @@ public:
                                               const std::u32string &,
                                               bool ignoreDiacritics ) override;
 
-  sptr< Dictionary::DataRequest > getResource( const string & name ) override;
+  sptr< ResourceRequest > getResource( const string & name ) override;
 
 protected:
 
@@ -312,7 +312,7 @@ sptr< Dictionary::DataRequest > ZipSoundsDictionary::getArticle( const std::u32s
   return ret;
 }
 
-sptr< Dictionary::DataRequest > ZipSoundsDictionary::getResource( const string & name )
+sptr< ResourceRequest > ZipSoundsDictionary::getResource( const string & name )
 
 {
   // Remove extension for sound files (like in sound dirs)
@@ -322,7 +322,7 @@ sptr< Dictionary::DataRequest > ZipSoundsDictionary::getResource( const string &
   vector< WordArticleLink > chain = findArticles( strippedName );
 
   if ( chain.empty() ) {
-    return std::make_shared< Dictionary::DataRequestInstant >( false ); // No such resource
+    return ResourceRequest::NoDataFinished(false); // No such resource
   }
 
   // Find sound
@@ -346,13 +346,13 @@ sptr< Dictionary::DataRequest > ZipSoundsDictionary::getResource( const string &
     }
   }
 
-  sptr< Dictionary::DataRequestInstant > dr = std::make_shared< Dictionary::DataRequestInstant >( true );
+  auto dr = ResourceRequest::NoDataFinished(true);
 
-  if ( zipsFile.loadFile( dataOffset, dr->getData() ) ) {
+  if ( zipsFile.loadFile( dataOffset, dr->data ) ) {
     return dr;
   }
 
-  return std::make_shared< Dictionary::DataRequestInstant >( false );
+  return ResourceRequest::NoDataFinished(false);
 }
 
 void ZipSoundsDictionary::loadIcon() noexcept

--- a/src/resourceschemehandler.cc
+++ b/src/resourceschemehandler.cc
@@ -11,7 +11,7 @@ void ResourceSchemeHandler::requestStarted( QWebEngineUrlRequestJob * requestJob
   const QUrl url = requestJob->requestUrl();
   QString content_type;
   const QMimeType mineType                    = db.mimeTypeForUrl( url );
-  const sptr< Dictionary::DataRequest > reply = this->mManager.getResource( url, content_type );
+  const sptr< ResourceRequest > reply = this->mManager.getResource( url, content_type );
   content_type                                = mineType.name();
 
   if ( reply == nullptr ) {
@@ -22,14 +22,14 @@ void ResourceSchemeHandler::requestStarted( QWebEngineUrlRequestJob * requestJob
     replyJob( reply, requestJob, content_type );
   }
   else {
-    connect( reply.get(), &Dictionary::DataRequest::finished, requestJob, [ = ]() {
+    connect( reply.get(), &ResourceRequest::finished, requestJob, [ = ]() {
       replyJob( reply, requestJob, content_type );
     } );
   }
 }
 
 
-void ResourceSchemeHandler::replyJob( sptr< Dictionary::DataRequest > reply,
+void ResourceSchemeHandler::replyJob( sptr< ResourceRequest > reply,
                                       QWebEngineUrlRequestJob * requestJob,
                                       QString content_type )
 {

--- a/src/resourceschemehandler.hh
+++ b/src/resourceschemehandler.hh
@@ -11,7 +11,7 @@ public:
   void requestStarted( QWebEngineUrlRequestJob * requestJob );
 
 protected:
-  void replyJob( sptr< Dictionary::DataRequest > reply, QWebEngineUrlRequestJob * requestJob, QString content_type );
+  void replyJob( sptr< ResourceRequest > reply, QWebEngineUrlRequestJob * requestJob, QString content_type );
 
 private:
   ArticleNetworkAccessManager & mManager;

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -1010,9 +1010,9 @@ void ArticleView::playAudio( const QUrl & url )
 
     // Download it
     if ( Utils::Url::isWebAudioUrl( url ) ) {
-      sptr< Dictionary::DataRequest > req = std::make_shared< Dictionary::WebMultimediaDownload >( url, articleNetMgr );
+      sptr< ResourceRequest > req = std::make_shared< Dictionary::WebMultimediaDownload >( url, articleNetMgr );
 
-      connect( req.get(), &Dictionary::Request::finished, this, [ req, this ]() {
+      connect( req.get(), &ResourceRequest::finished, this, [ req, this ]() {
         audioDownloadFinished( req );
       } );
     }
@@ -1025,11 +1025,11 @@ void ArticleView::playAudio( const QUrl & url )
 
       if ( dict ) {
         try {
-          sptr< Dictionary::DataRequest > req = dict->getResource( url.path().mid( 1 ).toUtf8().data() );
+          sptr<ResourceRequest > req = dict->getResource( url.path().mid( 1 ).toUtf8().data() );
 
           if ( !req->isFinished() ) {
             // Queued loading
-            connect( req.get(), &Dictionary::Request::finished, this, [ req, this ]() {
+            connect( req.get(), &ResourceRequest::finished, this, [ req, this ]() {
               audioDownloadFinished( req );
             } );
           }
@@ -1097,7 +1097,7 @@ void ArticleView::playAudio( const QUrl & url )
 ResourceToSaveHandler * ArticleView::saveResource( const QUrl & url, const QString & fileName )
 {
   ResourceToSaveHandler * handler = new ResourceToSaveHandler( this, fileName );
-  sptr< Dictionary::DataRequest > req;
+  sptr< ResourceRequest > req;
 
   if ( url.scheme() == "bres" || url.scheme() == "gico" || url.scheme() == "gdau" || url.scheme() == "gdvideo" ) {
     // Normal resource download
@@ -1690,7 +1690,7 @@ void ArticleView::resourceDownloadFinished( const sptr< Dictionary::DataRequest 
 }
 
 
-void ArticleView::audioDownloadFinished( const sptr< Dictionary::DataRequest > & req )
+void ArticleView::audioDownloadFinished( const sptr< ResourceRequest> & req )
 {
   if ( req->dataSize() >= 0 ) {
     // Ok, got one finished, all others are irrelevant now
@@ -2105,12 +2105,12 @@ ResourceToSaveHandler::ResourceToSaveHandler( ArticleView * view, QString fileNa
   connect( this, &ResourceToSaveHandler::statusBarMessage, view, &ArticleView::statusBarMessage );
 }
 
-void ResourceToSaveHandler::addRequest( const sptr< Dictionary::DataRequest > & req )
+void ResourceToSaveHandler::addRequest( const sptr< ResourceRequest > & req )
 {
   if ( !alreadyDone ) {
     downloadRequests.push_back( req );
 
-    connect( req.get(), &Dictionary::Request::finished, this, &ResourceToSaveHandler::downloadFinished );
+    connect( req.get(), &ResourceRequest::finished, this, &ResourceToSaveHandler::downloadFinished );
   }
 }
 

--- a/src/ui/articleview.hh
+++ b/src/ui/articleview.hh
@@ -147,7 +147,7 @@ public:
                  const QString & scrollTo  = QString(),
                  const Contexts & contexts = Contexts() );
   void playAudio( const QUrl & url );
-  void audioDownloadFinished( const sptr< Dictionary::DataRequest > & req );
+  void audioDownloadFinished( const sptr< ResourceRequest > & req );
 
   /// Called when the state of dictionary bar changes and the view is active.
   /// The function reloads content if the change affects it.
@@ -419,7 +419,7 @@ class ResourceToSaveHandler: public QObject
 
 public:
   explicit ResourceToSaveHandler( ArticleView * view, QString fileName );
-  void addRequest( const sptr< Dictionary::DataRequest > & req );
+  void addRequest( const sptr< ResourceRequest > & req );
   bool isEmpty()
   {
     return downloadRequests.empty();
@@ -433,7 +433,7 @@ public slots:
   void downloadFinished();
 
 private:
-  std::list< sptr< Dictionary::DataRequest > > downloadRequests;
+  std::list< sptr< ResourceRequest > > downloadRequests;
   QString fileName;
   bool alreadyDone;
 };

--- a/src/webmultimediadownload.hh
+++ b/src/webmultimediadownload.hh
@@ -7,7 +7,7 @@ namespace Dictionary {
 
 /// Downloads data from the web, wrapped as a dictionary's DataRequest. This
 /// is useful for multimedia files, like sounds and pronunciations.
-class WebMultimediaDownload: public DataRequest
+class WebMultimediaDownload: public ResourceRequest
 {
   Q_OBJECT
 


### PR DESCRIPTION
### Problem:

With the tool available at his time, the original GD's author created a mini async framework.

However, new needs keep occurring, different programmers have different ideas, the `Request` and its subclasses end up to be this big thing that cannot be easily modified and understood.

In fact, I find this tree of `Request` now matches a textbook example of horrible practice of OOP (Chapter 9.3 https://www.oscar.nierstrasz.org/oorp/, a book I read last year.).

Taking a closer look, the `Dictioanry::DataRequest` have 4 concurrency/parallelism/async primitives (atomic, conditional variable, future, plus qt's async-ish event system).

### This PR:

Split the resource request related code to its own class `ResourceRequest` and fully embrace `QFuture/QtConcurrent`.

Note that the `QFuture` is publicly accessible, so the users of `ResourceRequest` can obtain all powers of `QFuture` with much less code.

The new class is intended to introduce less code changes in other places except changing name.

### Previously

+ https://github.com/xiaoyifang/goldendict-ng/pull/893
+ https://github.com/xiaoyifang/goldendict-ng/issues/2424
+ ...

### Progress

The "welcome" page shows up correct. Basic audio works.

As this IS the core of goldendict, more work is needed.