### PR TITLE
Refactor: Move interfaceStyle parameter from preprocessor conditional to function parameter

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -153,11 +153,8 @@ Preferences::Preferences():
   inputPhraseLengthLimit( 1000 ),
   maxDictionaryRefsInContextMenu( 20 ),
   synonymSearchEnabled( true ),
-  stripClipboard( false )
-#if !defined( Q_OS_WIN )
-  ,
+  stripClipboard( false ),
   interfaceStyle( "Default" )
-#endif
 {
 }
 
@@ -784,9 +781,7 @@ Class load()
       c.preferences.enableInterfaceFont = enableInterfaceFont.toElement().text() == "1";
     }
 
-#if !defined( Q_OS_WIN )
     c.preferences.interfaceStyle = preferences.namedItem( "interfaceStyle" ).toElement().text();
-#endif
     c.preferences.newTabsOpenAfterCurrentOne =
       ( preferences.namedItem( "newTabsOpenAfterCurrentOne" ).toElement().text() == "1" );
     c.preferences.newTabsOpenInBackground =
@@ -1704,11 +1699,9 @@ void save( const Class & c )
     opt.appendChild( dd.createTextNode( c.preferences.displayStyle ) );
     preferences.appendChild( opt );
 
-#if !defined( Q_OS_WIN )
     opt = dd.createElement( "interfaceStyle" );
     opt.appendChild( dd.createTextNode( c.preferences.interfaceStyle ) );
     preferences.appendChild( opt );
-#endif
 
     opt = dd.createElement( "newTabsOpenAfterCurrentOne" );
     opt.appendChild( dd.createTextNode( c.preferences.newTabsOpenAfterCurrentOne ? "1" : "0" ) );

--- a/src/config.hh
+++ b/src/config.hh
@@ -386,7 +386,7 @@ struct Preferences
 
   // QApplication style https://doc.qt.io/qt-6/qapplication.html#setStyle
   // In addition to Qt's styles, "Default" is added as default.
-  // On Windows, this is always empty as Windows uses its own styling system.
+  // On Windows, this field exists but is not used (Windows uses its own styling system).
   QString interfaceStyle;
 
   Preferences();

--- a/src/config.hh
+++ b/src/config.hh
@@ -384,11 +384,10 @@ struct Preferences
   QString addonStyle;
   QString displayStyle; // Article Display style (Which also affect interface style on windows)
 
-#if !defined( Q_OS_WIN )
   // QApplication style https://doc.qt.io/qt-6/qapplication.html#setStyle
   // In addition to Qt's styles, "Default" is added as default.
+  // On Windows, this is always empty as Windows uses its own styling system.
   QString interfaceStyle;
-#endif
 
   Preferences();
 };

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -792,8 +792,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   updateAppearances( cfg.preferences.addonStyle,
                      cfg.preferences.displayStyle,
                      cfg.preferences.darkMode,
-                     cfg.preferences.interfaceStyle
-  );
+                     cfg.preferences.interfaceStyle );
 
   // Create and show the initial welcome tab
   history.enableAdd( false );
@@ -1523,8 +1522,7 @@ void MainWindow::refreshAppearances()
   updateAppearances( cfg.preferences.addonStyle,
                      cfg.preferences.displayStyle,
                      cfg.preferences.darkMode,
-                     cfg.preferences.interfaceStyle
-  );
+                     cfg.preferences.interfaceStyle );
 }
 
 void MainWindow::trayIconUpdateOrInit()
