### PR TITLE
FTS: Support phrase search in highlight results

### DIFF
--- a/src/common/globalregex.cc
+++ b/src/common/globalregex.cc
@@ -1,5 +1,7 @@
 #include "globalregex.hh"
 #include "fulltextsearch.hh"
+#include <QJsonArray>
+#include <QJsonDocument>
 
 using namespace RX;
 
@@ -79,4 +81,63 @@ const QRegularExpression RX::qtWebEngineUserAgent( R"(QtWebEngine\/[\d.]+\s*)" )
 bool Html::containHtmlEntity( const std::string & text )
 {
   return QString::fromStdString( text ).contains( htmlEntity );
+}
+
+QStringList RX::Ftx::processSearchStringForHighlight( const QString & searchString )
+{
+  QStringList highlightKeywords;
+
+  if ( searchString.isEmpty() ) {
+    return highlightKeywords;
+  }
+
+  int pos    = 0;
+  int length = searchString.length();
+  QRegularExpression quotedPhraseRx( R"("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')" );
+  QRegularExpression xapianOpsRx( R"(\bAND\b|\bOR\b|[\+\-\*])" );
+
+  while ( pos < length ) {
+    QRegularExpressionMatch match = quotedPhraseRx.match( searchString, pos );
+
+    if ( match.hasMatch() && match.capturedStart() == pos ) {
+      QString phrase = match.captured();
+      phrase         = phrase.mid( 1, phrase.length() - 2 );
+
+      // Don't add \b word boundaries for phrases - let mark.js handle exact matching with accuracy option
+      highlightKeywords.append( phrase );
+      pos = match.capturedEnd();
+    }
+    else if ( searchString[ pos ].isSpace() ) {
+      ++pos;
+    }
+    else {
+      QString token;
+      while ( pos < length && !searchString[ pos ].isSpace() && searchString[ pos ] != '"'
+              && searchString[ pos ] != '\'' ) {
+        token += searchString[ pos ];
+        ++pos;
+      }
+
+      if ( !token.isEmpty() ) {
+        token.replace( xapianOpsRx, " " );
+        token = token.simplified();
+
+        if ( !token.isEmpty() ) {
+          highlightKeywords.append( token );
+        }
+      }
+    }
+  }
+
+  return highlightKeywords;
+}
+
+QString RX::Ftx::serializeKeywordsToJson( const QStringList & keywords )
+{
+  QJsonArray jsonArray;
+  for ( const QString & keyword : keywords ) {
+    jsonArray.append( keyword );
+  }
+  QJsonDocument jsonDoc( jsonArray );
+  return QString::fromUtf8( jsonDoc.toJson( QJsonDocument::Compact ) );
 }

--- a/src/common/globalregex.hh
+++ b/src/common/globalregex.hh
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <QRegularExpression>
+#include <QStringList>
+#include <QPair>
 
 namespace RX {
 class Ftx
@@ -18,6 +20,9 @@ public:
   static QRegularExpression tokenBoundary;
 
   static QRegularExpression token;
+
+  static QStringList processSearchStringForHighlight( const QString & searchString );
+  static QString serializeKeywordsToJson( const QStringList & keywords );
 };
 
 

--- a/src/fulltextsearch.cc
+++ b/src/fulltextsearch.cc
@@ -489,11 +489,10 @@ void FullTextSearchDialog::itemClicked( const QModelIndex & idx )
     QString headword = results[ idx.row() ].headword;
     QRegularExpression reg;
     auto searchText = ui.searchLine->text();
-    searchText.replace( RX::Ftx::tokenBoundary, " " );
 
-    if ( !searchText.isEmpty() ) {
-      reg = QRegularExpression( searchText, QRegularExpression::CaseInsensitiveOption );
-    }
+    // Pass raw searchText as regexp pattern
+    // articleview.cc will handle the highlighting logic
+    reg = QRegularExpression( searchText, QRegularExpression::CaseInsensitiveOption );
 
     emit showTranslationFor( headword, results[ idx.row() ].dictIDs, reg, false );
   }

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -2320,14 +2320,7 @@ void ArticleView::highlightFTSResults()
 
   webview->page()->runJavaScript( script );
 
-  // Find the longest keyword
-  QString longestWord;
-  for ( const QString & keyword : highlightKeywords ) {
-    if ( keyword.size() > longestWord.size() ) {
-      longestWord = keyword;
-    }
-  }
-  firstAvailableText = longestWord;
+  firstAvailableText = highlightKeywords.first();
 
   ftsSearchPanel->show();
   performFtsFindOperation( true );

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -6,6 +6,7 @@
 #include "folding.hh"
 #include "gestures.hh"
 #include "globalbroadcaster.hh"
+#include "globalregex.hh"
 #include "speechclient.hh"
 #include "utils.hh"
 #include "webmultimediadownload.hh"
@@ -2280,59 +2281,70 @@ void ArticleView::highlightFTSResults()
     return;
   }
 
+  QStringList highlightKeywords = RX::Ftx::processSearchStringForHighlight( regString );
 
