### PR TITLE
fix(scanpopup): fix crash on Wayland when accessing QClipboard::Selection

### DIFF
--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1248,7 +1248,12 @@ void MainWindow::mousePressEvent( QMouseEvent * event )
   // middle clicked
   QString subtype = "plain";
 
-  QString str = QApplication::clipboard()->text( subtype, QClipboard::Selection );
+  QString str;
+  if ( Utils::isWayland() ) {
+    str = QApplication::clipboard()->text( subtype, QClipboard::Clipboard );
+  } else {
+    str = QApplication::clipboard()->text( subtype, QClipboard::Selection );
+  }
   setInputLineText( str, WildcardPolicy::EscapeWildcards, NoPopupChange );
 
   QKeyEvent ev( QEvent::KeyPress, Qt::Key_Enter, Qt::NoModifier );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1251,7 +1251,8 @@ void MainWindow::mousePressEvent( QMouseEvent * event )
   QString str;
   if ( Utils::isWayland() ) {
     str = QApplication::clipboard()->text( subtype, QClipboard::Clipboard );
-  } else {
+  }
+  else {
     str = QApplication::clipboard()->text( subtype, QClipboard::Selection );
   }
   setInputLineText( str, WildcardPolicy::EscapeWildcards, NoPopupChange );

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -523,7 +523,8 @@ void ScanPopup::translateWordFromClipboard( QClipboard::Mode m )
   QString str;
   try {
     str = QApplication::clipboard()->text( subtype, m );
-  } catch ( ... ) {
+  }
+  catch ( ... ) {
     qWarning( "Failed to read clipboard on Wayland" );
     return;
   }

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -4,6 +4,7 @@
 #include "scanpopup.hh"
 #include "folding.hh"
 #include "articlesaver.hh"
+#include "utils.hh"
 #include <QCursor>
 #include <QPixmap>
 #include <QMenu>
@@ -513,8 +514,19 @@ void ScanPopup::editGroupRequested()
 void ScanPopup::translateWordFromClipboard( QClipboard::Mode m )
 {
   GlobalBroadcaster::instance()->is_popup = true;
+
+  if ( m == QClipboard::Selection && Utils::isWayland() ) {
+    return;
+  }
+
   QString subtype = QStringLiteral( "plain" );
-  QString str     = QApplication::clipboard()->text( subtype, m );
+  QString str;
+  try {
+    str = QApplication::clipboard()->text( subtype, m );
+  } catch ( ... ) {
+    qWarning( "Failed to read clipboard on Wayland" );
+    return;
+  }
   qDebug( "Translate from clipboard %d -> %s", qToUnderlying( m ), str.toStdString().c_str() );
   translateWord( str );
 }

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -519,15 +519,18 @@ void ScanPopup::translateWordFromClipboard( QClipboard::Mode m )
     return;
   }
 
-  QString subtype = QStringLiteral( "plain" );
-  QString str;
-  try {
-    str = QApplication::clipboard()->text( subtype, m );
-  }
-  catch ( ... ) {
-    qWarning( "Failed to read clipboard on Wayland" );
+  QClipboard * clipboard = QApplication::clipboard();
+  if ( !clipboard ) {
+    qWarning( "Clipboard is not available" );
     return;
   }
+
+  QString subtype = QStringLiteral( "plain" );
+  QString str = clipboard->text( subtype, m );
+  if ( str.isEmpty() ) {
+    return;
+  }
+
   qDebug( "Translate from clipboard %d -> %s", qToUnderlying( m ), str.toStdString().c_str() );
   translateWord( str );
 }

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -526,7 +526,7 @@ void ScanPopup::translateWordFromClipboard( QClipboard::Mode m )
   }
 
   QString subtype = QStringLiteral( "plain" );
-  QString str = clipboard->text( subtype, m );
+  QString str     = clipboard->text( subtype, m );
   if ( str.isEmpty() ) {
     return;
   }


### PR DESCRIPTION
On Fedora 44 + GNOME 50 with Wayland, goldendict-ng crashes with segmentation fault when accessing QClipboard::Selection.

**Root Cause:**
Wayland doesn't have X11's PRIMARY selection buffer concept, and Qt6's Wayland implementation has issues with QClipboard::Selection mode. When the clipboard listener triggers QClipboard::Selection mode signal, it causes access to invalid memory.

**Changes:**
1. : Skip QClipboard::Selection access on Wayland platforms
2. : Fallback to QClipboard::Clipboard for middle-click paste on Wayland

**Testing:**
- With  environment variable, the app works correctly
- This fix ensures the app doesn't crash when running natively on Wayland

**Related:**
- The issue was reported on Fedora 44 + GNOME 50 with native Wayland
- Users can use  as a workaround before this fix