### PR TITLE
fix: resolve Scan Popup not triggered with multiple modifier keys

### DIFF
--- a/src/keyboardstate.cc
+++ b/src/keyboardstate.cc
@@ -8,8 +8,8 @@
 bool KeyboardState::checkModifiersPressed( int mask )
 {
   auto modifiers = QApplication::queryKeyboardModifiers();
-  return modifiers.testFlags( { ( mask & Alt ? Qt::AltModifier : Qt::NoModifier )
-                                | ( mask & Win ? Qt::MetaModifier : Qt::NoModifier )
-                                | ( mask & Ctrl ? Qt::ControlModifier : Qt::NoModifier )
-                                | ( mask & Shift ? Qt::ShiftModifier : Qt::NoModifier ) } );
+  return modifiers.testFlags( ( mask & Alt ? Qt::AltModifier : Qt::NoModifier )
+                              | ( mask & Win ? Qt::MetaModifier : Qt::NoModifier )
+                              | ( mask & Ctrl ? Qt::ControlModifier : Qt::NoModifier )
+                              | ( mask & Shift ? Qt::ShiftModifier : Qt::NoModifier ) );
 }


### PR DESCRIPTION
## Summary

Fixes an issue where Scan Popup fails to trigger when multiple modifier keys are configured (e.g., Ctrl+Shift).

## Problem

The `checkModifiersPressed` function in `src/keyboardstate.cc` used brace initialization with `testFlags()`:

```cpp
return modifiers.testFlags( { expression | expression | expression } );
```

This caused type mismatches when multiple modifier keys were checked, making the function return false even when all required modifiers were pressed.

## Solution

Removed the brace initialization to allow proper bitwise operations:

```cpp
return modifiers.testFlags( expression | expression | expression );
```

## Testing

- Single modifier key: Ctrl ✓
- Single modifier key: Shift ✓
- Multiple modifier keys: Ctrl+Shift ✓

## Files Changed

- `src/keyboardstate.cc`: Fixed `checkModifiersPressed` function