### PR TITLE
feat: 文章滚动分区与高度限制

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,4 +233,9 @@ else ()
     include(cmake/Package_macOS.cmake)
 endif ()
 
+# Default to Release for local builds (overridable)
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)
+endif()
+
 feature_summary(WHAT ALL DESCRIPTION "Build configuration:")

--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -3508,6 +3508,34 @@ from Stardict, Babylon and GLS dictionaries</source>
         <source>Customize Fonts</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Articles Extra</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Limit dictionary article height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max height:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>px</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scroll zone split:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Width of the middle scroll zone as percentage. Moving the mouse wheel in this zone scrolls the article. Moving in the outer zones scrolls the page.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ProgramTypeEditor</name>

--- a/src/article_maker.cc
+++ b/src/article_maker.cc
@@ -201,10 +201,9 @@ std::string ArticleMaker::makeHtmlHeader( const QString & word, const QString & 
   // Add overflow-y for scroll zones (always) and max-height if limit enabled
   result += QString( R"(<style>.gdarticlebody{overflow-y:auto;})" ).toStdString();
   if ( cfg.dictPanelEnabled ) {
-    result += QString(
-      R"(:root{--gd-panel-height:%1%2;}.gdarticlebody{max-height:var(--gd-panel-height);})"
-    ).arg( QString::number( cfg.dictPanelMaxHeight ), cfg.dictPanelHeightUnit )
-      .toStdString();
+    result += QString( R"(:root{--gd-panel-height:%1%2;}.gdarticlebody{max-height:var(--gd-panel-height);})" )
+                .arg( QString::number( cfg.dictPanelMaxHeight ), cfg.dictPanelHeightUnit )
+                .toStdString();
   }
   result += "</style>";
 

--- a/src/article_maker.cc
+++ b/src/article_maker.cc
@@ -198,6 +198,16 @@ std::string ArticleMaker::makeHtmlHeader( const QString & word, const QString & 
     result += fmt::format( FMT_COMPILE( R"(<script src="bres://user/{}" defer></script>)" ), userJsFile.value() );
   }
 
+  // Add overflow-y for scroll zones (always) and max-height if limit enabled
+  result += QString( R"(<style>.gdarticlebody{overflow-y:auto;})" ).toStdString();
+  if ( cfg.dictPanelEnabled ) {
+    result += QString(
+      R"(:root{--gd-panel-height:%1%2;}.gdarticlebody{max-height:var(--gd-panel-height);})"
+    ).arg( QString::number( cfg.dictPanelMaxHeight ), cfg.dictPanelHeightUnit )
+      .toStdString();
+  }
+  result += "</style>";
+
   result += "</head><body>";
 
   return result;

--- a/src/config.cc
+++ b/src/config.cc
@@ -1031,7 +1031,7 @@ Class load()
       c.preferences.raiseWindowOnSearch = ( preferences.namedItem( "raiseWindowOnSearch" ).toElement().text() == "1" );
     }
 
-    c.preferences.dictPanelEnabled = ( preferences.namedItem( "dictPanelEnabled" ).toElement().text() == "1" );
+    c.preferences.dictPanelEnabled   = ( preferences.namedItem( "dictPanelEnabled" ).toElement().text() == "1" );
     c.preferences.dictPanelMaxHeight = preferences.namedItem( "dictPanelMaxHeight" ).toElement().text().toInt();
     if ( !preferences.namedItem( "dictPanelHeightUnit" ).isNull() )
       c.preferences.dictPanelHeightUnit = preferences.namedItem( "dictPanelHeightUnit" ).toElement().text();
@@ -1039,7 +1039,8 @@ Class load()
       c.preferences.dictPanelScrollZone = preferences.namedItem( "dictPanelScrollZone" ).toElement().text().toInt();
 
     if ( !preferences.namedItem( "sideBySideDefaultSplit" ).isNull() )
-      c.preferences.sideBySideDefaultSplit = preferences.namedItem( "sideBySideDefaultSplit" ).toElement().text().toInt();
+      c.preferences.sideBySideDefaultSplit =
+        preferences.namedItem( "sideBySideDefaultSplit" ).toElement().text().toInt();
 
     QDomNode fts = preferences.namedItem( "fullTextSearch" );
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -154,7 +154,12 @@ Preferences::Preferences():
   maxDictionaryRefsInContextMenu( 20 ),
   synonymSearchEnabled( true ),
   stripClipboard( false ),
-  interfaceStyle( "Default" )
+  interfaceStyle( "Default" ),
+  dictPanelEnabled( true ),
+  dictPanelMaxHeight( 300 ),
+  dictPanelHeightUnit( "px" ),
+  dictPanelScrollZone( 50 ),
+  sideBySideDefaultSplit( 50 )
 {
 }
 
@@ -1025,6 +1030,16 @@ Class load()
     if ( !preferences.namedItem( "raiseWindowOnSearch" ).isNull() ) {
       c.preferences.raiseWindowOnSearch = ( preferences.namedItem( "raiseWindowOnSearch" ).toElement().text() == "1" );
     }
+
+    c.preferences.dictPanelEnabled = ( preferences.namedItem( "dictPanelEnabled" ).toElement().text() == "1" );
+    c.preferences.dictPanelMaxHeight = preferences.namedItem( "dictPanelMaxHeight" ).toElement().text().toInt();
+    if ( !preferences.namedItem( "dictPanelHeightUnit" ).isNull() )
+      c.preferences.dictPanelHeightUnit = preferences.namedItem( "dictPanelHeightUnit" ).toElement().text();
+    if ( !preferences.namedItem( "dictPanelScrollZone" ).isNull() )
+      c.preferences.dictPanelScrollZone = preferences.namedItem( "dictPanelScrollZone" ).toElement().text().toInt();
+
+    if ( !preferences.namedItem( "sideBySideDefaultSplit" ).isNull() )
+      c.preferences.sideBySideDefaultSplit = preferences.namedItem( "sideBySideDefaultSplit" ).toElement().text().toInt();
 
     QDomNode fts = preferences.namedItem( "fullTextSearch" );
 
@@ -2030,6 +2045,22 @@ void save( const Class & c )
 
     opt = dd.createElement( "raiseWindowOnSearch" );
     opt.appendChild( dd.createTextNode( c.preferences.raiseWindowOnSearch ? "1" : "0" ) );
+    preferences.appendChild( opt );
+
+    opt = dd.createElement( "dictPanelEnabled" );
+    opt.appendChild( dd.createTextNode( c.preferences.dictPanelEnabled ? "1" : "0" ) );
+    preferences.appendChild( opt );
+    opt = dd.createElement( "dictPanelMaxHeight" );
+    opt.appendChild( dd.createTextNode( QString::number( c.preferences.dictPanelMaxHeight ) ) );
+    preferences.appendChild( opt );
+    opt = dd.createElement( "dictPanelHeightUnit" );
+    opt.appendChild( dd.createTextNode( c.preferences.dictPanelHeightUnit ) );
+    preferences.appendChild( opt );
+    opt = dd.createElement( "dictPanelScrollZone" );
+    opt.appendChild( dd.createTextNode( QString::number( c.preferences.dictPanelScrollZone ) ) );
+    preferences.appendChild( opt );
+    opt = dd.createElement( "sideBySideDefaultSplit" );
+    opt.appendChild( dd.createTextNode( QString::number( c.preferences.sideBySideDefaultSplit ) ) );
     preferences.appendChild( opt );
 
     {

--- a/src/config.hh
+++ b/src/config.hh
@@ -384,6 +384,13 @@ struct Preferences
   // On Windows, this field exists but is not used (Windows uses its own styling system).
   QString interfaceStyle;
 
+  // Dict panel height limit
+  bool dictPanelEnabled;
+  int dictPanelMaxHeight;
+  QString dictPanelHeightUnit;
+  int dictPanelScrollZone;
+  int sideBySideDefaultSplit;
+
   Preferences();
 };
 

--- a/src/scripts/gd-builtin.js
+++ b/src/scripts/gd-builtin.js
@@ -205,48 +205,55 @@ if (
 }
 
 // Split-scroll zone: left half scrolls page, right half scrolls article
-(function() {
+(function () {
   var splitPercent = 50;
 
   function setupScrollZones() {
-    document.addEventListener('wheel', function(e) {
-      var article = e.target.closest('.gdarticlebody');
-      if (!article) return;
+    document.addEventListener(
+      "wheel",
+      function (e) {
+        var article = e.target.closest(".gdarticlebody");
+        if (!article) return;
 
-      var rect = article.getBoundingClientRect();
-      var relX = (e.clientX - rect.left) / rect.width; // 0..1 relative position
+        var rect = article.getBoundingClientRect();
+        var relX = (e.clientX - rect.left) / rect.width; // 0..1 relative position
 
-      // Middle 50%: scroll inside article. Outer 25% each side: scroll page.
-      if (relX >= 0.25 && relX <= 0.75) {
-      // Middle zone: try article scroll first, fall back to page scroll at edges
-      const atTop    = article.scrollTop <= 0 && e.deltaY < 0;
-      const atBottom = article.scrollTop + article.clientHeight >= article.scrollHeight - 1 && e.deltaY > 0;
-      if ( atTop || atBottom )
-        return; // let browser scroll the page
-      e.preventDefault();
-      article.scrollTop += e.deltaY;
-      return;
-      }
-      // Peripheral zone: scroll the outer page
-      e.preventDefault();
-      var scrollEl = document.scrollingElement || document.documentElement;
-      scrollEl.scrollTop += e.deltaY;
-    }, { passive: false });
+        // Middle 50%: scroll inside article. Outer 25% each side: scroll page.
+        if (relX >= 0.25 && relX <= 0.75) {
+          // Middle zone: try article scroll first, fall back to page scroll at edges
+          const atTop = article.scrollTop <= 0 && e.deltaY < 0;
+          const atBottom =
+            article.scrollTop + article.clientHeight >=
+              article.scrollHeight - 1 && e.deltaY > 0;
+          if (atTop || atBottom) return; // let browser scroll the page
+          e.preventDefault();
+          article.scrollTop += e.deltaY;
+          return;
+        }
+        // Peripheral zone: scroll the outer page
+        e.preventDefault();
+        var scrollEl = document.scrollingElement || document.documentElement;
+        scrollEl.scrollTop += e.deltaY;
+      },
+      { passive: false },
+    );
   }
 
   // Listen for C++ signal
   try {
-    if (typeof articleview !== 'undefined'
-        && typeof articleview.scrollZoneSplitChanged !== 'undefined') {
-      articleview.scrollZoneSplitChanged.connect(function(pct) {
+    if (
+      typeof articleview !== "undefined" &&
+      typeof articleview.scrollZoneSplitChanged !== "undefined"
+    ) {
+      articleview.scrollZoneSplitChanged.connect(function (pct) {
         splitPercent = pct;
       });
     }
-  } catch(e) {}
+  } catch (e) {}
 
   // Set up when DOM is ready
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', setupScrollZones);
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", setupScrollZones);
   } else {
     setupScrollZones();
   }

--- a/src/scripts/gd-builtin.js
+++ b/src/scripts/gd-builtin.js
@@ -203,3 +203,51 @@ if (
 } else {
   document.addEventListener("DOMContentLoaded", gdAttachEventHandlers);
 }
+
+// Split-scroll zone: left half scrolls page, right half scrolls article
+(function() {
+  var splitPercent = 50;
+
+  function setupScrollZones() {
+    document.addEventListener('wheel', function(e) {
+      var article = e.target.closest('.gdarticlebody');
+      if (!article) return;
+
+      var rect = article.getBoundingClientRect();
+      var relX = (e.clientX - rect.left) / rect.width; // 0..1 relative position
+
+      // Middle 50%: scroll inside article. Outer 25% each side: scroll page.
+      if (relX >= 0.25 && relX <= 0.75) {
+      // Middle zone: try article scroll first, fall back to page scroll at edges
+      const atTop    = article.scrollTop <= 0 && e.deltaY < 0;
+      const atBottom = article.scrollTop + article.clientHeight >= article.scrollHeight - 1 && e.deltaY > 0;
+      if ( atTop || atBottom )
+        return; // let browser scroll the page
+      e.preventDefault();
+      article.scrollTop += e.deltaY;
+      return;
+      }
+      // Peripheral zone: scroll the outer page
+      e.preventDefault();
+      var scrollEl = document.scrollingElement || document.documentElement;
+      scrollEl.scrollTop += e.deltaY;
+    }, { passive: false });
+  }
+
+  // Listen for C++ signal
+  try {
+    if (typeof articleview !== 'undefined'
+        && typeof articleview.scrollZoneSplitChanged !== 'undefined') {
+      articleview.scrollZoneSplitChanged.connect(function(pct) {
+        splitPercent = pct;
+      });
+    }
+  } catch(e) {}
+
+  // Set up when DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setupScrollZones);
+  } else {
+    setupScrollZones();
+  }
+})();

--- a/src/stylesheets/article-style.css
+++ b/src/stylesheets/article-style.css
@@ -3279,3 +3279,9 @@ table#sv-hooks,
 .gls_wav img {
   vertical-align: middle;
 }
+
+/* Dict panel height limit */
+.gdarticlebody {
+  max-height: var(--gd-panel-height);
+  overflow-y: auto;
+}

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -256,6 +256,22 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   ui.ignorePunctuation->setChecked( p.ignorePunctuation );
   ui.sessionCollapse->setChecked( p.sessionCollapse );
 
+  ui.dictPanelEnabled->setChecked( p.dictPanelEnabled );
+  ui.dictPanelMaxHeight->setValue( p.dictPanelMaxHeight );
+  int unitIdx = ui.dictPanelHeightUnit->findText( p.dictPanelHeightUnit );
+  if ( unitIdx >= 0 )
+    ui.dictPanelHeightUnit->setCurrentIndex( unitIdx );
+  ui.dictPanelScrollZone->setValue( p.dictPanelScrollZone );
+
+// Gray out height/spin controls when limit is unchecked
+auto updateDictPanelWidgets = [ this ]() {
+  bool on = ui.dictPanelEnabled->isChecked();
+  ui.dictPanelMaxHeight->setEnabled( on );
+  ui.dictPanelHeightUnit->setEnabled( on );
+};
+connect( ui.dictPanelEnabled, &QCheckBox::toggled, this, updateDictPanelWidgets );
+updateDictPanelWidgets();
+
   ui.synonymSearchEnabled->setChecked( p.synonymSearchEnabled );
 
   ui.stripClipboard->setChecked( p.stripClipboard );
@@ -527,6 +543,12 @@ Config::Preferences Preferences::getPreferences()
   p.ignoreDiacritics       = ui.ignoreDiacritics->isChecked();
   p.ignorePunctuation      = ui.ignorePunctuation->isChecked();
   p.sessionCollapse        = ui.sessionCollapse->isChecked();
+
+  p.dictPanelEnabled    = ui.dictPanelEnabled->isChecked();
+  p.dictPanelMaxHeight  = ui.dictPanelMaxHeight->value();
+  p.dictPanelHeightUnit = ui.dictPanelHeightUnit->currentText();
+  p.dictPanelScrollZone = ui.dictPanelScrollZone->value();
+
   p.stripClipboard         = ui.stripClipboard->isChecked();
   p.raiseWindowOnSearch    = ui.raiseWindowOnSearch->isChecked();
 

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -263,14 +263,14 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
     ui.dictPanelHeightUnit->setCurrentIndex( unitIdx );
   ui.dictPanelScrollZone->setValue( p.dictPanelScrollZone );
 
-// Gray out height/spin controls when limit is unchecked
-auto updateDictPanelWidgets = [ this ]() {
-  bool on = ui.dictPanelEnabled->isChecked();
-  ui.dictPanelMaxHeight->setEnabled( on );
-  ui.dictPanelHeightUnit->setEnabled( on );
-};
-connect( ui.dictPanelEnabled, &QCheckBox::toggled, this, updateDictPanelWidgets );
-updateDictPanelWidgets();
+  // Gray out height/spin controls when limit is unchecked
+  auto updateDictPanelWidgets = [ this ]() {
+    bool on = ui.dictPanelEnabled->isChecked();
+    ui.dictPanelMaxHeight->setEnabled( on );
+    ui.dictPanelHeightUnit->setEnabled( on );
+  };
+  connect( ui.dictPanelEnabled, &QCheckBox::toggled, this, updateDictPanelWidgets );
+  updateDictPanelWidgets();
 
   ui.synonymSearchEnabled->setChecked( p.synonymSearchEnabled );
 

--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -1880,6 +1880,79 @@ from mouse-over, selection, clipboard or command line</string>
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="dictPanelGroup">
+         <property name="title">
+          <string>Articles Extra</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout_dictPanel">
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="dictPanelEnabled">
+            <property name="text">
+             <string>Limit dictionary article height</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <layout class="QHBoxLayout" name="horizontalLayout_dictPanel">
+            <item>
+             <widget class="QLabel" name="dictPanelHeightLabel">
+              <property name="text">
+               <string>Max height:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="dictPanelMaxHeight">
+              <property name="minimum">
+               <number>50</number>
+              </property>
+              <property name="maximum">
+               <number>2000</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="dictPanelHeightUnit">
+              <item>
+               <property name="text">
+                <string>px</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="2" column="0">
+           <layout class="QHBoxLayout" name="horizontalLayout_dictPanelScroll">
+            <item>
+             <widget class="QLabel" name="dictPanelZoneLabel">
+              <property name="text">
+               <string>Scroll zone split:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="dictPanelScrollZone">
+              <property name="toolTip">
+               <string>Width of the middle scroll zone as percentage. Moving the mouse wheel in this zone scrolls the article. Moving in the outer zones scrolls the page.</string>
+              </property>
+              <property name="suffix">
+               <string>%</string>
+              </property>
+              <property name="minimum">
+               <number>0</number>
+              </property>
+              <property name="maximum">
+               <number>100</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="synonymSearchEnabled">
          <property name="toolTip">
           <string>Turn this option on to enable extra articles search via synonym lists


### PR DESCRIPTION
### 滚动分区
- 文章视图中部区域滚动文章内容，两侧区域滚动整页
- 中部到顶 / 底时自动穿透，继续滚动整页

### 文章高度限制
- 可设文章最大显示高度 (px)，超出部分内部滚动
- 始终注入 `overflow-y: auto` 保证滚动分区正常工作

### 偏好设置 (进阶 → Articles Extra)
- 「限制文章高度」复选框，关联控件在未启用时灰色不可编辑
- 「滚动分区」百分比滑块，设中间滚动区宽度

### 演示
https://youtu.be/7v9o7YLqZaU