### PR TITLE
style(article-stylesheets): modernize CSS by removing deprecated selectors and fixing contrast

### DIFF
--- a/src/stylesheets/article-style-st-classic.css
+++ b/src/stylesheets/article-style-st-classic.css
@@ -412,7 +412,7 @@ div.xdxf {
 .dsl_opt,
 .dsl_opt .dsl_ex,
 .dsl_opt .dsl_ex :not(a),
-.dsl_opt .dsl_ex font[color] /* DSL Feature: Enforce the optional zone color even if the children tags say otherwise */ {
+.dsl_opt .dsl_ex [color] /* DSL Feature: Enforce the optional zone color even if the children tags say otherwise */ {
   color: gray;
 }
 
@@ -1218,7 +1218,6 @@ div.xdxf {
   vertical-align: top;
 }
 .mwiki abbr,
-.mwiki acronym,
 .mwiki .explain {
   border-bottom: 1px dotted black;
   color: black;

--- a/src/stylesheets/article-style-st-lingoes-blue.css
+++ b/src/stylesheets/article-style-st-lingoes-blue.css
@@ -230,7 +230,7 @@ code::selection {
   border-radius: 100px;
   text-align: center;
   vertical-align: text-bottom;
-  color: #fff;
+  color: #1a3300;
   border: 1px solid #798415;
   box-shadow:
     1px 1px #ccc,

--- a/src/stylesheets/article-style.css
+++ b/src/stylesheets/article-style.css
@@ -551,7 +551,7 @@ div.xdxf {
 .dsl_opt,
 .dsl_opt .dsl_ex,
 .dsl_opt .dsl_ex :not(a),
-.dsl_opt .dsl_ex font[color] /* DSL Feature: Enforce the optional zone color even if the children tags say otherwise */ {
+.dsl_opt .dsl_ex [color] /* DSL Feature: Enforce the optional zone color even if the children tags say otherwise */ {
   color: gray;
 }
 
@@ -639,7 +639,7 @@ div.xdxf {
   margin: 12px;
 
   box-sizing: border-box;
-  word-break: break-word;
+  overflow-wrap: break-word;
   line-height: 1.5;
 }
 
@@ -1397,7 +1397,6 @@ div.xdxf {
   vertical-align: top;
 }
 .mwiki abbr,
-.mwiki acronym,
 .mwiki .explain {
   border-bottom: 1px dotted black;
   color: black;


### PR DESCRIPTION
## Summary

Modernize article stylesheets by removing deprecated CSS selectors and fixing accessibility issues.

## Changes

- Replace deprecated `font[color]` selector with `[color]` in `article-style.css` and `article-style-st-classic.css`
- Remove deprecated `acronym` selector (use `abbr` instead)
- Fix text contrast issue in sound icon button (`.dsl_s_wav a`) in `article-style-st-lingoes-blue.css`
- Replace deprecated `word-break: break-word` with `overflow-wrap: break-word`



## References

- HTML5 spec: `<font>` tag deprecated
- HTML5 spec: `<acronym>` tag deprecated, use `<abbr>` instead
- CSS spec: `word-break: break-word` deprecated, use `overflow-wrap: break-word`