### PR TITLE
feat(whitelist): Enhance domain whitelist matching functionality

### DIFF
--- a/src/common/globalbroadcaster.cc
+++ b/src/common/globalbroadcaster.cc
@@ -3,6 +3,7 @@
 #include "utils.hh"
 
 Q_GLOBAL_STATIC( GlobalBroadcaster, bdcaster )
+
 GlobalBroadcaster::GlobalBroadcaster( QObject * parent ):
   QObject( parent )
 {
@@ -22,6 +23,7 @@ void GlobalBroadcaster::setPreference( Config::Preferences * p )
 {
   preference = p;
 }
+
 Config::Preferences * GlobalBroadcaster::getPreference() const
 {
   return preference;
@@ -35,11 +37,58 @@ void GlobalBroadcaster::addWhitelist( QString url )
 bool GlobalBroadcaster::existedInWhitelist( QString url ) const
 {
   for ( const QString & item : whitelist ) {
-    if ( url.endsWith( item ) ) {
-      return true; // Match found
+    // Exact match - e.g. "www.example.com" matches "www.example.com"
+    if ( url == item ) {
+      return true;
+    }
+
+    // Extract base domain from both url and item for comparison
+    QString urlBaseDomain = extractBaseDomain( url );
+    QString itemBaseDomain = extractBaseDomain( item );
+
+    // Compare base domains
+    if ( urlBaseDomain == itemBaseDomain ) {
+      return true;
     }
   }
-  return false; // No match found
+  return false;  // No match found
+}
+
+QString GlobalBroadcaster::extractBaseDomain( const QString & domain ) const
+{
+  // More generic approach for detecting two-part TLDs
+  // Look for patterns like com.xx, co.xx, org.xx, gov.xx, net.xx, edu.xx
+  QStringList parts = domain.split( '.' );
+  if ( parts.size() >= 3 ) {
+    QString secondLevel = parts[ parts.size() - 2 ];
+    QString topLevel = parts[ parts.size() - 1 ];
+
+    // Check if the second level is a common second-level domain indicator
+    // and the top level is a standard TLD (2-3 characters)
+    if ( ( secondLevel == "com" || secondLevel == "co" || secondLevel == "org" ||
+           secondLevel == "gov" || secondLevel == "net" || secondLevel == "edu" ) &&
+         ( topLevel.length() == 2 || topLevel.length() == 3 ) ) {
+      // Extract the registrable domain (e.g., "example.com" from "www.example.com.jp")
+      if ( parts.size() >= 3 ) {
+        return parts[ parts.size() - 3 ] + "." + secondLevel;
+      }
+      return secondLevel + "." + topLevel;
+    }
+  }
+
+  // For domains with multiple parts, extract the last two parts as base domain
+  int dotCount = domain.count( '.' );
+  if ( dotCount >= 2 ) {
+    if ( parts.isEmpty() ) {
+      parts = domain.split( '.' );
+    }
+    if ( parts.size() >= 2 ) {
+      return parts[ parts.size() - 2 ] + "." + parts[ parts.size() - 1 ];
+    }
+  }
+
+  // For domains with one or no dots, return as is
+  return domain;
 }
 
 
@@ -48,7 +97,7 @@ QString GlobalBroadcaster::getAbbrName( const QString & text )
   if ( text.isEmpty() ) {
     return {};
   }
-  //remove whitespace,number,mark,puncuation,symbol
+  // remove whitespace,number,mark,puncuation,symbol
   QString simplified = text;
   simplified.remove(
     QRegularExpression( R"([\p{Z}\p{N}\p{M}\p{P}\p{S}])", QRegularExpression::UseUnicodePropertiesOption ) );
@@ -59,4 +108,3 @@ QString GlobalBroadcaster::getAbbrName( const QString & text )
 
   return _icon_names.getIconName( simplified );
 }
-// namespace global

--- a/src/common/globalbroadcaster.hh
+++ b/src/common/globalbroadcaster.hh
@@ -24,13 +24,52 @@ class GlobalBroadcaster: public QObject
   Config::Preferences * preference;
   QSet< QString > whitelist;
   Icons::DictionaryIconName _icon_names;
+  
+  /// \brief Extract the base domain from a given domain string.
+  ///
+  /// This method handles several cases:
+  /// 1. Standard domains like "example.com" -> "example.com"
+  /// 2. Subdomains like "www.example.com" -> "example.com"
+  /// 3. Generic patterns like ".com.xx", ".co.xx", ".org.xx" where xx is a 2-3 character TLD -> "example.com"
+  ///
+  /// Examples:
+  /// - "www.example.com.jp" -> "example.com"
+  /// - "subdomain.example.org.uk" -> "example.org"
+  ///
+  /// \param domain The domain string to process
+  /// \return The extracted base domain
+  QString extractBaseDomain( const QString & domain ) const;
 
 public:
   void setPreference( Config::Preferences * _pre );
   Config::Preferences * getPreference() const;
   GlobalBroadcaster( QObject * parent = nullptr );
-  void addWhitelist( QString host );
-  bool existedInWhitelist( QString host ) const;
+  /// \brief Add a host to whitelist.
+  ///
+  /// The host should be a full domain. For subdomain matching, add the base domain
+  /// (e.g. "example.com"). For special TLDs, add the appropriate form
+  /// (e.g. "example.com.uk" for UK sites).
+  ///
+  /// \param host The host to add to whitelist
+  void addWhitelist( QString url );
+
+  /// \brief Check if a URL exists in the whitelist
+  ///
+  /// This method checks for exact matches and base domain matches:
+  /// 1. Direct string matching - e.g. "www.example.com" matches "www.example.com"
+  /// 2. Base domain matching using extractBaseDomain() - e.g. "example.com" matches "www.example.com"
+  ///
+  /// Generic pattern handling for TLDs like .com.xx, .co.xx, .org.xx:
+  /// - For "www.example.com.jp", the base domain is "example.com"
+  /// - For "api.service.org.uk", the base domain is "service.org"
+  ///
+  /// Cross-TLD matching requires explicit entries:
+  /// - To match both ".com" and ".com.xx" domains, both "example.com" and "example.com.xx"
+  ///   need to be added to the whitelist separately
+  ///
+  /// \param url The URL to check
+  /// \return true if the URL is in the whitelist, false otherwise
+  bool existedInWhitelist( QString url ) const;
   static GlobalBroadcaster * instance();
   unsigned currentGroupId;
   QString translateLineText{};


### PR DESCRIPTION
Add extractBaseDomain method to extract base domain, improve whitelist matching logic. Now supports:
1. Exact matching (e.g. "www.example.com")
2. Base domain matching (e.g. "example.com" matches "www.example.com")
3. Special TLD handling (patterns like ".com.xx", ".co.xx", etc.)