### PR TITLE
fix(ankiconnector): improve word boundary matching

### DIFF
--- a/src/ankiconnector.cc
+++ b/src/ankiconnector.cc
@@ -7,8 +7,7 @@ QString markTargetWord( const QString & sentence, const QString & word )
 {
   QString escapedWord = QRegularExpression::escape( word );
   QRegularExpression re( QString( R"((?<!\w)%1(?!\w))" ).arg( escapedWord ),
-                         QRegularExpression::CaseInsensitiveOption
-                           | QRegularExpression::UseUnicodePropertiesOption );
+                         QRegularExpression::CaseInsensitiveOption | QRegularExpression::UseUnicodePropertiesOption );
   QString result = sentence;
   return result.replace( re, "<b>\\0</b>" );
 }

--- a/src/ankiconnector.cc
+++ b/src/ankiconnector.cc
@@ -5,9 +5,12 @@
 
 QString markTargetWord( const QString & sentence, const QString & word )
 {
-  // TODO properly handle inflected words.
+  QString escapedWord = QRegularExpression::escape( word );
+  QRegularExpression re( QString( R"((?<!\w)%1(?!\w))" ).arg( escapedWord ),
+                         QRegularExpression::CaseInsensitiveOption
+                           | QRegularExpression::UseUnicodePropertiesOption );
   QString result = sentence;
-  return result.replace( word, "<b>" + word + "</b>", Qt::CaseInsensitive );
+  return result.replace( re, "<b>\\0</b>" );
 }
 
 AnkiConnector::AnkiConnector( QObject * parent, const Config::Class & _cfg ):


### PR DESCRIPTION
Improve the markTargetWord function in ankiconnector.cc to properly handle word boundaries when highlighting words in sentences.

**Changes:**
- Replace simple string replacement with regex-based word boundary matching
- Use negative lookbehind and lookahead assertions to ensure only complete words are highlighted
- Enable Unicode properties for proper handling of non-ASCII characters
- Escape special regex characters for safety

**Before:**


**After:**


**Example:**
- Input: word="cat", sentence="The cat is in the category."
- Before: "The <b>cat</b> is in the <b>cat</b>egory."
- After: "The <b>cat</b> is in the category."