### PR TITLE
fix(dict): Remove duplicate dataMutex to fix shadowing issue

### DIFF
--- a/src/dict/dictionary.hh
+++ b/src/dict/dictionary.hh
@@ -179,8 +179,6 @@ protected:
 
   // Subclasses should be filling up the 'matches' array, locking the mutex when
   // whey work with it.
-  QMutex dataMutex;
-
   vector< WordMatch > matches;
   bool uncertain;
 };


### PR DESCRIPTION
Remove duplicate QMutex dataMutex declaration in WordSearchRequest class that was shadowing the inherited dataMutex from Request base class. This ensures proper thread-safety across the class hierarchy.