### PR TITLE
perf(mdx): optimize filterResource by using pre-compiled regex patterns

### DIFF
--- a/src/common/globalregex.cc
+++ b/src/common/globalregex.cc
@@ -73,6 +73,14 @@ QRegularExpression Mdx::fontFace( R"((?:url\s*\(\s*\"(.*?)\"\s*)\))",
 QRegularExpression Mdx::styleElement( R"((<style[^>]*>)([\w\W]*?)(<\/style>))",
                                       QRegularExpression::CaseInsensitiveOption );
 
+QRegularExpression Mdx::protocolRelativeUrlQuoted( R"(([\s"'](?:src|href|data)\s*=\s*["'])\/\/)" );
+QRegularExpression Mdx::protocolRelativeUrlUnquoted( R"(([\s"'](?:src|href|data)\s*=\s*)(?!\s*["'])\/\/)" );
+QRegularExpression Mdx::htmlTagStart( "<html\\b", QRegularExpression::CaseInsensitiveOption );
+QRegularExpression Mdx::htmlTagEnd( "</html>", QRegularExpression::CaseInsensitiveOption );
+QRegularExpression Mdx::bodyTagStart( "<body\\b", QRegularExpression::CaseInsensitiveOption );
+QRegularExpression Mdx::bodyTagEnd( "</body>", QRegularExpression::CaseInsensitiveOption );
+QRegularExpression Mdx::headTagStart( "<head\\b", QRegularExpression::CaseInsensitiveOption );
+QRegularExpression Mdx::headTagEnd( "</head>", QRegularExpression::CaseInsensitiveOption );
 
 QRegularExpression Epwing::refWord( R"([r|p](\d+)at(\d+))", QRegularExpression::CaseInsensitiveOption );
 

--- a/src/common/globalregex.hh
+++ b/src/common/globalregex.hh
@@ -48,6 +48,15 @@ public:
   static QRegularExpression links;
   static QRegularExpression fontFace;
   static QRegularExpression styleElement;
+
+  static QRegularExpression protocolRelativeUrlQuoted;
+  static QRegularExpression protocolRelativeUrlUnquoted;
+  static QRegularExpression htmlTagStart;
+  static QRegularExpression htmlTagEnd;
+  static QRegularExpression bodyTagStart;
+  static QRegularExpression bodyTagEnd;
+  static QRegularExpression headTagStart;
+  static QRegularExpression headTagEnd;
 };
 
 namespace Zim {

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -917,20 +917,20 @@ QString & MdxDictionary::filterResource( QString & article )
 
   // Handle protocol-relative URLs (//) - Replace them with https://
   // This must be done before replaceLinks so they are seen as absolute URLs
-  article.replace( QRegularExpression( R"(([\s"'](?:src|href|data)\s*=\s*["'])\/\/)" ), R"(\1https://)" );
-  article.replace( QRegularExpression( R"(([\s"'](?:src|href|data)\s*=\s*)(?!\s*["'])\/\/)" ), R"(\1https://)" );
+  article.replace( RX::Mdx::protocolRelativeUrlQuoted, R"(\1https://)" );
+  article.replace( RX::Mdx::protocolRelativeUrlUnquoted, R"(\1https://)" );
 
   replaceLinks( id, article );
 
   // Replace html/body/head with custom tags to avoid hoisting by browser
-  article.replace( QRegularExpression( "<html\\b", QRegularExpression::CaseInsensitiveOption ), "<gd-section-html" );
-  article.replace( QRegularExpression( "</html>", QRegularExpression::CaseInsensitiveOption ), "</gd-section-html>" );
+  article.replace( RX::Mdx::htmlTagStart, "<gd-section-html" );
+  article.replace( RX::Mdx::htmlTagEnd, "</gd-section-html>" );
 
-  article.replace( QRegularExpression( "<body\\b", QRegularExpression::CaseInsensitiveOption ), "<gd-section-body" );
-  article.replace( QRegularExpression( "</body>", QRegularExpression::CaseInsensitiveOption ), "</gd-section-body>" );
+  article.replace( RX::Mdx::bodyTagStart, "<gd-section-body" );
+  article.replace( RX::Mdx::bodyTagEnd, "</gd-section-body>" );
 
-  article.replace( QRegularExpression( "<head\\b", QRegularExpression::CaseInsensitiveOption ), "<gd-section-head" );
-  article.replace( QRegularExpression( "</head>", QRegularExpression::CaseInsensitiveOption ), "</gd-section-head>" );
+  article.replace( RX::Mdx::headTagStart, "<gd-section-head" );
+  article.replace( RX::Mdx::headTagEnd, "</gd-section-head>" );
 
   replaceStyleInHtml( id, article );
   article = isolateStyleCssInHtml( article );


### PR DESCRIPTION
Move 6 dynamically created QRegularExpression objects in filterResource() to pre-compiled static members in RX::Mdx, eliminating repeated regex compilation overhead on every article processing.