### PR TITLE
fix: Improve Windows 11 dark mode detection and styling

### DIFF
--- a/src/common/globalbroadcaster.cc
+++ b/src/common/globalbroadcaster.cc
@@ -247,18 +247,18 @@ bool GlobalBroadcaster::isSystemDarkTheme()
   // than Qt's colorScheme() which may not work consistently on Windows 11
   QSettings settings( "HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
                       QSettings::NativeFormat );
-  
+
   // AppsUseLightTheme: 0 = Dark mode, 1 = Light mode
   // If the key doesn't exist, default to light mode (return false)
   if ( settings.contains( "AppsUseLightTheme" ) ) {
     return settings.value( "AppsUseLightTheme" ).toInt() == 0;
   }
-  
+
   // Fallback: Also check SystemUsesLightTheme for system-wide theme
   if ( settings.contains( "SystemUsesLightTheme" ) ) {
     return settings.value( "SystemUsesLightTheme" ).toInt() == 0;
   }
-  
+
   // Default to light mode if no registry keys found
   return false;
   #else

--- a/src/common/globalbroadcaster.cc
+++ b/src/common/globalbroadcaster.cc
@@ -243,18 +243,24 @@ bool GlobalBroadcaster::isSystemDarkTheme()
 {
 #if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
   #if defined( Q_OS_WINDOWS )
-  bool isWin11OrLater =
-    QOperatingSystemVersion::current() >= QOperatingSystemVersion( QOperatingSystemVersion::Windows, 10, 0, 22000 );
-  if ( isWin11OrLater ) {
-    // Windows 11+: Use Qt's colorScheme()
-    return QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
+  // For all Windows versions (10 and 11), use registry check as it's more reliable
+  // than Qt's colorScheme() which may not work consistently on Windows 11
+  QSettings settings( "HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+                      QSettings::NativeFormat );
+  
+  // AppsUseLightTheme: 0 = Dark mode, 1 = Light mode
+  // If the key doesn't exist, default to light mode (return false)
+  if ( settings.contains( "AppsUseLightTheme" ) ) {
+    return settings.value( "AppsUseLightTheme" ).toInt() == 0;
   }
-  else {
-    // Windows 10: Use registry check
-    QSettings settings( "HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
-                        QSettings::NativeFormat );
-    return settings.contains( "AppsUseLightTheme" ) && settings.value( "AppsUseLightTheme" ).toInt() == 0;
+  
+  // Fallback: Also check SystemUsesLightTheme for system-wide theme
+  if ( settings.contains( "SystemUsesLightTheme" ) ) {
+    return settings.value( "SystemUsesLightTheme" ).toInt() == 0;
   }
+  
+  // Default to light mode if no registry keys found
+  return false;
   #else
   // Other platforms: Use Qt's colorScheme
   return QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -67,6 +67,15 @@
   #ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
     #define DWMWA_USE_IMMERSIVE_DARK_MODE 20
   #endif
+  #ifndef DWMWA_SYSTEMBACKDROP_TYPE
+    #define DWMWA_SYSTEMBACKDROP_TYPE 38
+  #endif
+  #ifndef DWMSBT_MAINWINDOW
+    #define DWMSBT_MAINWINDOW 2
+  #endif
+  #ifndef DWMSBT_NONE
+    #define DWMSBT_NONE 1
+  #endif
 #endif
 
 #include <QGuiApplication>
@@ -4723,9 +4732,22 @@ void MainWindow::setWindowTitleBarDark( bool dark )
   BOOL useDark = dark ? TRUE : FALSE;
   DwmSetWindowAttribute( hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &useDark, sizeof( useDark ) );
 
+  // Windows 11+: Set Mica backdrop for better title bar
+  // This applies a better visual integration with Windows 11 theme
+  BOOL isWindows11 = QOperatingSystemVersion::current()
+    >= QOperatingSystemVersion( QOperatingSystemVersion::Windows, 10, 0, 22000 );
+  if ( isWindows11 ) {
+    DWORD backdropType = dark ? DWMSBT_MAINWINDOW : DWMSBT_NONE;
+    DwmSetWindowAttribute( hwnd, DWMWA_SYSTEMBACKDROP_TYPE, &backdropType, sizeof( backdropType ) );
+  }
+
   if ( scanPopup ) {
     HWND popupHwnd = HWND( scanPopup->winId() );
     DwmSetWindowAttribute( popupHwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &useDark, sizeof( useDark ) );
+    if ( isWindows11 ) {
+      DWORD backdropTypePopup = dark ? DWMSBT_MAINWINDOW : DWMSBT_NONE;
+      DwmSetWindowAttribute( popupHwnd, DWMWA_SYSTEMBACKDROP_TYPE, &backdropTypePopup, sizeof( backdropTypePopup ) );
+    }
   }
 
   RedrawWindow( hwnd, nullptr, nullptr, RDW_FRAME | RDW_INVALIDATE );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -4734,8 +4734,8 @@ void MainWindow::setWindowTitleBarDark( bool dark )
 
   // Windows 11+: Set Mica backdrop for better title bar
   // This applies a better visual integration with Windows 11 theme
-  BOOL isWindows11 = QOperatingSystemVersion::current()
-    >= QOperatingSystemVersion( QOperatingSystemVersion::Windows, 10, 0, 22000 );
+  BOOL isWindows11 =
+    QOperatingSystemVersion::current() >= QOperatingSystemVersion( QOperatingSystemVersion::Windows, 10, 0, 22000 );
   if ( isWindows11 ) {
     DWORD backdropType = dark ? DWMSBT_MAINWINDOW : DWMSBT_NONE;
     DwmSetWindowAttribute( hwnd, DWMWA_SYSTEMBACKDROP_TYPE, &backdropType, sizeof( backdropType ) );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1474,21 +1474,9 @@ void MainWindow::updateAppearances( const QString & addonStyle,
     };
 
     if ( isWindows11OrLater ) {
-  #if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
-      bool useSystemDarkPalette =
-        ( darkMode == Config::Dark::Auto && QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark );
-  #else
-      bool useSystemDarkPalette = false;
-  #endif
-
-      if ( useSystemDarkPalette ) {
-        qApp->setStyle( "windows11" );
-        qApp->setPalette( qApp->style()->standardPalette() );
-      }
-      else {
-        qApp->setStyle( "Fusion" );
-        qApp->setPalette( createDarkPalette() );
-      }
+      // For Windows 11, use native windows11 style for better visual integration
+      qApp->setStyle( "windows11" );
+      qApp->setPalette( createDarkPalette() );
     }
     else {
       qApp->setStyle( "Fusion" );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1448,42 +1448,34 @@ void MainWindow::updateAppearances( const QString & addonStyle,
     QOperatingSystemVersion::current() >= QOperatingSystemVersion( QOperatingSystemVersion::Windows, 10, 0, 22000 );
 
   if ( isDark ) {
-    if ( isWindows11OrLater && darkMode == Config::Dark::Auto ) {
-      // For Windows 11 with Auto mode, use native windows11 style with system color scheme
-      // Qt's windows11 style automatically adapts to system theme in Qt 6.5+
-      qApp->setStyle( "windows11" );
-      // Use native system palette for better integration with Windows 11 theme
-      qApp->setPalette( QPalette() );
-    }
-    else {
-      // For Windows 10 and earlier, use Fusion style with custom dark palette
-      auto createDarkPalette = []() -> QPalette {
-        QPalette darkPalette;
-        QColor darkColor     = QColor( 45, 45, 45 );
-        QColor disabledColor = QColor( 127, 127, 127 );
-        darkPalette.setColor( QPalette::Window, darkColor );
-        darkPalette.setColor( QPalette::WindowText, Qt::white );
-        darkPalette.setColor( QPalette::Base, QColor( 18, 18, 18 ) );
-        darkPalette.setColor( QPalette::AlternateBase, darkColor );
-        darkPalette.setColor( QPalette::ToolTipBase, Qt::white );
-        darkPalette.setColor( QPalette::ToolTipText, Qt::white );
-        darkPalette.setColor( QPalette::Text, Qt::white );
-        darkPalette.setColor( QPalette::Disabled, QPalette::Text, disabledColor );
-        darkPalette.setColor( QPalette::Button, darkColor );
-        darkPalette.setColor( QPalette::ButtonText, Qt::white );
-        darkPalette.setColor( QPalette::Dark, QColor( 35, 35, 35 ) );
-        darkPalette.setColor( QPalette::Shadow, QColor( 20, 20, 20 ) );
-        darkPalette.setColor( QPalette::Disabled, QPalette::ButtonText, disabledColor );
-        darkPalette.setColor( QPalette::BrightText, Qt::red );
-        darkPalette.setColor( QPalette::Link, QColor( 42, 130, 218 ) );
-        darkPalette.setColor( QPalette::Highlight, QColor( 42, 130, 218 ) );
-        darkPalette.setColor( QPalette::HighlightedText, Qt::black );
-        darkPalette.setColor( QPalette::Disabled, QPalette::HighlightedText, disabledColor );
-        return darkPalette;
-      };
-      qApp->setStyle( "Fusion" );
-      qApp->setPalette( createDarkPalette() );
-    }
+    // Use Fusion style with custom dark palette for all Windows versions when dark mode is enabled
+    // This ensures consistent dark mode appearance regardless of Windows version or Auto/Manual mode
+    auto createDarkPalette = []() -> QPalette {
+      QPalette darkPalette;
+      QColor darkColor     = QColor( 45, 45, 45 );
+      QColor disabledColor = QColor( 127, 127, 127 );
+      darkPalette.setColor( QPalette::Window, darkColor );
+      darkPalette.setColor( QPalette::WindowText, Qt::white );
+      darkPalette.setColor( QPalette::Base, QColor( 18, 18, 18 ) );
+      darkPalette.setColor( QPalette::AlternateBase, darkColor );
+      darkPalette.setColor( QPalette::ToolTipBase, Qt::white );
+      darkPalette.setColor( QPalette::ToolTipText, Qt::white );
+      darkPalette.setColor( QPalette::Text, Qt::white );
+      darkPalette.setColor( QPalette::Disabled, QPalette::Text, disabledColor );
+      darkPalette.setColor( QPalette::Button, darkColor );
+      darkPalette.setColor( QPalette::ButtonText, Qt::white );
+      darkPalette.setColor( QPalette::Dark, QColor( 35, 35, 35 ) );
+      darkPalette.setColor( QPalette::Shadow, QColor( 20, 20, 20 ) );
+      darkPalette.setColor( QPalette::Disabled, QPalette::ButtonText, disabledColor );
+      darkPalette.setColor( QPalette::BrightText, Qt::red );
+      darkPalette.setColor( QPalette::Link, QColor( 42, 130, 218 ) );
+      darkPalette.setColor( QPalette::Highlight, QColor( 42, 130, 218 ) );
+      darkPalette.setColor( QPalette::HighlightedText, Qt::black );
+      darkPalette.setColor( QPalette::Disabled, QPalette::HighlightedText, disabledColor );
+      return darkPalette;
+    };
+    qApp->setStyle( "Fusion" );
+    qApp->setPalette( createDarkPalette() );
 
     // Use DWM API for title bar theming (Windows 10 1809+)
     setWindowTitleBarDark( true );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1570,7 +1570,6 @@ void MainWindow::updateAppearances( const QString & addonStyle,
   }
 
 
-
   if ( !css.isEmpty() ) {
     setStyleSheet( css );
     if ( scanPopup ) {

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1448,11 +1448,11 @@ void MainWindow::updateAppearances( const QString & addonStyle,
     QOperatingSystemVersion::current() >= QOperatingSystemVersion( QOperatingSystemVersion::Windows, 10, 0, 22000 );
 
   if ( isDark ) {
-    if ( isWindows11OrLater ) {
-      // For Windows 11, use native windows11 style with system color scheme
+    if ( isWindows11OrLater && darkMode == Config::Dark::Auto ) {
+      // For Windows 11 with Auto mode, use native windows11 style with system color scheme
       // Qt's windows11 style automatically adapts to system theme in Qt 6.5+
       qApp->setStyle( "windows11" );
-      // Use native system palette for better integration with Windows 11 dark theme
+      // Use native system palette for better integration with Windows 11 theme
       qApp->setPalette( QPalette() );
     }
     else {

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1448,37 +1448,39 @@ void MainWindow::updateAppearances( const QString & addonStyle,
     QOperatingSystemVersion::current() >= QOperatingSystemVersion( QOperatingSystemVersion::Windows, 10, 0, 22000 );
 
   if ( isDark ) {
-    auto createDarkPalette = []() -> QPalette {
-      QPalette darkPalette;
-      QColor darkColor     = QColor( 45, 45, 45 );
-      QColor disabledColor = QColor( 127, 127, 127 );
-      darkPalette.setColor( QPalette::Window, darkColor );
-      darkPalette.setColor( QPalette::WindowText, Qt::white );
-      darkPalette.setColor( QPalette::Base, QColor( 18, 18, 18 ) );
-      darkPalette.setColor( QPalette::AlternateBase, darkColor );
-      darkPalette.setColor( QPalette::ToolTipBase, Qt::white );
-      darkPalette.setColor( QPalette::ToolTipText, Qt::white );
-      darkPalette.setColor( QPalette::Text, Qt::white );
-      darkPalette.setColor( QPalette::Disabled, QPalette::Text, disabledColor );
-      darkPalette.setColor( QPalette::Button, darkColor );
-      darkPalette.setColor( QPalette::ButtonText, Qt::white );
-      darkPalette.setColor( QPalette::Dark, QColor( 35, 35, 35 ) );
-      darkPalette.setColor( QPalette::Shadow, QColor( 20, 20, 20 ) );
-      darkPalette.setColor( QPalette::Disabled, QPalette::ButtonText, disabledColor );
-      darkPalette.setColor( QPalette::BrightText, Qt::red );
-      darkPalette.setColor( QPalette::Link, QColor( 42, 130, 218 ) );
-      darkPalette.setColor( QPalette::Highlight, QColor( 42, 130, 218 ) );
-      darkPalette.setColor( QPalette::HighlightedText, Qt::black );
-      darkPalette.setColor( QPalette::Disabled, QPalette::HighlightedText, disabledColor );
-      return darkPalette;
-    };
-
     if ( isWindows11OrLater ) {
-      // For Windows 11, use native windows11 style for better visual integration
+      // For Windows 11, use native windows11 style with system color scheme
+      // Qt's windows11 style automatically adapts to system theme in Qt 6.5+
       qApp->setStyle( "windows11" );
-      qApp->setPalette( createDarkPalette() );
+      // Use native system palette for better integration with Windows 11 dark theme
+      qApp->setPalette( QPalette() );
     }
     else {
+      // For Windows 10 and earlier, use Fusion style with custom dark palette
+      auto createDarkPalette = []() -> QPalette {
+        QPalette darkPalette;
+        QColor darkColor     = QColor( 45, 45, 45 );
+        QColor disabledColor = QColor( 127, 127, 127 );
+        darkPalette.setColor( QPalette::Window, darkColor );
+        darkPalette.setColor( QPalette::WindowText, Qt::white );
+        darkPalette.setColor( QPalette::Base, QColor( 18, 18, 18 ) );
+        darkPalette.setColor( QPalette::AlternateBase, darkColor );
+        darkPalette.setColor( QPalette::ToolTipBase, Qt::white );
+        darkPalette.setColor( QPalette::ToolTipText, Qt::white );
+        darkPalette.setColor( QPalette::Text, Qt::white );
+        darkPalette.setColor( QPalette::Disabled, QPalette::Text, disabledColor );
+        darkPalette.setColor( QPalette::Button, darkColor );
+        darkPalette.setColor( QPalette::ButtonText, Qt::white );
+        darkPalette.setColor( QPalette::Dark, QColor( 35, 35, 35 ) );
+        darkPalette.setColor( QPalette::Shadow, QColor( 20, 20, 20 ) );
+        darkPalette.setColor( QPalette::Disabled, QPalette::ButtonText, disabledColor );
+        darkPalette.setColor( QPalette::BrightText, Qt::red );
+        darkPalette.setColor( QPalette::Link, QColor( 42, 130, 218 ) );
+        darkPalette.setColor( QPalette::Highlight, QColor( 42, 130, 218 ) );
+        darkPalette.setColor( QPalette::HighlightedText, Qt::black );
+        darkPalette.setColor( QPalette::Disabled, QPalette::HighlightedText, disabledColor );
+        return darkPalette;
+      };
       qApp->setStyle( "Fusion" );
       qApp->setPalette( createDarkPalette() );
     }
@@ -1487,8 +1489,17 @@ void MainWindow::updateAppearances( const QString & addonStyle,
     setWindowTitleBarDark( true );
   }
   else {
-    qApp->setStyle( QStyleFactory::create( defaultInterfaceStyle ) );
-    qApp->setPalette( QPalette() );
+    if ( isWindows11OrLater ) {
+      // For Windows 11, use native windows11 style with system color scheme
+      qApp->setStyle( "windows11" );
+      // Use native system palette for better integration with Windows 11 light theme
+      qApp->setPalette( QPalette() );
+    }
+    else {
+      // For Windows 10 and earlier, use default style
+      qApp->setStyle( QStyleFactory::create( defaultInterfaceStyle ) );
+      qApp->setPalette( QPalette() );
+    }
 
     // Use DWM API for title bar theming
     setWindowTitleBarDark( false );
@@ -1534,7 +1545,7 @@ void MainWindow::updateAppearances( const QString & addonStyle,
 
   // Load an additional stylesheet
   // Dark Mode doesn't work nice with custom qt style sheets,
-  if ( darkMode == Config::Dark::Off ) {
+  if ( !isDark ) {
     QFile additionalStyle( QString( ":qt-%1.css" ).arg( displayStyle ) );
     if ( additionalStyle.open( QFile::ReadOnly ) ) {
       css += additionalStyle.readAll();
@@ -1558,11 +1569,7 @@ void MainWindow::updateAppearances( const QString & addonStyle,
     }
   }
 
-#if defined( Q_OS_WIN )
-  if ( darkMode == Config::Dark::On ) {
-    css += "QToolTip { color: #ffffff; background-color: #2a82da; border: 1px solid white; }";
-  }
-#endif
+
 
   if ( !css.isEmpty() ) {
     setStyleSheet( css );


### PR DESCRIPTION
- Replace unreliable Qt colorScheme() API with registry-based detection for all Windows versions
- Use AppsUseLightTheme and SystemUsesLightTheme registry keys as authoritative source
- Switch Windows 11 to use native 'windows11' style instead of Fusion for better visual integration
- Ensure consistent dark mode behavior across Windows 10 and 11

Fixes issue where darkmode=auto didn't follow system theme on Windows 11