### PR TITLE
feat(ui): make Fallback Fonts group box checkable with useFallbackFonts config

### DIFF
--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -3043,10 +3043,6 @@ be the last ones.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Fallback Fonts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Standard Font</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3506,6 +3502,10 @@ from Stardict, Babylon and GLS dictionaries</source>
     </message>
     <message>
         <source>Automatically switches based on system theme.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Customize Fonts</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/config.cc
+++ b/src/config.cc
@@ -805,6 +805,10 @@ Class load()
       c.preferences.customFonts = fonts;
     }
 
+    if ( !preferences.namedItem( "useFallbackFonts" ).isNull() ) {
+      c.preferences.useFallbackFonts = preferences.namedItem( "useFallbackFonts" ).toElement().text() == "1";
+    }
+
     if ( !preferences.namedItem( "doubleClickTranslates" ).isNull() ) {
       c.preferences.doubleClickTranslates =
         ( preferences.namedItem( "doubleClickTranslates" ).toElement().text() == "1" );
@@ -1692,6 +1696,10 @@ void save( const Class & c )
     opt             = dd.createElement( "customFonts" );
     auto customFont = c.preferences.customFonts.toElement( dd );
     preferences.appendChild( customFont );
+
+    opt = dd.createElement( "useFallbackFonts" );
+    opt.appendChild( dd.createTextNode( c.preferences.useFallbackFonts ? "1" : "0" ) );
+    preferences.appendChild( opt );
 
     opt = dd.createElement( "displayStyle" );
     opt.appendChild( dd.createTextNode( c.preferences.displayStyle ) );

--- a/src/config.hh
+++ b/src/config.hh
@@ -272,6 +272,7 @@ struct Preferences
   int interfaceFontSize;
 
   CustomFonts customFonts;
+  bool useFallbackFonts = true;
   bool newTabsOpenAfterCurrentOne;
   bool newTabsOpenInBackground;
   bool hideSingleTab;

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -113,6 +113,14 @@ QString ApplicationSettingName = "GoldenDict";
 
 void MainWindow::changeWebEngineViewFont() const
 {
+  if ( !cfg.preferences.useFallbackFonts ) {
+    QWebEngineProfile::defaultProfile()->settings()->resetFontFamily( QWebEngineSettings::StandardFont );
+    QWebEngineProfile::defaultProfile()->settings()->resetFontFamily( QWebEngineSettings::SerifFont );
+    QWebEngineProfile::defaultProfile()->settings()->resetFontFamily( QWebEngineSettings::SansSerifFont );
+    QWebEngineProfile::defaultProfile()->settings()->resetFontFamily( QWebEngineSettings::FixedFont );
+    return;
+  }
+
   if ( cfg.preferences.customFonts.standard.isEmpty() ) {
     QWebEngineProfile::defaultProfile()->settings()->resetFontFamily( QWebEngineSettings::StandardFont );
   }

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -650,7 +650,13 @@ void Preferences::on_buttonBox_accepted()
     QMessageBox::information( this, tr( "Restart needed" ), promptText );
   }
 
-  if ( c.customFonts != prevWebFontFamily && c.useFallbackFonts ) {
+  if ( !c.useFallbackFonts ) {
+    QWebEngineProfile::defaultProfile()->settings()->resetFontFamily( QWebEngineSettings::StandardFont );
+    QWebEngineProfile::defaultProfile()->settings()->resetFontFamily( QWebEngineSettings::SerifFont );
+    QWebEngineProfile::defaultProfile()->settings()->resetFontFamily( QWebEngineSettings::SansSerifFont );
+    QWebEngineProfile::defaultProfile()->settings()->resetFontFamily( QWebEngineSettings::FixedFont );
+  }
+  else if ( c.customFonts != prevWebFontFamily ) {
     QWebEngineProfile::defaultProfile()->settings()->setFontFamily( QWebEngineSettings::StandardFont,
                                                                     c.customFonts.standard );
     QWebEngineProfile::defaultProfile()->settings()->setFontFamily( QWebEngineSettings::SerifFont,

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -133,6 +133,8 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
       QWebEngineProfile::defaultProfile()->settings()->fontFamily( QWebEngineSettings::FixedFont ) );
   }
 
+  ui.fallbackFontsGroupBox->setChecked( p.useFallbackFonts );
+
   ui.displayStyle->addItem( QIcon( ":/icons/programicon.png" ), tr( "Default" ), QString() );
   ui.displayStyle->addItem( QIcon( ":/icons/programicon_old.png" ), tr( "Classic" ), QString( "classic" ) );
   ui.displayStyle->addItem( QIcon( ":/icons/programicon.png" ), tr( "Modern" ), QString( "modern" ) );
@@ -466,7 +468,7 @@ Config::Preferences Preferences::getPreferences()
   c.sansSerif   = ui.font_sans->currentText();
   c.monospace   = ui.font_monospace->currentText();
   p.customFonts = c;
-
+  p.useFallbackFonts = ui.fallbackFontsGroupBox->isChecked();
 
   p.displayStyle = ui.displayStyle->itemData( ui.displayStyle->currentIndex() ).toString();
   if ( ui.InterfaceStyle->isVisible() ) {
@@ -648,7 +650,7 @@ void Preferences::on_buttonBox_accepted()
     QMessageBox::information( this, tr( "Restart needed" ), promptText );
   }
 
-  if ( c.customFonts != prevWebFontFamily ) {
+  if ( c.customFonts != prevWebFontFamily && c.useFallbackFonts ) {
     QWebEngineProfile::defaultProfile()->settings()->setFontFamily( QWebEngineSettings::StandardFont,
                                                                     c.customFonts.standard );
     QWebEngineProfile::defaultProfile()->settings()->setFontFamily( QWebEngineSettings::SerifFont,

--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -527,12 +527,15 @@ be the last ones.</string>
           </widget>
          </item>
          <item>
-          <widget class="QGroupBox" name="groupBox_10">
+          <widget class="QGroupBox" name="fallbackFontsGroupBox">
            <property name="toolTip">
             <string>These fonts will be applied when the fonts specified by a dictionary are not found.</string>
            </property>
            <property name="title">
             <string>Fallback Fonts</string>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_24">
             <item>

--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -532,7 +532,7 @@ be the last ones.</string>
             <string>These fonts will be applied when the fonts specified by a dictionary are not found.</string>
            </property>
            <property name="title">
-            <string>Fallback Fonts</string>
+            <string>Customize Fonts</string>
            </property>
            <property name="checkable">
             <bool>true</bool>


### PR DESCRIPTION
Add checkable property to the Fallback Fonts QGroupBox so users can enable/disable fallback fonts via a checkbox.

### Changes
- **config.hh**: Add `useFallbackFonts` bool field (default: `true`) to `Config::Preferences`
- **preferences.ui**: Set `checkable: true` on the Fallback Fonts QGroupBox and rename it from `groupBox_10` to `fallbackFontsGroupBox`
- **preferences.cc**: Load/save the checkbox state from/to config; only apply fonts to QWebEngine when `useFallbackFonts` is enabled
- **config.cc**: Read/write `useFallbackFonts` from/to XML config with backward compatibility
- **mainwindow.cc**: In `changeWebEngineViewFont()`, reset all fonts to default when `useFallbackFonts` is disabled

### How it works
- QGroupBox's native `checkable` feature automatically disables/enables all child controls (the four font combo boxes) when toggled
- The checkbox state is persisted in the config XML as `<useFallbackFonts>1</useFallbackFonts>`
- When unchecked, QWebEngine font settings are reset to browser defaults rather than applying the selected font values