### PR TITLE
fix(tray): use QIcon::fromTheme for tray icon with builtin fallback

### DIFF
--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1610,7 +1610,7 @@ void MainWindow::trayIconUpdateOrInit()
   }
   else {
     // Update the icon to reflect the scanning mode
-    QIcon icon( ":/icons/programicon.png" );
+    QIcon icon = QIcon::fromTheme( "goldendict-tray", QIcon( ":/icons/programicon.png" ) );
 
 #ifdef Q_OS_MACOS
     // On macOS, use the icon directly without mask for proper color display


### PR DESCRIPTION
Use QIcon::fromTheme with goldendict-tray theme name and the built-in programicon.png as fallback, allowing the tray icon to respect the system/desktop theme when available.