### PR TITLE
fix: use vs action to set MSVC env

### DIFF
--- a/.github/workflows/Manual-Build-Action.yml
+++ b/.github/workflows/Manual-Build-Action.yml
@@ -122,12 +122,13 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+      - name: Setup MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.vs_arch }}
       - name: Build
         id: build
         run: |
-          # Launch-VsDevShell also provides Ninja
-          & 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1' `
-            -SkipAutomaticLocation -Arch ${{ matrix.vs_arch }} -HostArch amd64
           New-Item -Path './build_dir' -ItemType Directory
           
           # RelWithDebInfo + msvc's = .pdb file beside program file.

--- a/.github/workflows/PR-check-cmake.yml
+++ b/.github/workflows/PR-check-cmake.yml
@@ -137,12 +137,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+      - name: Setup MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
       - name: Run build
         run: |
-          # Launch-VsDevShell also provides Ninja
-          & 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1' `
-            -SkipAutomaticLocation -Arch amd64 -HostArch amd64
-
           New-Item -Path './build_dir' -ItemType Directory
           cmake -S . -B "./build_dir" `
             -G Ninja `

--- a/.github/workflows/Release-all.yml
+++ b/.github/workflows/Release-all.yml
@@ -124,12 +124,13 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+      - name: Setup MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.vs_arch }}
       - name: Build
         id: build
         run: |
-          # Launch-VsDevShell also provides Ninja
-          & 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1' `
-            -SkipAutomaticLocation -Arch ${{ matrix.vs_arch }} -HostArch amd64
           New-Item -Path './build_dir' -ItemType Directory
 
           # RelWithDebInfo + msvc's = .pdb file beside program file.

--- a/.github/workflows/Release-chaos.yml
+++ b/.github/workflows/Release-chaos.yml
@@ -122,11 +122,13 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+      - name: Setup MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.vs_arch }}
       - name: Build
         id: build
         run: |
-          & 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1' `
-            -SkipAutomaticLocation -Arch ${{ matrix.vs_arch }} -HostArch amd64
           New-Item -Path './build_dir' -ItemType Directory
 
           cmake -S . -B "./build_dir" `


### PR DESCRIPTION
Fix Windows build by using vswhere to dynamically locate Visual Studio installation path instead of hardcoded path