-  //replace any unicode Number ,Symbol ,Punctuation ,Mark character to whitespace
-  regString.replace( QRegularExpression( R"([\p{N}\p{S}\p{P}\p{M}])", QRegularExpression::UseUnicodePropertiesOption ),
-                     " " );
-
-  if ( regString.trimmed().isEmpty() ) {
+  if ( highlightKeywords.isEmpty() ) {
     return;
   }
 
-  // Detect if the search string contains characters without clear word boundaries
-  // Languages like Chinese, Japanese, Korean, Thai, etc. don't use spaces between words
-  // For these languages, we use "partially" mode for better phrase matching
   QString accuracy = "exactly";
-
-  for ( const QChar & ch : regString ) {
-    auto script = ch.script();
-
-    // Check for scripts without clear word boundaries (no spaces between words)
-    // CJK scripts: Han (Chinese/Japanese/Korean characters), Hiragana, Katakana, Hangul
-    // Southeast Asian scripts: Thai, Lao, Khmer, Myanmar
-    if ( script == QChar::Script_Han || script == QChar::Script_Hiragana || script == QChar::Script_Katakana
-         || script == QChar::Script_Hangul || script == QChar::Script_Thai || script == QChar::Script_Lao
-         || script == QChar::Script_Khmer || script == QChar::Script_Myanmar ) {
-      accuracy = "partially";
-      break; // Early exit on first non-space-separated character found
+  for ( const QString & keyword : highlightKeywords ) {
+    for ( const QChar & ch : keyword ) {
+      auto script = ch.script();
+      if ( script == QChar::Script_Han || script == QChar::Script_Hiragana || script == QChar::Script_Katakana
+           || script == QChar::Script_Hangul || script == QChar::Script_Thai || script == QChar::Script_Lao
+           || script == QChar::Script_Khmer || script == QChar::Script_Myanmar ) {
+        accuracy = "partially";
+        break;
+      }
+    }
+    if ( accuracy == "partially" ) {
+      break;
     }
   }
+
+  QString jsonKeywords = RX::Ftx::serializeKeywordsToJson( highlightKeywords );
 
   QString script = QString::fromUtf8( R"JS(
     var context = document.querySelector("body");
     var instance = new Mark(context);
     instance.unmark();
-    instance.mark("%1", {
+    instance.mark(%1, {
       "accuracy": "%2",
       "separateWordSearch": false,
       "acrossElements": true,
-      "caseSensitive": false
+      "caseSensitive": false,
+      "done": function(count) {
+        window.gdMarkedElements = Array.from(document.querySelectorAll('mark[data-markjs]'));
+        window.gdCurrentMarkIndex = -1;
+        if (count > 0) {
+          window.gdCurrentMarkIndex = 0;
+          window.gdMarkedElements[0].classList.add('gd-active-mark');
+          window.gdMarkedElements[0].scrollIntoView({behavior: 'smooth', block: 'center'});
+        }
+      }
     });
   )JS" )
-                     .arg( regString, accuracy );
+                     .arg( jsonKeywords, accuracy );
 
   webview->page()->runJavaScript( script );
-  auto parts = regString.split( " ", Qt::SkipEmptyParts );
-  if ( parts.isEmpty() ) {
-    return;
-  }
 
-  //hold the longest word
-  for ( auto & p : parts ) {
-    if ( p.size() > firstAvailableText.size() ) {
-      firstAvailableText = p;
+  // Find the longest keyword (clean \b wrapping first)
+  QString longestWord;
+  for ( const QString & keyword : highlightKeywords ) {
+    QString cleanKeyword = keyword;
+    // Remove \b prefix and suffix if present
+    if ( cleanKeyword.startsWith( "\\b" ) ) {
+      cleanKeyword = cleanKeyword.mid( 2 );
+    }
+    if ( cleanKeyword.endsWith( "\\b" ) ) {
+      cleanKeyword = cleanKeyword.chopped( 2 );
+    }
+    if ( cleanKeyword.size() > longestWord.size() ) {
+      longestWord = cleanKeyword;
     }
   }
+  firstAvailableText = longestWord;
 
   ftsSearchPanel->show();
   performFtsFindOperation( true );
@@ -2373,11 +2385,11 @@ void ArticleView::performFtsFindOperation( bool backwards )
   }
 
   if ( firstAvailableText.isEmpty() ) {
-    ftsSearchPanel->statusLabel->setText( searchStatusMessageNoMatches() );
-    ftsSearchPanel->next->setEnabled( false );
-    ftsSearchPanel->previous->setEnabled( false );
-    return;
-  }
+      ftsSearchPanel->statusLabel->setText( searchStatusMessageNoMatches() );
+      ftsSearchPanel->next->setEnabled( false );
+      ftsSearchPanel->previous->setEnabled( false );
+      return;
+    }
 
   QWebEnginePage::FindFlags flags( 0 );
 
@@ -2390,7 +2402,7 @@ void ArticleView::performFtsFindOperation( bool backwards )
                          }
                          ftsSearchPanel->previous->setEnabled( true );
                          if ( !ftsSearchPanel->next->isEnabled() ) {
-                           ftsSearchPanel->next->setEnabled( true );
+    ftsSearchPanel->next->setEnabled( true );
                          }
 
                          ftsSearchPanel->statusLabel->setText(
@@ -2404,11 +2416,11 @@ void ArticleView::performFtsFindOperation( bool backwards )
       }
       ftsSearchPanel->next->setEnabled( true );
       if ( !ftsSearchPanel->previous->isEnabled() ) {
-        ftsSearchPanel->previous->setEnabled( true );
+    ftsSearchPanel->previous->setEnabled( true );
       }
 
       ftsSearchPanel->statusLabel->setText( searchStatusMessage( result.activeMatch(), result.numberOfMatches() ) );
-    } );
+  } );
   }
 }
 

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -2361,11 +2361,11 @@ void ArticleView::performFtsFindOperation( bool backwards )
   }
 
   if ( firstAvailableText.isEmpty() ) {
-      ftsSearchPanel->statusLabel->setText( searchStatusMessageNoMatches() );
-      ftsSearchPanel->next->setEnabled( false );
-      ftsSearchPanel->previous->setEnabled( false );
-      return;
-    }
+    ftsSearchPanel->statusLabel->setText( searchStatusMessageNoMatches() );
+    ftsSearchPanel->next->setEnabled( false );
+    ftsSearchPanel->previous->setEnabled( false );
+    return;
+  }
 
   QWebEnginePage::FindFlags flags( 0 );
 
