### PR TITLE
Remove unused matchcase parameter and simplify searchRegExp type

### DIFF
--- a/src/fulltextsearch.cc
+++ b/src/fulltextsearch.cc
@@ -487,14 +487,11 @@ void FullTextSearchDialog::itemClicked( const QModelIndex & idx )
 {
   if ( idx.isValid() && idx.row() < results.size() ) {
     QString headword = results[ idx.row() ].headword;
-    QRegularExpression reg;
     auto searchText = ui.searchLine->text();
 
     // Pass raw searchText as regexp pattern
     // articleview.cc will handle the highlighting logic
-    reg = QRegularExpression( searchText, QRegularExpression::CaseInsensitiveOption );
-
-    emit showTranslationFor( headword, results[ idx.row() ].dictIDs, reg, false );
+    emit showTranslationFor( headword, results[ idx.row() ].dictIDs, searchText, false );
   }
 }
 

--- a/src/fulltextsearch.hh
+++ b/src/fulltextsearch.hh
@@ -237,7 +237,7 @@ private slots:
 signals:
   void showTranslationFor( const QString &,
                            const QStringList & dictIDs,
-                           const QRegularExpression & searchRegExp,
+                           const QString & searchRegExp,
                            bool ignoreDiacritics );
   void closeDialog();
 

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -371,7 +371,7 @@ void ArticleView::showDefinition( const QString & word,
 
 void ArticleView::showDefinition( const QString & word,
                                   const QStringList & dictIDs,
-                                  const QRegularExpression & searchRegExp,
+                                  const QString & searchRegExp,
                                   unsigned group,
                                   bool ignoreDiacritics )
 {
@@ -400,12 +400,7 @@ void ArticleView::showDefinition( const QString & word,
 
   reqQuery.addQueryItem( "word", word );
   reqQuery.addQueryItem( "dictionaries", dictIDs.join( "," ) );
-  reqQuery.addQueryItem( "regexp", searchRegExp.pattern() );
-  if ( !searchRegExp.patternOptions().testFlag( QRegularExpression::CaseInsensitiveOption ) ) {
-    reqQuery.addQueryItem( "matchcase", "1" );
-  }
-  //  if ( searchRegExp.patternSyntax() == QRegExp::WildcardUnix )
-  //    Utils::Url::addQueryItem( req, "wildcards", "1" );
+  reqQuery.addQueryItem( "regexp", searchRegExp );
   reqQuery.addQueryItem( "group", QString::number( group ) );
   if ( ignoreDiacritics ) {
     reqQuery.addQueryItem( "ignore_diacritics", "1" );

--- a/src/ui/articleview.hh
+++ b/src/ui/articleview.hh
@@ -136,7 +136,7 @@ public:
 
   void showDefinition( const QString & word,
                        const QStringList & dictIDs,
-                       const QRegularExpression & searchRegExp,
+                       const QString & searchRegExp,
                        unsigned group,
                        bool ignoreDiacritics );
   void showDefinition( const QString & word, const QStringList & dictIDs, unsigned group, bool ignoreDiacritics );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -3087,7 +3087,7 @@ void MainWindow::showTranslationFor( const QString & word, unsigned inGroup, con
 
 void MainWindow::showTranslationForDicts( const QString & inWord,
                                           const QStringList & dictIDs,
-                                          const QRegularExpression & searchRegExp,
+                                          const QString & searchRegExp,
                                           bool ignoreDiacritics )
 {
   ArticleView * view = getFirstNonWebSiteArticleView();

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -403,7 +403,7 @@ private slots:
 
   void showTranslationForDicts( const QString &,
                                 const QStringList & dictIDs,
-                                const QRegularExpression & searchRegExp,
+                                const QString & searchRegExp,
                                 bool ignoreDiacritics );
 
   void showHistoryItem( const QString & );


### PR DESCRIPTION
This PR removes the unused matchcase parameter and simplifies the searchRegExp type from QRegularExpression to QString.

**Changes:**
1. Remove unused matchcase parameter from articleview.cc (line 404-406)
2. Change searchRegExp parameter type from QRegularExpression to QString in:
   - fulltextsearch.hh
   - fulltextsearch.cc
   - mainwindow.hh
   - mainwindow.cc
   - articleview.hh
   - articleview.cc

The QRegularExpression was only used to extract the pattern string, so changing it to QString simplifies the code without losing functionality.