### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Release-all.yml
+++ b/.github/workflows/Release-all.yml
@@ -1,4 +1,6 @@
 name: Release All
+permissions:
+  contents: write
 concurrency:
    group: ${{ github.workflow }}-${{ github.ref }}
    cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/xiaoyifang/goldendict-ng/security/code-scanning/19](https://github.com/xiaoyifang/goldendict-ng/security/code-scanning/19)

To fix the problem, explicitly set the minimal required `permissions:` for the workflow.  
The best way is to add a `permissions:` block at the top level (immediately after the `name:` line and before `concurrency:`) to cover all jobs. For release publishing, creating or editing releases and uploading release assets requires `contents: write`. If finer control is needed, additional granularity may be added per-job, but here a workflow-level `permissions:` with `contents: write` is appropriate and safe.  
So, add:

```yaml
permissions:
  contents: write
```

immediately after the `name:` line (`line 1`), shifting the rest of the lines down.  
No changes are needed to any logic, and no additional methods, imports, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