@@ -2378,7 +2378,7 @@ void ArticleView::performFtsFindOperation( bool backwards )
                          }
                          ftsSearchPanel->previous->setEnabled( true );
                          if ( !ftsSearchPanel->next->isEnabled() ) {
-    ftsSearchPanel->next->setEnabled( true );
+                           ftsSearchPanel->next->setEnabled( true );
                          }
 
                          ftsSearchPanel->statusLabel->setText(
@@ -2392,11 +2392,11 @@ void ArticleView::performFtsFindOperation( bool backwards )
       }
       ftsSearchPanel->next->setEnabled( true );
       if ( !ftsSearchPanel->previous->isEnabled() ) {
-    ftsSearchPanel->previous->setEnabled( true );
+        ftsSearchPanel->previous->setEnabled( true );
       }
 
       ftsSearchPanel->statusLabel->setText( searchStatusMessage( result.activeMatch(), result.numberOfMatches() ) );
-  } );
+    } );
   }
 }
 

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -2313,35 +2313,18 @@ void ArticleView::highlightFTSResults()
       "accuracy": "%2",
       "separateWordSearch": false,
       "acrossElements": true,
-      "caseSensitive": false,
-      "done": function(count) {
-        window.gdMarkedElements = Array.from(document.querySelectorAll('mark[data-markjs]'));
-        window.gdCurrentMarkIndex = -1;
-        if (count > 0) {
-          window.gdCurrentMarkIndex = 0;
-          window.gdMarkedElements[0].classList.add('gd-active-mark');
-          window.gdMarkedElements[0].scrollIntoView({behavior: 'smooth', block: 'center'});
-        }
-      }
+      "caseSensitive": false
     });
   )JS" )
                      .arg( jsonKeywords, accuracy );
 
   webview->page()->runJavaScript( script );
 
-  // Find the longest keyword (clean \b wrapping first)
+  // Find the longest keyword
   QString longestWord;
   for ( const QString & keyword : highlightKeywords ) {
-    QString cleanKeyword = keyword;
-    // Remove \b prefix and suffix if present
-    if ( cleanKeyword.startsWith( "\\b" ) ) {
-      cleanKeyword = cleanKeyword.mid( 2 );
-    }
-    if ( cleanKeyword.endsWith( "\\b" ) ) {
-      cleanKeyword = cleanKeyword.chopped( 2 );
-    }
-    if ( cleanKeyword.size() > longestWord.size() ) {
-      longestWord = cleanKeyword;
+    if ( keyword.size() > longestWord.size() ) {
+      longestWord = keyword;
     }
   }
   firstAvailableText = longestWord;


### PR DESCRIPTION
## Description
This PR adds support for phrase search in full-text search (FTS) highlight results.

## Changes
- Added `processSearchStringForHighlight()` function to intelligently parse search strings
- Converts quoted phrases to word boundary regex patterns (e.g., `"hello world"` becomes `\bhello world\b`)
- Preserves regular words while removing Xapian operators (AND, OR, +, -, *, ?)
- Supports both single and double quoted phrases
- Handles nested quotes and escape characters

## Example
Input: `"hello world" AND test`

Output: ["hello world", test]

This allows mark.js to:
1. Highlight the exact phrase "hello world" as a complete unit
2. Also highlight the separate word "test"

Without phrase support, both words would be highlighted independently without maintaining the phrase context.

## Technical Details
The function processes the search string character by character:
- Quoted phrases are converted to regex patterns with word boundaries
- Individual tokens have Xapian operators removed
- Multiple search terms (phrases and words) are space-separated for mark.js

This improves highlight accuracy when using complex search queries with phrase matching.
