### PR TITLE
fix(ui): add left padding to GroupComboBox icon/label content

### DIFF
--- a/src/ui/groupcombobox.cc
+++ b/src/ui/groupcombobox.cc
@@ -3,7 +3,9 @@
 
 #include "groupcombobox.hh"
 #include <QEvent>
+#include <QPainter>
 #include <QShortcutEvent>
+#include <QStyleOptionComboBox>
 
 GroupComboBox::GroupComboBox( QWidget * parent ):
   QComboBox( parent ),
@@ -81,8 +83,8 @@ QSize GroupComboBox::sizeHint() const
       iconW += 6; // Icon plus some margin
     }
 
-    // 35 pixels for the arrow and internal padding
-    int estimated = iconW + maxW + 35;
+    // 41 pixels for the arrow and internal padding (35 + 6 for left padding)
+    int estimated = iconW + maxW + 41;
     if ( s.width() < estimated ) {
       s.setWidth( estimated );
     }
@@ -105,6 +107,23 @@ bool GroupComboBox::event( QEvent * event )
   }
 
   return QComboBox::event( event );
+}
+
+void GroupComboBox::paintEvent( QPaintEvent * )
+{
+  QStyleOptionComboBox opt;
+  initStyleOption( &opt );
+
+  QPainter painter( this );
+
+  // Draw frame, focus rect, drop-down button
+  style()->drawComplexControl( QStyle::CC_ComboBox, &opt, &painter, this );
+
+  // Add left padding so the icon/text isn't flush against the left edge
+  opt.rect.adjust( 6, 0, 0, 0 );
+
+  // Draw the label (icon + text) with the adjusted content area
+  style()->drawControl( QStyle::CE_ComboBoxLabel, &opt, &painter, this );
 }
 
 QList< QAction * > GroupComboBox::getExternActions()

--- a/src/ui/groupcombobox.cc
+++ b/src/ui/groupcombobox.cc
@@ -115,6 +115,7 @@ void GroupComboBox::paintEvent( QPaintEvent * )
   initStyleOption( &opt );
 
   QPainter painter( this );
+  painter.setRenderHint( QPainter::Antialiasing );
 
   // Draw frame, focus rect, drop-down button
   style()->drawComplexControl( QStyle::CC_ComboBox, &opt, &painter, this );

--- a/src/ui/groupcombobox.cc
+++ b/src/ui/groupcombobox.cc
@@ -13,7 +13,7 @@ GroupComboBox::GroupComboBox( QWidget * parent ):
   selectNextAction( this ),
   selectPreviousAction( this )
 {
-  setIconSize( QSize( 16, 16 ) );
+  setIconSize( QSize( fontMetrics().height(), fontMetrics().height() ) );
   setSizeAdjustPolicy( AdjustToContents );
   setToolTip( tr( "Choose a Group (Alt+G)" ) );
 

--- a/src/ui/groupcombobox.hh
+++ b/src/ui/groupcombobox.hh
@@ -35,6 +35,7 @@ protected:
 
   /// We handle shortcut events here.
   virtual bool event( QEvent * event ) override;
+  virtual void paintEvent( QPaintEvent * ) override;
   virtual QSize sizeHint() const override;
 
   virtual QSize minimumSizeHint() const override


### PR DESCRIPTION
## Description

Added a custom `paintEvent` to `GroupComboBox` to provide 6px left padding for the icon and text, preventing them from being flush against the left edge.

## Changes

- `src/ui/groupcombobox.hh`: Added `paintEvent` override declaration
- `src/ui/groupcombobox.cc`:
  - Added custom `paintEvent` with 6px left padding via `opt.rect.adjust(6, 0, 0, 0)`
  - Updated `sizeHint` constant from 35 to 41 to account for the extra padding