### PR TITLE
Fix macOS goldendict:// URL scheme handling

### DIFF
--- a/src/common/utils.hh
+++ b/src/common/utils.hh
@@ -395,7 +395,8 @@ inline QString decodeUrlEncodedWord( QString word )
 {
   if ( word.startsWith( QStringLiteral( "xn--" ) ) ) {
     word = QUrl::fromAce( word.toLatin1(), QUrl::IgnoreIDNWhitelist );
-  } else if ( word.startsWith( QStringLiteral( "%" ) ) ) {
+  }
+  else if ( word.startsWith( QStringLiteral( "%" ) ) ) {
     word = QUrl::fromPercentEncoding( word.toLatin1() );
   }
   return word;

--- a/src/common/utils.hh
+++ b/src/common/utils.hh
@@ -391,6 +391,16 @@ QString extractBaseDomain( const QString & domain );
 
 QString getSchemeAndHost( const QUrl & url );
 
+inline QString decodeUrlEncodedWord( QString word )
+{
+  if ( word.startsWith( QStringLiteral( "xn--" ) ) ) {
+    word = QUrl::fromAce( word.toLatin1(), QUrl::IgnoreIDNWhitelist );
+  } else if ( word.startsWith( QStringLiteral( "%" ) ) ) {
+    word = QUrl::fromPercentEncoding( word.toLatin1() );
+  }
+  return word;
+}
+
 } // namespace Url
 
 namespace Path {

--- a/src/macos/mac_url_handler.cc
+++ b/src/macos/mac_url_handler.cc
@@ -1,11 +1,24 @@
 #ifdef __APPLE__
   #include "mac_url_handler.hh"
+  #include "utils.hh"
   #include <QDebug>
 
 void MacUrlHandler::processURL( const QUrl & url )
 {
   qDebug() << "External URL received: " << url;
-  emit wordReceived( QStringLiteral( "translateWord: " )
-                     + QUrl::fromAce( url.authority().toLatin1(), QUrl::IgnoreIDNWhitelist ) );
+  
+  if ( url.scheme() == "goldendict" ) {
+    QString word = url.authority();
+    
+    if ( word.isEmpty() && !url.path().isEmpty() ) {
+      word = url.path().remove( 0, 1 );
+    }
+    
+    word = Utils::Url::decodeUrlEncodedWord( word );
+    
+    if ( !word.isEmpty() ) {
+      emit wordReceived( QStringLiteral( "action:translate|word:" ) + word );
+    }
+  }
 }
 #endif

--- a/src/macos/mac_url_handler.cc
+++ b/src/macos/mac_url_handler.cc
@@ -6,16 +6,16 @@
 void MacUrlHandler::processURL( const QUrl & url )
 {
   qDebug() << "External URL received: " << url;
-  
+
   if ( url.scheme() == "goldendict" ) {
     QString word = url.authority();
-    
+
     if ( word.isEmpty() && !url.path().isEmpty() ) {
       word = url.path().remove( 0, 1 );
     }
-    
+
     word = Utils::Url::decodeUrlEncodedWord( word );
-    
+
     if ( !word.isEmpty() ) {
       emit wordReceived( QStringLiteral( "action:translate|word:" ) + word );
     }

--- a/src/main.cc
+++ b/src/main.cc
@@ -228,14 +228,7 @@ void processCommandLine( QCoreApplication * app, GDOptions * result )
     }
 
     // Handle cases where we get encoded URL
-    if ( result->word.startsWith( QStringLiteral( "xn--" ) ) ) {
-      // For `kde-open` or `gio` or others, URL are encoded into ACE or Punycode
-      result->word = QUrl::fromAce( result->word.toLatin1(), QUrl::IgnoreIDNWhitelist );
-    }
-    else if ( result->word.startsWith( QStringLiteral( "%" ) ) ) {
-      // For Firefox or other browsers where URL are percent encoded
-      result->word = QUrl::fromPercentEncoding( result->word.toLatin1() );
-    }
+    result->word = Utils::Url::decodeUrlEncodedWord( result->word );
 #endif
   }
 }


### PR DESCRIPTION
Fix the issue where clicking goldendict://word links on macOS could only bring the app to front but failed to automatically search the word.

**Changes:**
- Add Utils::Url::decodeUrlEncodedWord() utility function for URL decoding
- Fix MacUrlHandler to properly extract word from goldendict:// URLs
- Support both goldendict://word and goldendict:///word formats
- Use unified decoding logic across all platforms

**Root Cause:**
macOS handles custom protocols via Apple Events rather than command line arguments. The previous implementation didn't properly parse the URL structure.