### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Manual-Build-Action.yml
+++ b/.github/workflows/Manual-Build-Action.yml
@@ -1,4 +1,6 @@
 name: Manual Build Action(for testing)
+permissions:
+  contents: read
 concurrency: 
    group: ${{ github.workflow }}-${{ github.ref }}
    cancel-in-progress: true

--- a/.github/workflows/PR-check-cmake.yml
+++ b/.github/workflows/PR-check-cmake.yml
@@ -1,4 +1,6 @@
 name: Build Check
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/Release-all.yml
+++ b/.github/workflows/Release-all.yml
@@ -1,4 +1,6 @@
 name: Release All
+permissions:
+  contents: write
 concurrency:
    group: ${{ github.workflow }}-${{ github.ref }}
    cancel-in-progress: true

--- a/.github/workflows/Sonar Cloud.yml
+++ b/.github/workflows/Sonar Cloud.yml
@@ -1,4 +1,6 @@
 name: SonarCloud
+permissions:
+  contents: read
 concurrency: 
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/create-vcpkg-export-archive.yml
+++ b/.github/workflows/create-vcpkg-export-archive.yml
@@ -2,6 +2,8 @@ name: Create vcpkg export archive
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
 
 env:
   outputName: goldendict-ng-vcpkg-export

--- a/.github/workflows/issue-translator.yml
+++ b/.github/workflows/issue-translator.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
     steps:
       - uses: a631807682/issues-translator@v1.2.1
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/xiaoyifang/goldendict-ng/security/code-scanning/20](https://github.com/xiaoyifang/goldendict-ng/security/code-scanning/20)

To fix this problem, you should add a `permissions:` block at the top-level of the workflow file (.github/workflows/PR-check-cmake.yml), immediately beneath the `name:` declaration and before the `concurrency:` and `on:` sections. This permissions block should specify the least privilege required for the workflow, which in this case is `contents: read`. This setting will apply to all jobs in the workflow unless they have their own, more permissive `permissions` block. The `permissions:` declaration must be YAML-compliant, and because none of the current jobs write to the repository, raise issues, or modify pull requests, there is no need to grant any write-scoped permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
