### PR TITLE
Improve FTS phrase highlighting with Mark.js options

### DIFF
--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -2297,11 +2297,17 @@ void ArticleView::highlightFTSResults()
     accuracy = "partially";
   }
 
-  QString script = QString(
-                     "var context = document.querySelector(\"body\");\n"
-                     "var instance = new Mark(context);\n instance.unmark();\n"
-                     "instance.mark(\"%1\",{\"accuracy\": \"%2\"});" )
-                     .arg( regString, accuracy );
+  QString script = QString::fromUtf8( R"JS(
+    var context = document.querySelector("body");
+    var instance = new Mark(context);
+    instance.unmark();
+    instance.mark("%1", {
+      "accuracy": "%2",
+      "separateWordSearch": false,
+      "acrossElements": true,
+      "caseSensitive": false
+    });
+  )JS" ).arg( regString, accuracy );
 
   webview->page()->runJavaScript( script );
   auto parts = regString.split( " ", Qt::SkipEmptyParts );

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -2307,7 +2307,8 @@ void ArticleView::highlightFTSResults()
       "acrossElements": true,
       "caseSensitive": false
     });
-  )JS" ).arg( regString, accuracy );
+  )JS" )
+                     .arg( regString, accuracy );
 
   webview->page()->runJavaScript( script );
   auto parts = regString.split( " ", Qt::SkipEmptyParts );


### PR DESCRIPTION
## Changes

- Added `separateWordSearch: false` to ensure phrase matching instead of individual word matching
- Added `acrossElements: true` to support matching across HTML element boundaries  
- Added `caseSensitive: false` for case-insensitive highlighting
- Converted JavaScript string to C++ raw string literal for better readability

## Impact

This improves the full-text search highlighting behavior to properly match phrases like "next to" as a complete unit rather than separate words, and handles cases where text is split across HTML elements.