### PR TITLE
style(article): limit warning icon size to max 24px

### DIFF
--- a/src/stylesheets/article-style-st-classic.css
+++ b/src/stylesheets/article-style-st-classic.css
@@ -84,7 +84,8 @@ pre {
 .gderrordesc {
   font-style: italic;
   background: url("qrc:///icons/warning.svg") center left no-repeat !important;
-  padding-left: 22px !important;
+  background-size: auto min(100%, 24px);
+  padding-left: 2em !important;
   margin: 1em;
 }
 

--- a/src/stylesheets/article-style.css
+++ b/src/stylesheets/article-style.css
@@ -184,7 +184,8 @@ gd-dict-header,
 .gderrordesc {
   font-style: italic;
   background: url("qrc:///icons/warning.svg") center left no-repeat !important;
-  padding-left: 22px !important;
+  background-size: auto min(100%, 24px);
+  padding-left: 2em !important;
   margin: 1em;
 }
 


### PR DESCRIPTION
Fix warning icon appearing too large in error messages by adding max size constraint.