@@ -2374,11 +2372,7 @@ void MainWindow::editPreferences()
          || cfg.preferences.interfaceStyle != p.interfaceStyle
 #endif
     ) {
-      updateAppearances( p.addonStyle,
-                         p.displayStyle,
-                         p.darkMode,
-                         p.interfaceStyle
-      );
+      updateAppearances( p.addonStyle, p.displayStyle, p.darkMode, p.interfaceStyle );
     }
 
     if ( cfg.preferences.favoritesStoreInterval != p.favoritesStoreInterval ) {

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -791,11 +791,8 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   updateAppearances( cfg.preferences.addonStyle,
                      cfg.preferences.displayStyle,
-                     cfg.preferences.darkMode
-#if !defined( Q_OS_WIN )
-                     ,
+                     cfg.preferences.darkMode,
                      cfg.preferences.interfaceStyle
-#endif
   );
 
   // Create and show the initial welcome tab
@@ -1363,14 +1360,10 @@ QPrinter & MainWindow::getPrinter()
 
 void MainWindow::updateAppearances( const QString & addonStyle,
                                     const QString & displayStyle,
-                                    Config::Dark darkMode
-#if !defined( Q_OS_WIN )
-                                    ,
-                                    const QString & interfaceStyle
-#endif
-)
+                                    Config::Dark darkMode,
+                                    const QString & interfaceStyle )
 {
-#if defined( Q_OS_WIN )
+#ifdef Q_OS_WIN
   // https://forum.qt.io/topic/101391/windows-10-dark-theme
 
   auto isDarkModeEnabled = [ darkMode ]() -> bool {
@@ -1449,12 +1442,14 @@ void MainWindow::updateAppearances( const QString & addonStyle,
 #endif
 
 #if !defined( Q_OS_WIN )
-  if ( interfaceStyle == "Default" ) {
-    QApplication::setStyle( QStyleFactory::create( defaultInterfaceStyle ) );
-  }
-  else {
-    if ( QStyleFactory::keys().contains( interfaceStyle ) ) {
-      QApplication::setStyle( QStyleFactory::create( interfaceStyle ) );
+  if ( !interfaceStyle.isEmpty() ) {
+    if ( interfaceStyle == "Default" ) {
+      QApplication::setStyle( QStyleFactory::create( defaultInterfaceStyle ) );
+    }
+    else {
+      if ( QStyleFactory::keys().contains( interfaceStyle ) ) {
+        QApplication::setStyle( QStyleFactory::create( interfaceStyle ) );
+      }
     }
   }
 #endif
@@ -1527,11 +1522,8 @@ void MainWindow::refreshAppearances()
 {
   updateAppearances( cfg.preferences.addonStyle,
                      cfg.preferences.displayStyle,
-                     cfg.preferences.darkMode
-#if !defined( Q_OS_WIN )
-                     ,
+                     cfg.preferences.darkMode,
                      cfg.preferences.interfaceStyle
-#endif
   );
 }
 
@@ -2384,11 +2376,8 @@ void MainWindow::editPreferences()
     ) {
       updateAppearances( p.addonStyle,
                          p.displayStyle,
-                         p.darkMode
-#if !defined( Q_OS_WIN )
-                         ,
+                         p.darkMode,
                          p.interfaceStyle
-#endif
       );
     }
 

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -201,8 +201,7 @@ private:
   void updateAppearances( const QString & addonStyle,
                           const QString & displayStyle,
                           Config::Dark darkMode,
-                          const QString & interfaceStyle = QString()
-                        );
+                          const QString & interfaceStyle = QString() );
 
   /// Creates, destroys or otherwise updates tray icon, according to the
   /// current configuration and situation.

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -200,12 +200,9 @@ private:
   /// Applies Qt stylesheets, use Windows dark palette etc....
   void updateAppearances( const QString & addonStyle,
                           const QString & displayStyle,
-                          Config::Dark darkMode
-#if !defined( Q_OS_WIN )
-                          ,
-                          const QString & interfaceStyle
-#endif
-  );
+                          Config::Dark darkMode,
+                          const QString & interfaceStyle = QString()
+                        );
 
   /// Creates, destroys or otherwise updates tray icon, according to the
   /// current configuration and situation.

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -471,9 +471,9 @@ Config::Preferences Preferences::getPreferences()
 
 
   p.displayStyle = ui.displayStyle->itemData( ui.displayStyle->currentIndex() ).toString();
-#if !defined( Q_OS_WIN )
-  p.interfaceStyle = ui.InterfaceStyle->itemData( ui.InterfaceStyle->currentIndex() ).toString();
-#endif
+  if ( ui.InterfaceStyle->isVisible() ) {
+    p.interfaceStyle = ui.InterfaceStyle->itemData( ui.InterfaceStyle->currentIndex() ).toString();
+  }
 
   p.newTabsOpenAfterCurrentOne = ui.newTabsOpenAfterCurrentOne->isChecked();
   p.newTabsOpenInBackground    = ui.newTabsOpenInBackground->isChecked();


### PR DESCRIPTION
This PR refactors the updateAppearances function to move the interfaceStyle parameter from compile-time preprocessor conditional to a runtime function parameter with a default string value.

**Changes:**
- Modified  to always include interfaceStyle parameter with default value
- Modified  function signature to always include interfaceStyle parameter
- Updated all call sites to always pass interfaceStyle parameter
- Added runtime check  before applying interface style changes

**Benefits:**
- Cleaner code with reduced preprocessor directives
- Easier to understand and maintain
- Better separation between compile-time and runtime logic