### PR TITLE
Optimize Windows style settings and proxy type names

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -301,12 +301,6 @@ int main( int argc, char ** argv )
   GD_QApplication::setWindowIcon( QIcon( ":/icons/programicon.png" ) );
 #endif
 
-#ifdef Q_OS_WIN
-  // TODO: Force fusion because Qt6.7's "ModernStyle"'s dark theme have problems, need to test / reconsider in future
-  GD_QApplication::setStyle( QStyleFactory::create( "WindowsVista" ) );
-#endif
-
-
 #if defined( USE_BREAKPAD )
   QString appDirPath = Config::getConfigDir() + "crash";
 

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -337,7 +337,7 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   ui.useProxyServer->setChecked( p.proxyServer.enabled );
 
   ui.proxyType->addItem( "SOCKS5" );
-  ui.proxyType->addItem( "HTTP Transp." );
+  ui.proxyType->addItem( "HTTP Connect" );
   ui.proxyType->addItem( "HTTP Caching" );
 
   ui.proxyType->setCurrentIndex( p.proxyServer.type );


### PR DESCRIPTION
- Remove forced WindowsVista style setting in main.cc (let Qt use default system style for better integration)
- Update proxy type name 'HTTP Transp.' to 'HTTP Connect' for better user understanding