### PR TITLE
fix: show splash screen when mainwindow is still hidden

### DIFF
--- a/src/dict/loaddictionaries.cc
+++ b/src/dict/loaddictionaries.cc
@@ -226,7 +226,7 @@ void loadDictionaries( QWidget * parent,
 
   bool showSplashWindow = !cfg.preferences.enableTrayIcon || !cfg.preferences.startToTray;
   // Start a thread to load all the dictionaries
-  ::Initializing init( parent, showSplashWindow );
+  ::Initializing init( nullptr, showSplashWindow );
 
   LoadDictionaries loadDicts( cfg );
 


### PR DESCRIPTION
Pass nullptr as parent to Initializing dialog to allow it to show when MainWindow is hidden during initialization.