### PR TITLE
feat: add target parameter support for goldendict:// URL scheme

### DIFF
--- a/src/macos/mac_url_handler.cc
+++ b/src/macos/mac_url_handler.cc
@@ -23,7 +23,7 @@ void MacUrlHandler::processURL( const QUrl & url )
 
     if ( !word.isEmpty() ) {
       // Parse query parameters to determine target window
-      QString query = url.query();
+      QString query   = url.query();
       QString message = QStringLiteral( "action:translate" );
 
       if ( !query.isEmpty() ) {

--- a/src/macos/mac_url_handler.cc
+++ b/src/macos/mac_url_handler.cc
@@ -14,10 +14,32 @@ void MacUrlHandler::processURL( const QUrl & url )
       word = url.path().remove( 0, 1 );
     }
 
+    // Remove trailing slash if present
+    if ( word.endsWith( "/" ) ) {
+      word.chop( 1 );
+    }
+
     word = Utils::Url::decodeUrlEncodedWord( word );
 
     if ( !word.isEmpty() ) {
-      emit wordReceived( QStringLiteral( "action:translate|word:" ) + word );
+      // Parse query parameters to determine target window
+      QString query = url.query();
+      QString message = QStringLiteral( "action:translate" );
+
+      if ( !query.isEmpty() ) {
+        QUrlQuery urlQuery( query );
+        QString targetParam = urlQuery.queryItemValue( "target" );
+
+        if ( targetParam == "popup" ) {
+          message += "|window:popup";
+        }
+        else if ( targetParam == "main" ) {
+          message += "|window:main";
+        }
+      }
+
+      message += "|word:" + word;
+      emit wordReceived( message );
     }
   }
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -223,23 +223,23 @@ void processCommandLine( QCoreApplication * app, GDOptions * result )
       // Parse the full URL to extract query parameters
       QUrl url( originalArg );
       QString query = url.query();
-      
+
       // Extract word from URL (remove scheme and parse path/host)
       result->word = url.authority();
       if ( result->word.isEmpty() && !url.path().isEmpty() ) {
         result->word = url.path().remove( 0, 1 );
       }
-      
+
       // In microsoft Words, the / will be automatically appended
       if ( result->word.endsWith( "/" ) ) {
         result->word.chop( 1 );
       }
-      
+
       // Parse query parameters: target=popup or target=main
       if ( !query.isEmpty() ) {
         QUrlQuery urlQuery( query );
         QString targetParam = urlQuery.queryItemValue( "target" );
-        
+
         if ( targetParam == "popup" ) {
           result->window = "popup";
         }

--- a/src/main.cc
+++ b/src/main.cc
@@ -214,21 +214,49 @@ void processCommandLine( QCoreApplication * app, GDOptions * result )
 
   const QStringList posArgs = qcmd.positionalArguments();
   if ( !posArgs.empty() ) {
-    result->word = posArgs.at( 0 );
+    QString originalArg = posArgs.at( 0 );
 
 #if defined( Q_OS_LINUX ) || defined( Q_OS_WIN )
     // handle url scheme like "goldendict://" or "dict://" on windows/linux
-    auto schemePos = result->word.indexOf( "://" );
+    auto schemePos = originalArg.indexOf( "://" );
     if ( schemePos != -1 ) {
-      result->word.remove( 0, schemePos + 3 );
+      // Parse the full URL to extract query parameters
+      QUrl url( originalArg );
+      QString query = url.query();
+      
+      // Extract word from URL (remove scheme and parse path/host)
+      result->word = url.authority();
+      if ( result->word.isEmpty() && !url.path().isEmpty() ) {
+        result->word = url.path().remove( 0, 1 );
+      }
+      
       // In microsoft Words, the / will be automatically appended
       if ( result->word.endsWith( "/" ) ) {
         result->word.chop( 1 );
       }
+      
+      // Parse query parameters: target=popup or target=main
+      if ( !query.isEmpty() ) {
+        QUrlQuery urlQuery( query );
+        QString targetParam = urlQuery.queryItemValue( "target" );
+        
+        if ( targetParam == "popup" ) {
+          result->window = "popup";
+        }
+        else if ( targetParam == "main" ) {
+          result->window = "main";
+        }
+      }
+    }
+    else {
+      // Not a URL scheme, treat as plain word
+      result->word = originalArg;
     }
 
     // Handle cases where we get encoded URL
     result->word = Utils::Url::decodeUrlEncodedWord( result->word );
+#else
+    result->word = originalArg;
 #endif
   }
 }
@@ -554,7 +582,8 @@ int main( int argc, char ** argv )
       m.showTranslation( gdcl.wordToTranslate(), "popup" );
     }
     else {
-      m.wordReceived( gdcl.wordToTranslate() );
+      // Default to main window when target parameter is not specified or set to "main"
+      m.showTranslation( gdcl.wordToTranslate(), "main" );
     }
   }
 

--- a/website/docs/topic_anki.md
+++ b/website/docs/topic_anki.md
@@ -61,3 +61,23 @@ On your Anki card's template, you can add the code below to create a "1-click op
 ```html
 <a href="goldendict://{{Front}}">{{Front}}</a>
 ```
+
+### Opening in Popup Window（supported specify target parameter at 2026-5-28）
+
+You can specify where to display the translation by adding the `target` parameter:
+
+```html
+<!-- Open in popup window -->
+<a href="goldendict://{{Front}}?target=popup">{{Front}}</a>
+
+<!-- Open in main window -->
+<a href="goldendict://{{Front}}?target=main">{{Front}}</a>
+```
+
+**Supported target values:**
+- `popup` - Display in scan popup window
+- `main` - Display in main window (default if no parameter specified)
+
+**Note for Linux/Wayland users:** The popup window feature may not work properly on some Wayland-based systems due to platform limitations. If you experience issues with `target=popup`, use `target=main` instead or configure GoldenDict to use X11 compatibility mode.
+
+This is useful for quick vocabulary lookup without leaving your current context.


### PR DESCRIPTION
- Add 'target' query parameter to control translation display location
- Support 'target=popup' for scan popup window
- Support 'target=main' for main window (default when no parameter)

Examples:
- goldendict://word?target=popup    # Open in popup
- goldendict://word?target=main     # Open in main window
- goldendict://word                 # Default: main window
