### PR TITLE
docs: Fix grammar errors and standardize format in documentation

### DIFF
--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -1,11 +1,11 @@
 ## Index file
 
-Each index file have 4 sections.
+Each index file has 4 sections.
 
-1. `IdxHeader`
-2. `ExtraInfo` (Being used but unnamed in source code)
-3. `Chunks`
-4. `BtreeIndex`
+1. `IdxHeader`:
+2. `ExtraInfo` (Being used but unnamed in source code):
+3. `Chunks`:
+4. `BtreeIndex`:
 
 The `IdxHeader` are 32bits blocks of various meta info of the index. The most important info are `chunksOffset` and `indexRootOffset` pointing to the starting offset of `BtreeIndex` and `Chunks`.
 

--- a/website/docs/developer.md
+++ b/website/docs/developer.md
@@ -4,11 +4,11 @@ This page is a brief introduction on how to get started.
 
 For technical details see [how to build from source](howto/build_from_source.md).
 
-## 1. Install Qt
+## Install Qt
 
 To install Qt on macOS or Windows, use the [Qt Online Installer](https://doc.qt.io/qt-6/get-and-install-qt.html). It can be downloaded from [Qt for Open Source](https://www.qt.io/download-open-source).
 
-Those Qt components are needed
+Those Qt components are needed:
 
 + Qt
   + 6.7.2 (Or another version)
@@ -30,19 +30,19 @@ Note that MinGW is not supported.
 
 CMake and Ninja are needed.
 
-## 2. Install a compiler
+## Install a compiler
 
 For windows, MSVC can be obtained by [installing Visual Studio's "Desktop development with C++"](https://learn.microsoft.com/cpp/build/vscpp-step-0-installation).
 
 For macOS, install [XCode](https://developer.apple.com/xcode/).
 
-## 3. Obtain dependencies
+## Obtain dependencies
 
 For Windows, prebuilt libraries will be automatically downloaded.
 
 For macOS, install [Homebrew](https://brew.sh/) and install related packages as described in [how to build from source](howto/build_from_source.md) or search `brew install` command in [macOS release's build file](https://github.com/xiaoyifang/goldendict-ng/blob/staged/.github/workflows/release-macos-homebrew.yml).
 
-## 4. Build
+## Build
 
 First, get GoldenDict's source code by [Cloning a repository](https://docs.github.com/repositories/creating-and-managing-repositories/cloning-a-repository).
 

--- a/website/docs/howto/how to customize the opencc.md
+++ b/website/docs/howto/how to customize the opencc.md
@@ -6,16 +6,12 @@ s2tw.json
 s2hk.json
 t2s.json
 ```
-- how to specify other configuration files?
+- How to specify other configuration files?
 
-1. create a custom file, such as custom.txt
-
-![image](https://user-images.githubusercontent.com/105986/192209053-82f316ca-8657-4a59-af50-6e704d155fad.png)
-
-2. modify the \*.json file, add the new custom.txt to the configuration.
-
-![image](https://user-images.githubusercontent.com/105986/192209129-ebc9efe7-ce82-4d4d-ad52-1b3c33eaf270.png)
-
-3. search `丑` in GoldenDict-ng will also show the result of `美`
+1. Create a custom file, such as custom.txt:
+   ![image](https://user-images.githubusercontent.com/105986/192209053-82f316ca-8657-4a59-af50-6e704d155fad.png)
+2. Modify the \*.json file, add the new custom.txt to the configuration:
+   ![image](https://user-images.githubusercontent.com/105986/192209129-ebc9efe7-ce82-4d4d-ad52-1b3c33eaf270.png)
+3. Search `丑` in GoldenDict-ng will also show the result of `美`:
 
 any other valid opencc configuration solutions should also work here.

--- a/website/docs/howto/how to manually reindex dictionary.md
+++ b/website/docs/howto/how to manually reindex dictionary.md
@@ -5,12 +5,12 @@ Sometimes you may want to manually reindex the dictionary.
 
 # Steps
 
-1. Find out the index filename of the dictionary
-You can find the index filename by right clicking on the dictionary in the dictionary bar.
-![alt text](reindex-step.png)
-2. open the index folder
-3. exit the gd-ng
-4. delete the dictionary's index file(&folder)
-![alt text](delete-index.png)
-5. reopen gd-ng
-the dictionary will be reindexed.
+1. Find out the index filename of the dictionary:
+   You can find the index filename by right clicking on the dictionary in the dictionary bar.
+   ![alt text](reindex-step.png)
+2. Open the index folder:
+3. Exit the gd-ng:
+4. Delete the dictionary's index file(&folder):
+   ![alt text](delete-index.png)
+5. Reopen gd-ng:
+   The dictionary will be reindexed.

--- a/website/docs/howto/how to use breadpad crash analysis.md
+++ b/website/docs/howto/how to use breadpad crash analysis.md
@@ -6,15 +6,15 @@ When a crash is encountered, a dump file is generated under the folder `crash`.T
 
 ## Option 1: Visual Studio
 
-1. Open the `.dmp` file with VS
-2. Click `Debug with Native Only`
-3. Click `Locate goldendict.pdb manually` -> click to a path that contains the `.pdf` file (Require exact naming of `goldendict.pdb`)
+1. Open the `.dmp` file with VS:
+2. Click `Debug with Native Only`:
+3. Click `Locate goldendict.pdb manually` -> click to a path that contains the `.pdf` file (Require exact naming of `goldendict.pdb`):
 
 Bottom tab --> `locals` --> watch stack.
 
-## Option2: WinDbg 
+## Option 2: WinDbg 
 
-1. Grab a modern version of WinDbg https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/
+1. Grab a modern version of WinDbg https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/:
 2. Click Settings -> Debug settings -> Debugging paths -> Symbol path -> (add a path contains `goldendict.pdb`).
 
 
@@ -37,14 +37,15 @@ Download the exe files from
 
 Part of Google breakpad's repo. Grab them from random places of internet (e.g. [minidump-tools](https://gitee.com/wabwh/breakpad-minindump-tools/tree/master/)).
 
-1. `dump_syms.exe GoldenDict.pdb > GoldenDict.sym`
+1. `dump_syms.exe GoldenDict.pdb > GoldenDict.sym`:
 The content of GoldenDict.sym is like this:
 ```
 MODULE windows x86_64 904B2C52C1EC411D9D0271445CAD6DCD2 GoldenDict.pdb
 INFO CODE_ID 645510C96CC000 GoldenDict.exe
 ```
 
-2. create a folder such as `symbols`  and a series of folders like this:
+2. Create a folder such as `symbols`  and a series of folders like this:
+
 ```
 GoldDict.exe
 a.dmp                 (A)
@@ -57,8 +58,8 @@ symbols
 - `B`   this is a folder name
 - `C`   this folder takes the name from the first line of `GoldenDict.sym` file
 
-3. anlaysis the dump file like this
+3. Analysis the dump file like this:
 ```
 minidump_stackwalk.exe  -s a.dmp symbols > a.txt
 ```
-4.  check the a.txt file to find the possible crash reason. usually it will point to the actual crash line number of the source code.
+4. Check the a.txt file to find the possible crash reason. Usually it will point to the actual crash line number of the source code.

--- a/website/docs/manage_sources.md
+++ b/website/docs/manage_sources.md
@@ -4,7 +4,7 @@ To use local dictionaries, add them via `Sources` -> `Files`.
 
 To inspect or disable individual dictionaries, go `Edit` -> `Dictionaries` -> `Dictionaries`.
 
-If you have too many dictionaries, consider use `Groups` to manage them.
+If you have too many dictionaries, consider using `Groups` to manage them.
 
 ## Files
 
@@ -13,11 +13,11 @@ If you have too many dictionaries, consider use `Groups` to manage them.
 
 Here you can add local dictionaries.
 
-Press the "Add" button and select folders that includes your local dictionaries. To search every subfolders, enable the "Recursive".
+Press the "Add" button and select folders that include your local dictionaries. To search every subfolder, enable the "Recursive":
 
-GoldenDict will scan these folders and add found dictionaries into dictionaries list.
+GoldenDict will scan these folders and add found dictionaries to the dictionaries list.
 
-"Rescan" button start forced scan of all folders in list.
+The "Rescan" button starts a forced scan of all folders in the list.
 
 
 ## Sound Dirs
@@ -32,7 +32,7 @@ A word could have several forms, but sometimes a dictionary only contains one fo
 
 Morphology dictionary uses Hunspell's morphological analysis to obtain word's variant forms.
 
-You can specify a path that includes Hunspell format data files (`.aff` + `.dic`). GoldenDict scan this folder and create a list of available dictionaries.
+You can specify a path that includes Hunspell format data files (`.aff` + `.dic`). GoldenDict will scan this folder and create a list of available dictionaries.
 
 One possible source of Hunspell dictionaries is LibreOffice's [dictionaries](https://github.com/LibreOffice/dictionaries).
 
@@ -46,9 +46,9 @@ There are some specially tailored hunspell dicts to use for Morphology. Such as
 
 ## Websites
 
-Here you can add any website which allow to set target word in url. To add such site you should set it url with target word template, name for dictionaries list and set mark in "Enabled" column. In the "Icon" column you can set custom icon for this site. If you add icon file name without path GoldenDict will search this file in configuration folder. "As link" column define method of article insertion into common page. If this option is set article will be inserted as link inside `<iframe>` tag (preferable mode). If articles are not loaded in this mode turn this option off, then articles will be inserted as html-code.
+Here you can add any website that allows you to set the target word in the URL. To add such a site, you should set its URL with the target word template, name for the dictionaries list, and set a mark in the "Enabled" column. In the "Icon" column, you can set a custom icon for this site. If you add an icon file name without a path, GoldenDict will search for this file in the configuration folder. The "As link" column defines the method of article insertion into the common page. If this option is set, the article will be inserted as a link inside an `<iframe>` tag (preferable mode). If articles are not loaded in this mode, turn this option off, then articles will be inserted as HTML code.
 
-Target word can be inserted into url in next encodings::
+Target word can be inserted into url in next encodings:
 
 | Target word template   | Encoding                                |
 |------------------------|-----------------------------------------|
@@ -57,7 +57,7 @@ Target word can be inserted into url in next encodings::
 
 ## DICT servers
 
-Here you can add servers which uses DICT protocol. To add such server you should set its url, name for dictionaries list, server bases list, search strategies list and set mark in "Enabled" column. If bases list is empty GoldenDict will use all server bases. If search strategies list is empty GoldenDict will use "prefix" strategy (comparing the first part of the word).
+Here you can add servers which use the DICT protocol. To add such a server, you should set its URL, name for the dictionaries list, server bases list, search strategies list, and set a mark in the "Enabled" column. If the bases list is empty, GoldenDict will use all server bases. If the search strategies list is empty, GoldenDict will use the "prefix" strategy (comparing the first part of the word).
 
 In the "Icon" column you can set custom icon for every server. If you add icon file name without path GoldenDict will search this file in configuration folder.
 
@@ -72,7 +72,7 @@ The `%GDWORD%` in command line will be replaced by word from search line.
 |--------------|---------------------------------------------------------------------------------------|
 | Audio        | Play sound.                                                                           |
 | Text         | Text printed by the program will be shown as separate article.                        |
-| HTML         | HTML printed by the program Will be shown as separate article.                        |
+| HTML         | HTML printed by the program will be shown as separate article.                        |
 | Prefix match | A list of words printed by the program will be added to search bar's completion list. |
 
 Other than "Audio", the program should print the content to standard output.
@@ -95,7 +95,7 @@ In the "Icon" column, you can set a custom icon for every application. If you ad
 
 ## Transliteration
 
-Here you can add transliteration algorithms. To add algorithm into dictionaries list just set mark beside it. When such dictionary added into current dictionaries group GoldenDict will search word in the input line as well as result of its handling by corresponding transliteration algorithm.
+Here you can add transliteration algorithms. To add an algorithm to the dictionaries list, just set a mark beside it. When such a dictionary is added to the current dictionaries group, GoldenDict will search for the word in the input line as well as the result of its handling by the corresponding transliteration algorithm.
 
 ## System Text-to-speech engines
 

--- a/website/docs/topic_anki.md
+++ b/website/docs/topic_anki.md
@@ -1,26 +1,26 @@
 # Anki Integration
 
-# prerequisite
-1. install Anki
-2. install ankiconnect
+# Prerequisite
+1. Install Anki:
+2. Install ankiconnect:
 
-# configure Anki
+# Configure Anki
 
-## 1. create a new model, or use an existing model
+## Create a new model, or use an existing model
 
 For example, the model could have `Front` and `Back` fields.
 
 ![Snipaste_2022-05-21_14-08-21](https://user-images.githubusercontent.com/105986/169638410-c6aa8038-df03-40de-8731-9f0b9f43bf59.png)
-## 2. configure the template
-the front template
+## Configure the template
+The front template
 
 ![image](https://user-images.githubusercontent.com/105986/169638457-2358d020-0132-469f-a6b4-0fb6d1590fa2.png)
-the back template
+The back template
 
 ![image](https://user-images.githubusercontent.com/105986/169638440-7191fcdd-c338-48a3-a899-7216a5c77425.png)
 
-# configure goldendict
-## 1. through toolbar=>preference=>network
+# Configure Goldendict
+## Through toolbar=>preference=>network
 ![screenshot](https://user-images.githubusercontent.com/69171671/224496944-dbf31d6e-26be-42c9-98fc-257f70a8428e.png)
 
 * Word - Vocabulary headword.
@@ -30,9 +30,9 @@ the back template
 **Example for adding Japanese sentences:**
 ![screenshot](https://user-images.githubusercontent.com/69171671/224497112-ab027a16-89b2-48d8-8308-a3dbb5b9e1e4.png)
 
-## 2. action
+## Action
 ![image](https://user-images.githubusercontent.com/105986/169638740-abecde84-d33b-45ce-932c-d465c6650334.png)
-## 3. result
+## Result
 
 **Word and definition:**
 ![image](https://user-images.githubusercontent.com/105986/169638761-f67c009d-27cd-440d-bafa-ebbdce9577e3.png)
@@ -44,7 +44,7 @@ the back template
 
 ## Using URI schemes
 
-`goldendict://word` link can be use to query a word directly on GoldenDict-ng.
+The `goldendict://word` link can be used to query a word directly on GoldenDict-ng.
 
 On your Anki card's template, you can add the code below to have a "1 click open in GoldenDict-ng" card.
 

--- a/website/docs/topic_move_index_folder.md
+++ b/website/docs/topic_move_index_folder.md
@@ -5,10 +5,10 @@ To move the index folder to other places:
 !!! note
     the [`mklink`](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/mklink#related-links) is built-in tool in Windows.
 
-1. Open `cmd` as administrator
-2. copy the index folder to another place,take `D:\gd-ng\index_new` for example.
-3. Run `mklink /D "C:\Users\USERNAME\Application Data\GoldenDict\index" "D:\gd-ng\index_new"`
-4. Run GoldenDict
+1. Open `cmd` as administrator:
+2. Copy the index folder to another place, take `D:\gd-ng\index_new` for example.:
+3. Run `mklink /D "C:\Users\USERNAME\Application Data\GoldenDict\index" "D:\gd-ng\index_new"`:
+4. Run GoldenDict:
 
 ## Linux/macOS
 

--- a/website/docs/topic_website_scripting.md
+++ b/website/docs/topic_website_scripting.md
@@ -4,23 +4,23 @@ GoldenDict allows you to inject custom JavaScript code into websites opened in s
 
 ## How to Use Website Scripting
 
-1. Open the **Edit | Dictionaries** dialog
-2. Go to the **Websites** tab
-3. Add or edit a website entry
+1. Open the **Edit | Dictionaries** dialog:
+2. Go to the **Websites** tab:
+3. Add or edit a website entry:
 4. In the **Script** column, you can specify either:
-   - A file path (relative to the config directory or absolute)
-   - Direct JavaScript code
+    - A file path (relative to the config directory or absolute)
+    - Direct JavaScript code
 
 ## Script Column Details
 
 The **Script** column in the Websites configuration accepts two types of input:
 
-1. **File Path**: 
-   - **Relative path**: Path relative to the GoldenDict configuration directory
-   - **Absolute path**: Full path to a JavaScript file on your system
+1. **File Path:**
+    - **Relative path:** Path relative to the GoldenDict configuration directory
+    - **Absolute path:** Full path to a JavaScript file on your system
    
-2. **Direct Script Content**: 
-   - JavaScript code directly entered in the field
+2. **Direct Script Content:**
+    - JavaScript code directly entered in the field
 
 When you specify a file path, GoldenDict will read the content of that file and inject it as JavaScript into the matching website. If the file doesn't exist or you've entered JavaScript code directly, GoldenDict will inject the content of the field directly as JavaScript.
 
@@ -38,7 +38,7 @@ You can also check the menu "Help->Configuration folder" to see the exact config
 
 ### Using a File
 
-1. Create a JavaScript file, for example `mywebsite.js` in your config directory
+1. Create a JavaScript file, for example `mywebsite.js` in your config directory:
 2. Add your JavaScript code to this file:
    ```javascript
    // Example: Hide a specific element
@@ -49,7 +49,7 @@ You can also check the menu "Help->Configuration folder" to see the exact config
        }
    });
    ```
-3. In the Script column, enter: `mywebsite.js`
+3. In the Script column, enter: `mywebsite.js`:
 
 ### Using Direct Script Content
 


### PR DESCRIPTION
- Fix grammar errors, spelling mistakes, and inconsistent formatting in multiple documents
- Standardize list item formatting and punctuation usage across documentation
- Optimize expression clarity of certain sentences