### PR TITLE
feat: Multi-Panel — Side-by-Side Dictionary Panels

### DIFF
--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -2651,6 +2651,46 @@ To find &apos;*&apos;, &apos;?&apos;, &apos;[&apos;, &apos;]&apos; symbols use &
         <source>Application is still running in the background. Click the tray icon to show the window.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Toggle Panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Panel Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Always Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to New Panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always Query This Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main Panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Panel %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(empty)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Mdx::MdxArticleRequest</name>
@@ -3506,6 +3546,14 @@ from Stardict, Babylon and GLS dictionaries</source>
     </message>
     <message>
         <source>Customize Fonts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open websites in panels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore session on startup (tabs, panels, layout)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -2664,15 +2664,7 @@ To find &apos;*&apos;, &apos;?&apos;, &apos;[&apos;, &apos;]&apos; symbols use &
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Toggle Always Query</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Move to New Panel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Always Query This Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2681,10 +2673,6 @@ To find &apos;*&apos;, &apos;?&apos;, &apos;[&apos;, &apos;]&apos; symbols use &
     </message>
     <message>
         <source>Panel %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(empty)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3550,10 +3538,6 @@ from Stardict, Babylon and GLS dictionaries</source>
     </message>
     <message>
         <source>Open websites in panels</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Restore session on startup (tabs, panels, layout)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/config.cc
+++ b/src/config.cc
@@ -953,6 +953,9 @@ Class load()
     if ( !preferences.namedItem( "openWebsiteInNewTab" ).isNull() ) {
       c.preferences.openWebsiteInNewTab = ( preferences.namedItem( "openWebsiteInNewTab" ).toElement().text() == "1" );
     }
+    if ( !preferences.namedItem( "openWebsitesInPanel" ).isNull() ) {
+      c.preferences.openWebsitesInPanel = ( preferences.namedItem( "openWebsitesInPanel" ).toElement().text() == "1" );
+    }
 
     if ( !preferences.namedItem( "suppressWebDialogs" ).isNull() ) {
       c.preferences.suppressWebDialogs = ( preferences.namedItem( "suppressWebDialogs" ).toElement().text() == "1" );
@@ -1974,6 +1977,10 @@ void save( const Class & c )
 
     opt = dd.createElement( "openWebsiteInNewTab" );
     opt.appendChild( dd.createTextNode( c.preferences.openWebsiteInNewTab ? "1" : "0" ) );
+    preferences.appendChild( opt );
+
+    opt = dd.createElement( "openWebsitesInPanel" );
+    opt.appendChild( dd.createTextNode( c.preferences.openWebsitesInPanel ? "1" : "0" ) );
     preferences.appendChild( opt );
 
     opt = dd.createElement( "suppressWebDialogs" );

--- a/src/config.hh
+++ b/src/config.hh
@@ -337,6 +337,7 @@ struct Preferences
     false;
 #endif
   bool openWebsiteInNewTab = false;
+  bool openWebsitesInPanel             = false;
   bool suppressWebDialogs  = false;
   bool enableJavaScriptClipboardAccess = false;
 

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -185,10 +185,12 @@ ArticleView::ArticleView( QWidget * parent,
   connect( &pasteAction, &QAction::triggered, this, &ArticleView::pasteTriggered );
 
   articleUpAction.setShortcut( QKeySequence( "Alt+Up" ) );
+  articleUpAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
   webview->addAction( &articleUpAction );
   connect( &articleUpAction, &QAction::triggered, this, &ArticleView::moveOneArticleUp );
 
   articleDownAction.setShortcut( QKeySequence( "Alt+Down" ) );
+  articleDownAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
   webview->addAction( &articleDownAction );
   connect( &articleDownAction, &QAction::triggered, this, &ArticleView::moveOneArticleDown );
 

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -1182,8 +1182,6 @@ void ArticleView::openLink( const QUrl & url, const QUrl & ref, const QString & 
     else {
       showDefinition( word, getGroup( ref ), scrollTo, contexts );
     }
-
-    // Notify MainWindow for Always Query forwarding
   }
   else if ( url.scheme() == "gdlookup" ) // Plain html links inherit gdlookup scheme
   {

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -1197,7 +1197,7 @@ void ArticleView::openLink( const QUrl & url, const QUrl & ref, const QString & 
         QStringList dictsList = Utils::Url::queryItemValue( url, "dictionaries" ).split( ",", Qt::SkipEmptyParts );
 
         showDefinition( word, dictsList, getGroup( url ), false );
-            return;
+        return;
       }
 
       QString newScrollTo( scrollTo );
@@ -1215,8 +1215,7 @@ void ArticleView::openLink( const QUrl & url, const QUrl & ref, const QString & 
       }
 
       showDefinition( word, getGroup( ref ), newScrollTo, contexts );
-
-      }
+    }
   }
   else if ( url.scheme() == "bres" || url.scheme() == "gdau" || url.scheme() == "gdvideo"
             || Utils::Url::isAudioUrl( url ) ) {

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -286,7 +286,7 @@ ArticleView::~ArticleView()
 {
   cleanupTemp();
   audioPlayer->stop();
-  //channel->deregisterObject(this);
+  // channel->deregisterObject(this);
 #ifndef Q_OS_MACOS
   webview->ungrabGesture( Gestures::GDPinchGestureType );
   webview->ungrabGesture( Gestures::GDSwipeGestureType );
@@ -358,10 +358,10 @@ void ArticleView::showDefinition( const QString & word,
   // Any search opened is probably irrelevant now
   closeSearch();
 
-  //log, req request
+  // log, req request
   qDebug() << "req url:" << req.toString();
 
-  //QApplication::setOverrideCursor( Qt::WaitCursor );
+  // QApplication::setOverrideCursor( Qt::WaitCursor );
   webview->setCursor( Qt::WaitCursor );
   load( req );
 
@@ -384,7 +384,7 @@ void ArticleView::showDefinition( const QString & word,
     return;
   }
   historyMode = false;
-  //clear founded dicts.
+  // clear founded dicts.
   currentActiveDictIds.clear();
   // first, let's stop the player
   audioPlayer->stop();
@@ -539,7 +539,7 @@ void ArticleView::loadFinished( bool result )
       }
     }
     else {
-      //clear current active dictionary id;
+      // clear current active dictionary id;
       setActiveArticleId( "" );
     }
 
@@ -568,8 +568,8 @@ void ArticleView::loadFinished( bool result )
     injectWebsiteConfigScript();
   }
 
-  //the click audio url such as gdau://xxxx ,webview also emit a pageLoaded signal but with the result is false.need future investigation.
-  //the audio link click ,no need to emit pageLoaded signal
+  // the click audio url such as gdau://xxxx ,webview also emit a pageLoaded signal but with the result is false.need
+  // future investigation. the audio link click ,no need to emit pageLoaded signal
   if ( result ) {
     emit pageLoaded( this );
   }
@@ -1150,8 +1150,8 @@ void ArticleView::openLink( const QUrl & url, const QUrl & ref, const QString & 
 
   auto [ valid, word ] = Utils::Url::getQueryWord( url );
   if ( valid && word.isEmpty() ) {
-    //if valid=true and word is empty,the url must be a invalid gdlookup url.
-    //else if valid=false,the url should be external urls.
+    // if valid=true and word is empty,the url must be a invalid gdlookup url.
+    // else if valid=false,the url should be external urls.
     return;
   }
 
@@ -1182,6 +1182,8 @@ void ArticleView::openLink( const QUrl & url, const QUrl & ref, const QString & 
     else {
       showDefinition( word, getGroup( ref ), scrollTo, contexts );
     }
+
+    // Notify MainWindow for Always Query forwarding
   }
   else if ( url.scheme() == "gdlookup" ) // Plain html links inherit gdlookup scheme
   {
@@ -1195,7 +1197,7 @@ void ArticleView::openLink( const QUrl & url, const QUrl & ref, const QString & 
         QStringList dictsList = Utils::Url::queryItemValue( url, "dictionaries" ).split( ",", Qt::SkipEmptyParts );
 
         showDefinition( word, dictsList, getGroup( url ), false );
-        return;
+            return;
       }
 
       QString newScrollTo( scrollTo );
@@ -1213,7 +1215,8 @@ void ArticleView::openLink( const QUrl & url, const QUrl & ref, const QString & 
       }
 
       showDefinition( word, getGroup( ref ), newScrollTo, contexts );
-    }
+
+      }
   }
   else if ( url.scheme() == "bres" || url.scheme() == "gdau" || url.scheme() == "gdvideo"
             || Utils::Url::isAudioUrl( url ) ) {
@@ -2077,13 +2080,13 @@ void ArticleView::on_searchCloseButton_clicked()
 
 void ArticleView::on_searchCaseSensitive_clicked( bool checked )
 {
-  //clear the previous findText results.
-  //when the results is empty, the highlight has not been removed.more likely a qt bug.
+  // clear the previous findText results.
+  // when the results is empty, the highlight has not been removed.more likely a qt bug.
   webview->findText( "" );
   performFindOperation( false );
 }
 
-//the id start with "gdform-"
+// the id start with "gdform-"
 void ArticleView::onJsActiveArticleChanged( const QString & id )
 {
   // Skip dictionary article change handling for website views

--- a/src/ui/articleview.hh
+++ b/src/ui/articleview.hh
@@ -68,7 +68,7 @@ class ArticleView: public QWidget
 
   bool historyMode = false;
 
-  //current active dictionary id;
+  // current active dictionary id;
   QString activeDictId;
 
   QString audioLink_;
@@ -231,7 +231,7 @@ public:
     if ( !qFuzzyCompare( existedFactor, factor ) ) {
       qDebug() << "zoom factor ,existed:" << existedFactor << "set:" << factor;
       webview->setZoomFactor( factor );
-      //webview->page()->setZoomFactor(factor);
+      // webview->page()->setZoomFactor(factor);
     }
   }
 
@@ -368,9 +368,10 @@ public slots:
 
   /// Selects an entire text of the current article
   void selectCurrentArticle();
-  //receive signal from weburlinterceptor.
+  // receive signal from weburlinterceptor.
   void linkClicked( const QUrl & );
-  //aim to receive signal from html. the fragment url click to  navigation through page wil not be intecepted by weburlinteceptor
+  // aim to receive signal from html. the fragment url click to  navigation through page wil not be intecepted by
+  // weburlinteceptor
   Q_INVOKABLE void linkClickedInHtml( const QUrl & );
 private slots:
   void inspectElement();
@@ -393,10 +394,10 @@ private slots:
 
   unsigned getCurrentGroup();
 
-  /// Nagivates to the previous article relative to the active one.
+  /// Navigates to the previous article relative to the active one.
   void moveOneArticleUp();
 
-  /// Nagivates to the next article relative to the active one.
+  /// Navigates to the next article relative to the active one.
   void moveOneArticleDown();
 
   void on_searchText_textEdited();

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1423,6 +1423,42 @@ QTabWidget * MainWindow::activePanel()
   return ui.tabWidget;
 }
 
+void MainWindow::closeTabInPanel( QTabWidget * panel, int tabIndex )
+{
+  QWidget * w = panel->widget( tabIndex );
+  if ( !w )
+    return;
+  mruList.removeOne( w );
+
+  // Main panel: activate neighbor or MRU tab before removing
+  if ( panel == ui.tabWidget ) {
+    if ( cfg.preferences.mruTabOrder && !mruList.empty() ) {
+      ui.tabWidget->setCurrentWidget( mruList.at( 0 ) );
+    }
+    else if ( ui.tabWidget->count() > 1 ) {
+      int n = tabIndex >= ui.tabWidget->count() - 1 ? tabIndex - 1 : tabIndex + 1;
+      if ( n >= 0 )
+        ui.tabWidget->setCurrentIndex( n );
+    }
+  }
+
+  panel->removeTab( tabIndex );
+  delete w;
+
+  if ( panel == ui.tabWidget ) {
+    if ( ui.tabWidget->count() == 0 )
+      createNewTab( true, tr( "(untitled)" ) )->load( QUrl( "gdinternal://untitle-page" ) );
+  }
+  else {
+    if ( panel->count() == 0 ) {
+      delete panel;
+      distributePanelSizes();
+    }
+    if ( totalTabCount() == 0 )
+      addNewTab();
+  }
+}
+
 void MainWindow::setupTabWidgetCommon( QTabWidget * panel )
 {
   panel->setMovable( true );
@@ -1488,19 +1524,7 @@ QTabWidget * MainWindow::createNewSidePanel()
   } );
 
   connect( panel, &QTabWidget::tabCloseRequested, this, [ this, panel ]( int tabIndex ) {
-    QWidget * w = panel->widget( tabIndex );
-    if ( !w )
-      return;
-    mruList.removeOne( w );
-    panel->removeTab( tabIndex );
-    delete w;
-    if ( panel->count() == 0 ) {
-      delete panel;
-      distributePanelSizes();
-    }
-    // Make sure at least one tab exists somewhere
-    if ( totalTabCount() == 0 )
-      addNewTab();
+    closeTabInPanel( panel, tabIndex );
   } );
 
   ui.panelSplitter->addWidget( panel );
@@ -1636,7 +1660,7 @@ void MainWindow::showTabContextMenu( QTabWidget * panel, int tabIdx, QPoint glob
     } );
 
     // Add all tabs to Favorites (panel-scoped)
-    QAction * favAllAction = menu.addAction( starIcon, tr( "Add all tabs to Favorites" ) );
+    QAction * favAllAction = menu.addAction( tr( "Add all tabs to Favorites" ) );
     connect( favAllAction, &QAction::triggered, this, [ this, panel ]() {
       for ( int i = 0; i < panel->count(); i++ ) {
         auto * av2 = qobject_cast< ArticleView * >( panel->widget( i ) );
@@ -2425,35 +2449,7 @@ void MainWindow::addNewTab()
 
 void MainWindow::addNewTabToPanel( QTabWidget * panel )
 {
-  ArticleView * view = new ArticleView( this,
-                                        articleNetMgr,
-                                        false,
-                                        cfg,
-                                        translateLine,
-                                        dictionaryBar.toggleViewAction(),
-                                        groupList->getCurrentGroup() );
-
-  connect( view, &ArticleView::inspectSignal, this, &MainWindow::inspectElement );
-  connect( view, &ArticleView::titleChanged, this, &MainWindow::titleChanged );
-  connect( view, &ArticleView::pageLoaded, this, &MainWindow::pageLoaded );
-  connect( view, &ArticleView::updateFoundInDictsList, this, &MainWindow::updateFoundInDictsList );
-  connect( view, &ArticleView::openLinkInNewTab, this, &MainWindow::openLinkInNewTab );
-  connect( view, &ArticleView::showDefinitionInNewTab, this, &MainWindow::showDefinitionInNewTab );
-  connect( view, &ArticleView::typingEvent, this, &MainWindow::typingEvent );
-  connect( view, &ArticleView::activeArticleChanged, this, &MainWindow::activeArticleChanged );
-  connect( view, &ArticleView::statusBarMessage, this, &MainWindow::showStatusBarMessage );
-  connect( view, &ArticleView::showDictsPane, this, &MainWindow::showDictsPane );
-  connect( view, &ArticleView::forceAddWordToHistory, this, &MainWindow::forceAddWordToHistory );
-  connect( view, &ArticleView::sendWordToHistory, this, &MainWindow::addWordToHistory );
-  connect( view, &ArticleView::sendWordToInputLine, this, &MainWindow::sendWordToInputLine );
-  connect( view, &ArticleView::storeResourceSavePath, this, &MainWindow::storeResourceSavePath );
-  connect( view, &ArticleView::zoomIn, this, &MainWindow::zoomin );
-  connect( view, &ArticleView::zoomOut, this, &MainWindow::zoomout );
-  connect( view, &ArticleView::saveBookmarkSignal, this, &MainWindow::addBookmarkToFavorite );
-  connect( view, &ArticleView::translateSelectedText, this, &MainWindow::handleTranslateSelectedText );
-
-  view->setSelectionBySingleClick( cfg.preferences.selectWordBySingleClick );
-  view->setZoomFactor( cfg.preferences.zoomFactor );
+  ArticleView * view = createArticleView();
 
   int index = panel->addTab( view, tr( "(untitled)" ) );
   panel->setCurrentIndex( index );
@@ -2462,53 +2458,46 @@ void MainWindow::addNewTabToPanel( QTabWidget * panel )
   view->load( QUrl( "gdinternal://untitle-page" ) );
 }
 
-ArticleView * MainWindow::createNewTab( bool switchToIt, const QString & name )
+ArticleView * MainWindow::createArticleView()
 {
-  ArticleView * view = new ArticleView( this,
-                                        articleNetMgr,
-                                        false,
-                                        cfg,
-                                        translateLine,
-                                        dictionaryBar.toggleViewAction(),
-                                        groupList->getCurrentGroup() );
+  auto * view = new ArticleView( this,
+                                 articleNetMgr,
+                                 false,
+                                 cfg,
+                                 translateLine,
+                                 dictionaryBar.toggleViewAction(),
+                                 groupList->getCurrentGroup() );
 
   connect( view, &ArticleView::inspectSignal, this, &MainWindow::inspectElement );
-
   connect( view, &ArticleView::titleChanged, this, &MainWindow::titleChanged );
-
   connect( view, &ArticleView::pageLoaded, this, &MainWindow::pageLoaded );
-
   connect( view, &ArticleView::updateFoundInDictsList, this, &MainWindow::updateFoundInDictsList );
-
   connect( view, &ArticleView::openLinkInNewTab, this, &MainWindow::openLinkInNewTab );
-
   connect( view, &ArticleView::showDefinitionInNewTab, this, &MainWindow::showDefinitionInNewTab );
-
   connect( view, &ArticleView::typingEvent, this, &MainWindow::typingEvent );
-
   connect( view, &ArticleView::activeArticleChanged, this, &MainWindow::activeArticleChanged );
-
   connect( view, &ArticleView::statusBarMessage, this, &MainWindow::showStatusBarMessage );
-
   connect( view, &ArticleView::showDictsPane, this, &MainWindow::showDictsPane );
-
   connect( view, &ArticleView::forceAddWordToHistory, this, &MainWindow::forceAddWordToHistory );
-
   connect( view, &ArticleView::sendWordToHistory, this, &MainWindow::addWordToHistory );
-
   connect( view, &ArticleView::sendWordToInputLine, this, &MainWindow::sendWordToInputLine );
-
   connect( view, &ArticleView::storeResourceSavePath, this, &MainWindow::storeResourceSavePath );
-
   connect( view, &ArticleView::zoomIn, this, &MainWindow::zoomin );
-
   connect( view, &ArticleView::zoomOut, this, &MainWindow::zoomout );
   connect( view, &ArticleView::saveBookmarkSignal, this, &MainWindow::addBookmarkToFavorite );
   connect( view, &ArticleView::translateSelectedText, this, &MainWindow::handleTranslateSelectedText );
 
+  view->setSelectionBySingleClick( cfg.preferences.selectWordBySingleClick );
+  view->setZoomFactor( cfg.preferences.zoomFactor );
+  return view;
+}
+
+ArticleView * MainWindow::createNewTab( bool switchToIt, const QString & name )
+{
+  ArticleView * view = createArticleView();
+
   connect( ui.searchInPageAction, &QAction::triggered, view, [ this, view ]() {
 #ifdef Q_OS_MACOS
-    // workaround to fix macos popup page search Ctrl + F
     if ( scanPopup && scanPopup->isActiveWindow() ) {
       scanPopup->openSearch();
       return;
@@ -2517,20 +2506,14 @@ ArticleView * MainWindow::createNewTab( bool switchToIt, const QString & name )
     view->openSearch();
   } );
 
-  view->setSelectionBySingleClick( cfg.preferences.selectWordBySingleClick );
-
-  int index = cfg.preferences.newTabsOpenAfterCurrentOne ? ui.tabWidget->currentIndex() + 1 : ui.tabWidget->count();
-
-  QString escaped = Utils::escapeAmps( name );
+  int index          = cfg.preferences.newTabsOpenAfterCurrentOne ? ui.tabWidget->currentIndex() + 1 : ui.tabWidget->count();
+  QString escaped    = Utils::escapeAmps( name );
 
   ui.tabWidget->insertTab( index, view, escaped );
   mruList.append( dynamic_cast< QWidget * >( view ) );
 
-  if ( switchToIt ) {
+  if ( switchToIt )
     ui.tabWidget->setCurrentIndex( index );
-  }
-
-  view->setZoomFactor( cfg.preferences.zoomFactor );
 
 #if defined( Q_OS_WIN )
   view->installEventFilter( this );
@@ -2548,32 +2531,7 @@ void MainWindow::inspectElement( QWebEnginePage * page )
 
 void MainWindow::tabCloseRequested( int x )
 {
-  QWidget * w = ui.tabWidget->widget( x );
-
-  mruList.removeOne( w );
-
-  // In MRU case: First, we switch to the appropriate tab
-  // and only then remove the old one.
-
-  // activate a tab in accordance with MRU
-  if ( cfg.preferences.mruTabOrder && !mruList.empty() ) {
-    ui.tabWidget->setCurrentWidget( mruList.at( 0 ) );
-  }
-  else if ( ui.tabWidget->count() > 1 ) {
-    // activate neighboring tab
-    int n = x >= ui.tabWidget->count() - 1 ? x - 1 : x + 1;
-    if ( n >= 0 ) {
-      ui.tabWidget->setCurrentIndex( n );
-    }
-  }
-
-  ui.tabWidget->removeTab( x );
-  delete w;
-
-  // if everything is closed, add a new tab
-  if ( ui.tabWidget->count() == 0 ) {
-    addNewTab();
-  }
+  closeTabInPanel( ui.tabWidget, x );
 }
 
 void MainWindow::closeCurrentTab()
@@ -2582,25 +2540,7 @@ void MainWindow::closeCurrentTab()
   int idx             = panel->currentIndex();
   if ( idx < 0 )
     return;
-
-  if ( panel == ui.tabWidget ) {
-    tabCloseRequested( idx );
-  }
-  else {
-    // Duplicate side-panel close logic inline (cf. createNewSidePanel lambda)
-    QWidget * w = panel->widget( idx );
-    if ( !w )
-      return;
-    mruList.removeOne( w );
-    panel->removeTab( idx );
-    delete w;
-    if ( panel->count() == 0 ) {
-      delete panel;
-      distributePanelSizes();
-    }
-    if ( totalTabCount() == 0 )
-      addNewTab();
-  }
+  closeTabInPanel( panel, idx );
 }
 
 void MainWindow::closeAllTabs()
@@ -2616,22 +2556,10 @@ void MainWindow::closeAllTabs()
       tabCloseRequested( ui.tabWidget->currentIndex() );
   }
   else {
-    // Side panel: close every tab, then delete the panel.
-    while ( panel->count() > 0 ) {
-      int idx = panel->currentIndex();
-      if ( idx < 0 )
-        break;
-      QWidget * w = panel->widget( idx );
-      if ( !w )
-        break;
-      mruList.removeOne( w );
-      panel->removeTab( idx );
-      delete w;
-    }
-    delete panel;
-    distributePanelSizes();
-    if ( totalTabCount() == 0 )
-      addNewTab();
+    // Side panel: close every tab. closeTabInPanel deletes panel when empty.
+    QPointer< QTabWidget > panelPtr = panel;
+    while ( panelPtr && panelPtr->count() > 0 )
+      closeTabInPanel( panelPtr, panelPtr->currentIndex() );
   }
 }
 
@@ -2659,12 +2587,7 @@ void MainWindow::closeRestTabs()
     for ( int i = panel->count() - 1; i >= 0; i-- ) {
       if ( panel->widget( i ) == keepWidget )
         continue;
-      QWidget * w = panel->widget( i );
-      if ( !w )
-        continue;
-      mruList.removeOne( w );
-      panel->removeTab( i );
-      delete w;
+      closeTabInPanel( panel, i );
     }
     panel->setCurrentWidget( keepWidget );
   }

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -713,7 +713,9 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   setupTabWidgetCommon( ui.tabWidget );
 
-  connect( &addTab, &QAbstractButton::clicked, this, &MainWindow::addNewTab );
+  connect( &addTab, &QAbstractButton::clicked, this, [ this ]() {
+    createNewTab( true, tr( "(untitled)" ) )->load( QUrl( "gdinternal://untitle-page" ) );
+  } );
 
   connect( ui.tabWidget, &QTabWidget::tabCloseRequested, this, &MainWindow::tabCloseRequested );
 
@@ -1468,7 +1470,7 @@ void MainWindow::setupTabWidgetCommon( QTabWidget * panel )
   connect( panel->tabBar(), &QTabBar::tabBarDoubleClicked, this, [ this, panel ]( int index ) {
     if ( index == -1 ) {
       if ( panel == ui.tabWidget )
-        addNewTab();
+        createNewTab( true, tr( "(untitled)" ) )->load( QUrl( "gdinternal://untitle-page" ) );
       else
         addNewTabToPanel( panel );
     }

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1489,7 +1489,7 @@ QTabWidget * MainWindow::createPanel()
   panel->setContextMenuPolicy( Qt::CustomContextMenu );
   panel->tabBar()->installEventFilter( this );
 
-  // "+" button — every panel gets one
+  // "+" button for creating new tabs in this panel
   auto * addBtn = new QToolButton( panel );
   addBtn->setAutoRaise( true );
   addBtn->setIcon( QIcon( ":/icons/addtab.svg" ) );
@@ -1643,7 +1643,7 @@ void MainWindow::showTabContextMenu( QTabWidget * panel, int tabIdx, QPoint glob
         tabCloseRequested( ui.tabWidget->currentIndex() );
     }
     else {
-      // Side panel: close every tab — panel self-deletes via closeTabInPanel
+      // Side panel: close every tab; panel is deleted when empty
       while ( panelPtr && panelPtr->count() > 0 )
         closeTabInPanel( panelPtr, panelPtr->count() - 1 );
     }
@@ -3312,8 +3312,10 @@ bool MainWindow::eventFilter( QObject * obj, QEvent * ev )
       }
     }
 
-    // workaround to fix #660 — only for bare keys (no modifier)
-    // Let Alt+Up/Down through so articleUp/articleDown shortcuts fire.
+    // When no child widget has focus, a bare key press (without modifiers)
+    // reaches the main window. Redirect it to the article view so scrolling
+    // works. Modified key presses (Alt-Up etc.) belong to the shortcut system
+    // and must not be consumed here.
     if ( obj == this && ev->type() == QEvent::KeyPress && ke->modifiers() == Qt::NoModifier
          && ( key == Qt::Key_Up || key == Qt::Key_Down || key == Qt::Key_Space || key == Qt::Key_PageUp
               || key == Qt::Key_PageDown ) ) {

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -3312,8 +3312,9 @@ bool MainWindow::eventFilter( QObject * obj, QEvent * ev )
       }
     }
 
-    // workaround to fix #660
-    if ( obj == this && ev->type() == QEvent::KeyPress
+    // workaround to fix #660 — only for bare keys (no modifier)
+    // Let Alt+Up/Down through so articleUp/articleDown shortcuts fire.
+    if ( obj == this && ev->type() == QEvent::KeyPress && ke->modifiers() == Qt::NoModifier
          && ( key == Qt::Key_Up || key == Qt::Key_Down || key == Qt::Key_Space || key == Qt::Key_PageUp
               || key == Qt::Key_PageDown ) ) {
       ArticleView * view = getCurrentArticleView();

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1493,19 +1493,19 @@ QTabWidget * MainWindow::createNewSidePanel()
   } );
 
   connect( panel, &QTabWidget::tabCloseRequested, this, [ this, panel ]( int tabIndex ) {
-    auto * w       = panel->widget( tabIndex );
-    auto * avClose = qobject_cast< ArticleView * >( w );
-    if ( !avClose )
+    QWidget * w = panel->widget( tabIndex );
+    if ( !w )
       return;
-    QString tabTitle = panel->tabText( tabIndex );
+    mruList.removeOne( w );
     panel->removeTab( tabIndex );
-    int newIdx = ui.tabWidget->addTab( avClose, tabTitle );
-    ui.tabWidget->setCurrentIndex( newIdx );
-    updateTabTitleMarker( avClose );
+    delete w;
     if ( panel->count() == 0 ) {
       delete panel;
       distributePanelSizes();
     }
+    // Make sure at least one tab exists somewhere
+    if ( totalTabCount() == 0 )
+      addNewTab();
   } );
 
   ui.panelSplitter->addWidget( panel );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1428,6 +1428,17 @@ QTabWidget * MainWindow::panelForView( ArticleView * av )
   return nullptr;
 }
 
+QTabWidget * MainWindow::activePanel()
+{
+  auto * av = getCurrentArticleView();
+  if ( av ) {
+    auto * panel = panelForView( av );
+    if ( panel )
+      return panel;
+  }
+  return ui.tabWidget;
+}
+
 void MainWindow::setupTabWidgetCommon( QTabWidget * panel )
 {
   panel->setMovable( true );
@@ -1558,10 +1569,14 @@ void MainWindow::showTabContextMenu( QTabWidget * panel, int tabIdx, QPoint glob
   // Close all tabs except current (panel-scoped)
   if ( panel->count() > 1 ) {
     QAction * closeRestAction = menu.addAction( tr( "Close all tabs except current" ) );
-    connect( closeRestAction, &QAction::triggered, this, [ panel, tabIdx ]() {
-      for ( int i = panel->count() - 1; i >= 0; i-- ) {
-        if ( i != tabIdx )
-          emit panel->tabCloseRequested( i );
+    QPointer< QTabWidget > panelPtr = panel;
+    QWidget * keepWidget            = panel->widget( tabIdx );
+    connect( closeRestAction, &QAction::triggered, this, [ this, panelPtr, keepWidget ]() {
+      if ( !panelPtr )
+        return;
+      for ( int i = panelPtr->count() - 1; i >= 0; i-- ) {
+        if ( panelPtr->widget( i ) != keepWidget )
+          emit panelPtr->tabCloseRequested( i );
       }
     } );
   }
@@ -1569,10 +1584,11 @@ void MainWindow::showTabContextMenu( QTabWidget * panel, int tabIdx, QPoint glob
   menu.addSeparator();
 
   // Close all tabs (panel-scoped)
-  QAction * closeAllAction = menu.addAction( tr( "Close all tabs" ) );
-  connect( closeAllAction, &QAction::triggered, this, [ panel ]() {
-    while ( panel->count() > 0 )
-      emit panel->tabCloseRequested( panel->count() - 1 );
+  QAction * closeAllAction    = menu.addAction( tr( "Close all tabs" ) );
+  QPointer< QTabWidget > panelPtr = panel;
+  connect( closeAllAction, &QAction::triggered, this, [ this, panelPtr ]() {
+    while ( panelPtr && panelPtr->count() > 0 )
+      emit panelPtr->tabCloseRequested( panelPtr->count() - 1 );
   } );
 
   menu.addSeparator();
@@ -2397,7 +2413,11 @@ void MainWindow::switchToWindow( QAction * act )
 
 void MainWindow::addNewTab()
 {
-  createNewTab( true, tr( "(untitled)" ) )->load( QUrl( "gdinternal://untitle-page" ) );
+  QTabWidget * panel = activePanel();
+  if ( panel == ui.tabWidget )
+    createNewTab( true, tr( "(untitled)" ) )->load( QUrl( "gdinternal://untitle-page" ) );
+  else
+    addNewTabToPanel( panel );
 }
 
 void MainWindow::addNewTabToPanel( QTabWidget * panel )
@@ -2555,59 +2575,115 @@ void MainWindow::tabCloseRequested( int x )
 
 void MainWindow::closeCurrentTab()
 {
-  tabCloseRequested( ui.tabWidget->currentIndex() );
+  QTabWidget * panel = activePanel();
+  int idx             = panel->currentIndex();
+  if ( idx < 0 )
+    return;
+
+  if ( panel == ui.tabWidget ) {
+    tabCloseRequested( idx );
+  }
+  else {
+    // Duplicate side-panel close logic inline (cf. createNewSidePanel lambda)
+    QWidget * w = panel->widget( idx );
+    if ( !w )
+      return;
+    mruList.removeOne( w );
+    panel->removeTab( idx );
+    delete w;
+    if ( panel->count() == 0 ) {
+      delete panel;
+      distributePanelSizes();
+    }
+    if ( totalTabCount() == 0 )
+      addNewTab();
+  }
 }
 
 void MainWindow::closeAllTabs()
 {
-  while ( ui.tabWidget->count() > 1 ) {
-    closeCurrentTab();
-  }
+  QTabWidget * panel = activePanel();
 
-  // close last tab
-  closeCurrentTab();
+  if ( panel == ui.tabWidget ) {
+    // Close all but one, then close the last — triggers addNewTab()
+    // which replaces it with a fresh untitled tab.
+    while ( ui.tabWidget->count() > 1 )
+      tabCloseRequested( ui.tabWidget->currentIndex() );
+    if ( ui.tabWidget->count() > 0 )
+      tabCloseRequested( ui.tabWidget->currentIndex() );
+  }
+  else {
+    // Side panel: close every tab, then delete the panel.
+    while ( panel->count() > 0 ) {
+      int idx = panel->currentIndex();
+      if ( idx < 0 )
+        break;
+      QWidget * w = panel->widget( idx );
+      if ( !w )
+        break;
+      mruList.removeOne( w );
+      panel->removeTab( idx );
+      delete w;
+    }
+    delete panel;
+    distributePanelSizes();
+    if ( totalTabCount() == 0 )
+      addNewTab();
+  }
 }
 
 void MainWindow::closeRestTabs()
 {
-  if ( ui.tabWidget->count() < 2 ) {
+  QTabWidget * panel = activePanel();
+  if ( panel->count() < 2 )
     return;
+
+  if ( panel == ui.tabWidget ) {
+    // Track keep tab by widget pointer to handle index drift
+    QWidget * keepWidget = ui.tabWidget->currentWidget();
+
+    // Close from highest index down to avoid index drift
+    for ( int i = ui.tabWidget->count() - 1; i >= 0; i-- ) {
+      if ( ui.tabWidget->widget( i ) == keepWidget )
+        continue;
+      tabCloseRequested( i );
+    }
+    ui.tabWidget->setCurrentWidget( keepWidget );
   }
+  else {
+    QWidget * keepWidget = panel->currentWidget();
 
-  int idx = ui.tabWidget->currentIndex();
-
-  for ( int i = 0; i < idx; i++ ) {
-    tabCloseRequested( 0 );
-  }
-
-  ui.tabWidget->setCurrentIndex( 0 );
-
-  while ( ui.tabWidget->count() > 1 ) {
-    tabCloseRequested( 1 );
+    for ( int i = panel->count() - 1; i >= 0; i-- ) {
+      if ( panel->widget( i ) == keepWidget )
+        continue;
+      QWidget * w = panel->widget( i );
+      if ( !w )
+        continue;
+      mruList.removeOne( w );
+      panel->removeTab( i );
+      delete w;
+    }
+    panel->setCurrentWidget( keepWidget );
   }
 }
 
 void MainWindow::switchToNextTab()
 {
-  if ( ui.tabWidget->count() < 2 ) {
+  QTabWidget * panel = activePanel();
+  if ( panel->count() < 2 )
     return;
-  }
-
-  ui.tabWidget->setCurrentIndex( ( ui.tabWidget->currentIndex() + 1 ) % ui.tabWidget->count() );
+  panel->setCurrentIndex( ( panel->currentIndex() + 1 ) % panel->count() );
 }
 
 void MainWindow::switchToPrevTab()
 {
-  if ( ui.tabWidget->count() < 2 ) {
+  QTabWidget * panel = activePanel();
+  if ( panel->count() < 2 )
     return;
-  }
-
-  if ( !ui.tabWidget->currentIndex() ) {
-    ui.tabWidget->setCurrentIndex( ui.tabWidget->count() - 1 );
-  }
-  else {
-    ui.tabWidget->setCurrentIndex( ui.tabWidget->currentIndex() - 1 );
-  }
+  if ( !panel->currentIndex() )
+    panel->setCurrentIndex( panel->count() - 1 );
+  else
+    panel->setCurrentIndex( panel->currentIndex() - 1 );
 }
 
 void MainWindow::backClicked()
@@ -3706,7 +3782,7 @@ void MainWindow::showTranslationFor( const QString & word, unsigned inGroup, con
   GlobalBroadcaster::instance()->is_popup = false;
 
   ArticleView * view = getCurrentArticleView();
-  if ( !view )
+  if ( !view || view->isWebsite() )
     view = getFirstNonWebSiteArticleView();
 
   navPronounce->setEnabled( false );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -728,7 +728,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
     ui.tabWidget->setCurrentIndex( act->data().toInt() );
   } );
 
-  // Double-click empty tab bar
+  // Double-click blank space in tab widget
   connect( ui.tabWidget->tabBar(), &QTabBar::tabBarDoubleClicked, this, [ this ]( int index ) {
     if ( index == -1 )
       createNewTab( true, tr( "(untitled)" ) )->load( QUrl( "gdinternal://untitle-page" ) );
@@ -1522,7 +1522,7 @@ QTabWidget * MainWindow::createPanel()
     panel->setCurrentIndex( act->data().toInt() );
   } );
 
-  // Double-click empty tab bar → new tab in this panel
+  // Double-click blank space in tab widget → new tab in this panel
   connect( panel->tabBar(), &QTabBar::tabBarDoubleClicked, this, [ this, panel ]( int index ) {
     if ( index == -1 )
       addNewTabToPanel( panel );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -349,7 +349,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   navToolbar->widgetForAction( navToolbar->addSeparator() )->setObjectName( "separatorBeforeAddToFavorites" );
 
-  addToFavorites = navToolbar->addAction( starIcon, tr( "Add current tab to Favorites" ) );
+  addToFavorites = navToolbar->addAction( starIcon, tr( "Add to Favorites" ) );
   navToolbar->widgetForAction( addToFavorites )->setObjectName( "addToFavoritesButton" );
 
   connect( addToFavorites, &QAction::triggered, this, &MainWindow::handleAddToFavoritesButton );
@@ -564,55 +564,6 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   connect( &addAllTabToFavoritesAction, &QAction::triggered, this, &MainWindow::addAllTabsToFavorites );
 
-  tabMenu = new QMenu( this );
-
-  // Close actions scoped to the main panel (tabMenuTabIndex is set in tabMenuRequested)
-  QAction * tabMenuCloseAction = tabMenu->addAction( tr( "Close current tab" ) );
-  connect( tabMenuCloseAction, &QAction::triggered, this, [ this ]() {
-    if ( tabMenuTabIndex >= 0 )
-      emit ui.tabWidget->tabCloseRequested( tabMenuTabIndex );
-  } );
-
-  QAction * tabMenuCloseRestAction = tabMenu->addAction( tr( "Close all tabs except current" ) );
-  connect( tabMenuCloseRestAction, &QAction::triggered, this, [ this ]() {
-    QWidget * keepWidget = ( tabMenuTabIndex >= 0 ) ? ui.tabWidget->widget( tabMenuTabIndex ) : nullptr;
-    for ( int i = ui.tabWidget->count() - 1; i >= 0; i-- ) {
-      if ( ui.tabWidget->widget( i ) != keepWidget )
-        tabCloseRequested( i );
-    }
-    if ( keepWidget )
-      ui.tabWidget->setCurrentWidget( keepWidget );
-  } );
-
-  tabMenu->addSeparator();
-
-  QAction * tabMenuCloseAllAction = tabMenu->addAction( tr( "Close all tabs" ) );
-  connect( tabMenuCloseAllAction, &QAction::triggered, this, [ this ]() {
-    while ( ui.tabWidget->count() > 1 )
-      tabCloseRequested( ui.tabWidget->currentIndex() );
-    if ( ui.tabWidget->count() > 0 )
-      tabCloseRequested( ui.tabWidget->currentIndex() );
-  } );
-
-  tabMenu->addSeparator();
-
-  // Move-to submenu is rebuilt dynamically in tabMenuRequested
-  moveToMenu = tabMenu->addMenu( tr( "Move to Panel" ) );
-
-  // Flat New Panel action — shown when no side panels exist (submenu hidden)
-  newPanelAction = tabMenu->addAction( tr( "Move to New Panel" ) );
-  connect( newPanelAction, &QAction::triggered, this, [ this ]() {
-    if ( tabMenuTabIndex >= 0 ) {
-      auto * av = qobject_cast< ArticleView * >( ui.tabWidget->widget( tabMenuTabIndex ) );
-      if ( av )
-        addPanel( av, -1 );
-    }
-  } );
-  tabMenu->addSeparator();
-
-  tabMenu->addAction( addToFavorites );
-  tabMenu->addAction( &addAllTabToFavoritesAction );
-
   // Dictionary bar names
   showDictBarNamesAction.setCheckable( true );
   showDictBarNamesAction.setChecked( cfg.showingDictBarNames );
@@ -768,7 +719,15 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   connect( ui.tabWidget, &QTabWidget::currentChanged, this, &MainWindow::tabSwitched );
 
-  connect( ui.tabWidget, &QWidget::customContextMenuRequested, this, &MainWindow::tabMenuRequested );
+  connect( ui.tabWidget, &QWidget::customContextMenuRequested, this, [ this ]( const QPoint & pos ) {
+    int tabIdx = ui.tabWidget->tabBar()->tabAt( pos );
+    if ( tabIdx >= 0 ) {
+      auto * av = qobject_cast< ArticleView * >( ui.tabWidget->widget( tabIdx ) );
+      if ( av )
+        lastFocusedArticleView = av;
+      showTabContextMenu( ui.tabWidget, tabIdx, ui.tabWidget->mapToGlobal( pos ) );
+    }
+  } );
 
   ui.tabWidget->setTabsClosable( true );
 
@@ -1412,7 +1371,7 @@ void MainWindow::addPanel( ArticleView * av, int targetPanelIdx )
 
   // Auto-create empty tab if main panel just became empty
   if ( currentPanel == ui.tabWidget && ui.tabWidget->count() == 0 ) {
-    createNewTab( true, tr( "(empty)" ) );
+    createNewTab( true, tr( "(untitled)" ) );
   }
 
   // Determine target panel
@@ -1587,6 +1546,8 @@ void MainWindow::showTabContextMenu( QTabWidget * panel, int tabIdx, QPoint glob
 
   // Close Tab
   QAction * closeAction = menu.addAction( tr( "Close current tab" ) );
+  closeAction->setShortcut( QKeySequence( "Ctrl+W" ) );
+  closeAction->setShortcutVisibleInContextMenu( true );
   connect( closeAction, &QAction::triggered, this, [ panel, tabIdx ]() {
     emit panel->tabCloseRequested( tabIdx );
   } );
@@ -1609,11 +1570,25 @@ void MainWindow::showTabContextMenu( QTabWidget * panel, int tabIdx, QPoint glob
   menu.addSeparator();
 
   // Close all tabs (panel-scoped)
-  QAction * closeAllAction    = menu.addAction( tr( "Close all tabs" ) );
+  QAction * closeAllAction        = menu.addAction( tr( "Close all tabs" ) );
+  closeAllAction->setShortcut( QKeySequence( "Ctrl+Shift+W" ) );
+  closeAllAction->setShortcutVisibleInContextMenu( true );
   QPointer< QTabWidget > panelPtr = panel;
   connect( closeAllAction, &QAction::triggered, this, [ this, panelPtr ]() {
-    while ( panelPtr && panelPtr->count() > 0 )
-      emit panelPtr->tabCloseRequested( panelPtr->count() - 1 );
+    if ( !panelPtr )
+      return;
+    if ( panelPtr == ui.tabWidget ) {
+      // Main panel: close all but one, then close last — triggers addNewTab()
+      while ( ui.tabWidget->count() > 1 )
+        tabCloseRequested( ui.tabWidget->currentIndex() );
+      if ( ui.tabWidget->count() > 0 )
+        tabCloseRequested( ui.tabWidget->currentIndex() );
+    }
+    else {
+      // Side panel: close every tab — panel self-deletes via closeTabInPanel
+      while ( panelPtr && panelPtr->count() > 0 )
+        closeTabInPanel( panelPtr, panelPtr->count() - 1 );
+    }
   } );
 
   menu.addSeparator();
@@ -1649,16 +1624,19 @@ void MainWindow::showTabContextMenu( QTabWidget * panel, int tabIdx, QPoint glob
   auto * av = qobject_cast< ArticleView * >( panel->widget( tabIdx ) );
   if ( av ) {
 
-    // Add to Favorites
-    QAction * favAction = menu.addAction( tr( "Add to Favorites" ) );
+    // Add to Favorites (blue star if already favorited)
+    QString headword          = av->getCurrentWord();
+    bool alreadyFav            = !headword.isEmpty() && ui.favoritesPaneWidget->isWordPresentInActiveFolder( headword );
+    QIcon favIcon              = alreadyFav ? blueStarIcon : starIcon;
+    QAction * favAction        = menu.addAction( favIcon, tr( "Add to Favorites" ) );
     connect( favAction, &QAction::triggered, this, [ this, av ]() {
-      QString headword = av->getCurrentWord();
-      if ( !headword.isEmpty() )
-        ui.favoritesPaneWidget->addWordToActiveFav( headword );
+      QString word = av->getCurrentWord();
+      if ( !word.isEmpty() )
+        ui.favoritesPaneWidget->addWordToActiveFav( word );
     } );
 
     // Add all tabs to Favorites (panel-scoped)
-    QAction * favAllAction = menu.addAction( tr( "Add all tabs to Favorites" ) );
+    QAction * favAllAction = menu.addAction( starIcon, tr( "Add all tabs to Favorites" ) );
     connect( favAllAction, &QAction::triggered, this, [ this, panel ]() {
       for ( int i = 0; i < panel->count(); i++ ) {
         auto * av2 = qobject_cast< ArticleView * >( panel->widget( i ) );
@@ -2834,43 +2812,6 @@ void MainWindow::tabSwitched( int )
     groupList->setCurrentGroup( view->getCurrentGroupId() );
     groupList->blockSignals( false );
   }
-}
-
-void MainWindow::tabMenuRequested( QPoint pos )
-{
-  tabMenuTabIndex = ui.tabWidget->tabBar()->tabAt( pos );
-
-  bool hasSidePanels = ( ui.panelSplitter->count() > 1 );
-  if ( moveToMenu ) {
-    moveToMenu->menuAction()->setVisible( hasSidePanels );
-    if ( hasSidePanels && tabMenuTabIndex >= 0 ) {
-      moveToMenu->clear();
-      for ( int i = 0; i < ui.panelSplitter->count(); i++ ) {
-        auto * p = qobject_cast< QTabWidget * >( ui.panelSplitter->widget( i ) );
-        if ( !p )
-          continue;
-        // Skip self
-        if ( p == ui.tabWidget && ui.tabWidget->indexOf( ui.tabWidget->widget( tabMenuTabIndex ) ) >= 0 )
-          continue;
-        if ( p->indexOf( ui.tabWidget->widget( tabMenuTabIndex ) ) >= 0 )
-          continue;
-
-        QString label        = ( i == 0 ) ? tr( "Main Panel" ) : tr( "Panel %1" ).arg( i );
-        QAction * moveAction = moveToMenu->addAction( label );
-        int targetIdx        = i;
-        connect( moveAction, &QAction::triggered, this, [ this, targetIdx ]() {
-          if ( tabMenuTabIndex >= 0 ) {
-            auto * av = qobject_cast< ArticleView * >( ui.tabWidget->widget( tabMenuTabIndex ) );
-            if ( av )
-              addPanel( av, targetIdx );
-          }
-        } );
-      }
-    }
-  }
-
-  // Hide Always Query for website tabs, sync checked state to right-clicked tab
-  tabMenu->popup( ui.tabWidget->mapToGlobal( pos ) );
 }
 
 void MainWindow::dictionaryBarToggled( bool )

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -2733,7 +2733,7 @@ void MainWindow::tabSwitched( int )
   }
 
   // Set icon for "Add to Favorites" action
-  auto view = getCurrentArticleView();
+  auto view = qobject_cast< ArticleView * >( ui.tabWidget->currentWidget() );
   QString headword;
   if ( view ) {
     headword = view->getCurrentWord();

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1066,6 +1066,10 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
       groupList->blockSignals( true );
       groupList->setCurrentGroup( av->getCurrentGroupId() );
       groupList->blockSignals( false );
+      // Update dictionary bar to reflect the newly focused tab's group
+      unsigned grp_id = av->getCurrentGroupId();
+      cfg.lastMainGroupId = grp_id;
+      dictionaryBar.updateToGroup( groupInstances.findGroup( grp_id ), &cfg.mutedDictionaries, cfg );
     }
   } );
 }

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -743,7 +743,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   connect( &addTab, &QAbstractButton::clicked, this, &MainWindow::addNewTab );
 
-  connect( ui.tabWidget, &MainTabWidget::tabBarDoubleClicked, this, [ this ]( const int index ) {
+  connect( ui.tabWidget->tabBar(), &QTabBar::tabBarDoubleClicked, this, [ this ]( const int index ) {
     if ( -1 == index ) { // empty space at tabbar clicked.
       this->addNewTab();
     }
@@ -1442,6 +1442,39 @@ QTabWidget * MainWindow::createNewSidePanel()
   panel->setUsesScrollButtons( true );
   panel->setDocumentMode( true );
   panel->tabBar()->installEventFilter( this );
+
+  // Double-click empty tab bar space → new untitled tab in this panel
+  connect( panel->tabBar(), &QTabBar::tabBarDoubleClicked, this, [ this, panel ]( int index ) {
+    if ( index == -1 ) {
+      addNewTabToPanel( panel );
+    }
+  } );
+
+  // Tab list dropdown button
+  auto * tabListBtn = new QToolButton( panel );
+  tabListBtn->setAutoRaise( true );
+  tabListBtn->setIcon( QIcon( ":/icons/windows-list.svg" ) );
+  tabListBtn->setToolTip( tr( "Open Tabs List" ) );
+  tabListBtn->setPopupMode( QToolButton::InstantPopup );
+  tabListBtn->setFocusPolicy( Qt::NoFocus );
+
+  auto * panelTabMenu = new QMenu( tr( "Opened tabs" ), panel );
+  tabListBtn->setMenu( panelTabMenu );
+  connect( panelTabMenu, &QMenu::aboutToShow, this, [ this, panel, panelTabMenu ]() {
+    panelTabMenu->clear();
+    for ( int i = 0; i < panel->count(); i++ ) {
+      QAction * act = panelTabMenu->addAction( panel->tabIcon( i ), panel->tabText( i ) );
+      act->setData( i );
+      if ( i == panel->currentIndex() )
+        panelTabMenu->setDefaultAction( act );
+    }
+  } );
+  connect( panelTabMenu, &QMenu::triggered, this, [ panel ]( QAction * act ) {
+    int idx = act->data().toInt();
+    panel->setCurrentIndex( idx );
+  } );
+
+  panel->setCornerWidget( tabListBtn );
 
   // Transfer focus to webview when side panel tab changes (group list syncs via focusChanged)
   connect( panel, &QTabWidget::currentChanged, this, [ this, panel ]( int index ) {
@@ -2362,6 +2395,46 @@ void MainWindow::switchToWindow( QAction * act )
 void MainWindow::addNewTab()
 {
   createNewTab( true, tr( "(untitled)" ) )->load( QUrl( "gdinternal://untitle-page" ) );
+}
+
+void MainWindow::addNewTabToPanel( QTabWidget * panel )
+{
+  ArticleView * view = new ArticleView( this,
+                                        articleNetMgr,
+                                        false,
+                                        cfg,
+                                        translateLine,
+                                        dictionaryBar.toggleViewAction(),
+                                        groupList->getCurrentGroup() );
+
+  connect( view, &ArticleView::inspectSignal, this, &MainWindow::inspectElement );
+  connect( view, &ArticleView::titleChanged, this, &MainWindow::titleChanged );
+  connect( view, &ArticleView::pageLoaded, this, &MainWindow::pageLoaded );
+  connect( view, &ArticleView::updateFoundInDictsList, this, &MainWindow::updateFoundInDictsList );
+  connect( view, &ArticleView::openLinkInNewTab, this, &MainWindow::openLinkInNewTab );
+  connect( view, &ArticleView::showDefinitionInNewTab, this, &MainWindow::showDefinitionInNewTab );
+  connect( view, &ArticleView::typingEvent, this, &MainWindow::typingEvent );
+  connect( view, &ArticleView::activeArticleChanged, this, &MainWindow::activeArticleChanged );
+  connect( view, &ArticleView::statusBarMessage, this, &MainWindow::showStatusBarMessage );
+  connect( view, &ArticleView::showDictsPane, this, &MainWindow::showDictsPane );
+  connect( view, &ArticleView::forceAddWordToHistory, this, &MainWindow::forceAddWordToHistory );
+  connect( view, &ArticleView::sendWordToHistory, this, &MainWindow::addWordToHistory );
+  connect( view, &ArticleView::sendWordToInputLine, this, &MainWindow::sendWordToInputLine );
+  connect( view, &ArticleView::storeResourceSavePath, this, &MainWindow::storeResourceSavePath );
+  connect( view, &ArticleView::wordLookedUp, this, &MainWindow::forwardToAlwaysQueryTabs );
+  connect( view, &ArticleView::zoomIn, this, &MainWindow::zoomin );
+  connect( view, &ArticleView::zoomOut, this, &MainWindow::zoomout );
+  connect( view, &ArticleView::saveBookmarkSignal, this, &MainWindow::addBookmarkToFavorite );
+  connect( view, &ArticleView::translateSelectedText, this, &MainWindow::handleTranslateSelectedText );
+
+  view->setSelectionBySingleClick( cfg.preferences.selectWordBySingleClick );
+  view->setZoomFactor( cfg.preferences.zoomFactor );
+
+  int index = panel->addTab( view, tr( "(untitled)" ) );
+  panel->setCurrentIndex( index );
+  mruList.append( dynamic_cast< QWidget * >( view ) );
+
+  view->load( QUrl( "gdinternal://untitle-page" ) );
 }
 
 ArticleView * MainWindow::createNewTab( bool switchToIt, const QString & name )

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -565,10 +565,35 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   connect( &addAllTabToFavoritesAction, &QAction::triggered, this, &MainWindow::addAllTabsToFavorites );
 
   tabMenu = new QMenu( this );
-  tabMenu->addAction( &closeCurrentTabAction );
-  tabMenu->addAction( &closeRestTabAction );
+
+  // Close actions scoped to the main panel (tabMenuTabIndex is set in tabMenuRequested)
+  QAction * tabMenuCloseAction = tabMenu->addAction( tr( "Close current tab" ) );
+  connect( tabMenuCloseAction, &QAction::triggered, this, [ this ]() {
+    if ( tabMenuTabIndex >= 0 )
+      emit ui.tabWidget->tabCloseRequested( tabMenuTabIndex );
+  } );
+
+  QAction * tabMenuCloseRestAction = tabMenu->addAction( tr( "Close all tabs except current" ) );
+  connect( tabMenuCloseRestAction, &QAction::triggered, this, [ this ]() {
+    QWidget * keepWidget = ( tabMenuTabIndex >= 0 ) ? ui.tabWidget->widget( tabMenuTabIndex ) : nullptr;
+    for ( int i = ui.tabWidget->count() - 1; i >= 0; i-- ) {
+      if ( ui.tabWidget->widget( i ) != keepWidget )
+        tabCloseRequested( i );
+    }
+    if ( keepWidget )
+      ui.tabWidget->setCurrentWidget( keepWidget );
+  } );
+
   tabMenu->addSeparator();
-  tabMenu->addAction( &closeAllTabAction );
+
+  QAction * tabMenuCloseAllAction = tabMenu->addAction( tr( "Close all tabs" ) );
+  connect( tabMenuCloseAllAction, &QAction::triggered, this, [ this ]() {
+    while ( ui.tabWidget->count() > 1 )
+      tabCloseRequested( ui.tabWidget->currentIndex() );
+    if ( ui.tabWidget->count() > 0 )
+      tabCloseRequested( ui.tabWidget->currentIndex() );
+  } );
+
   tabMenu->addSeparator();
 
   // Move-to submenu is rebuilt dynamically in tabMenuRequested

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -353,6 +353,18 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   connect( addToFavorites, &QAction::triggered, this, &MainWindow::handleAddToFavoritesButton );
   connect( ui.actionAddToFavorites, &QAction::triggered, this, &MainWindow::addCurrentTabToFavorites );
 
+  // Ctrl+F: open search bar in the currently focused article view
+  connect( ui.searchInPageAction, &QAction::triggered, this, [ this ]() {
+#ifdef Q_OS_MACOS
+    if ( scanPopup && scanPopup->isActiveWindow() ) {
+      scanPopup->openSearch();
+      return;
+    }
+#endif
+    if ( auto * view = getCurrentArticleView() )
+      view->openSearch();
+  } );
+
   beforeOptionsSeparator = navToolbar->addSeparator();
   navToolbar->widgetForAction( beforeOptionsSeparator )->setObjectName( "beforeOptionsSeparator" );
   beforeOptionsSeparator->setVisible( cfg.preferences.hideMenubar );
@@ -2507,16 +2519,6 @@ ArticleView * MainWindow::createNewTab( bool switchToIt, const QString & name )
 {
   ArticleView * view = createArticleView();
 
-  connect( ui.searchInPageAction, &QAction::triggered, view, [ this, view ]() {
-#ifdef Q_OS_MACOS
-    if ( scanPopup && scanPopup->isActiveWindow() ) {
-      scanPopup->openSearch();
-      return;
-    }
-#endif
-    view->openSearch();
-  } );
-
   int index          = cfg.preferences.newTabsOpenAfterCurrentOne ? ui.tabWidget->currentIndex() + 1 : ui.tabWidget->count();
   QString escaped    = Utils::escapeAmps( name );
 
@@ -3303,8 +3305,9 @@ bool MainWindow::eventFilter( QObject * obj, QEvent * ev )
 {
   if ( ev->type() == QEvent::ShortcutOverride || ev->type() == QEvent::KeyPress ) {
     auto * ke = dynamic_cast< QKeyEvent * >( ev );
-    // Handle F3/Shift+F3 shortcuts
     const int key = ke->key();
+
+    // Handle F3/Shift+F3 shortcuts
     if ( key == Qt::Key_F3 ) {
       ArticleView * view = getCurrentArticleView();
       if ( view && view->handleF3( obj, ev ) ) {

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -14,7 +14,6 @@
 #include "preferences.hh"
 #include "globalregex.hh"
 #include "about.hh"
-#include "mruqmenu.hh"
 #include "gestures.hh"
 #include "dictheadwords.hh"
 #include <QTextStream>
@@ -178,7 +177,6 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   useNormalIconsInToolbarsAction( tr( "Show &Normal Icons in Toolbars" ), this ),
   stopAudioAction( this ),
   trayIconMenu( this ),
-  addTab( this ),
   cfg( cfg_ ),
   history( cfg_.preferences.maxStringsInHistory, cfg_.maxHeadwordSize ),
   dictionaryBar( this, cfg.preferences.maxDictionaryRefsInContextMenu ),
@@ -500,11 +498,6 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   addTabAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
   addTabAction.setShortcut( QKeySequence( "Ctrl+T" ) );
 
-  // Tab management
-  tabListMenu = new MRUQMenu( tr( "Opened tabs" ), ui.tabWidget );
-
-  connect( tabListMenu, &MRUQMenu::requestTabChange, ui.tabWidget, &MainTabWidget::setCurrentIndex );
-
   connect( &addTabAction, &QAction::triggered, this, &MainWindow::addNewTab );
 
   addAction( &addTabAction );
@@ -698,29 +691,50 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   connect( navBack, &QAction::triggered, this, &MainWindow::backClicked );
   connect( navForward, &QAction::triggered, this, &MainWindow::forwardClicked );
 
-  addTab.setAutoRaise( true );
-  addTab.setToolTip( tr( "New Tab" ) );
-  addTab.setFocusPolicy( Qt::NoFocus );
-  addTab.setIcon( QIcon( ":/icons/addtab.svg" ) );
-
   ui.tabWidget->setHideSingleTab( cfg.preferences.hideSingleTab );
   ui.tabWidget->clear();
 
+  // Main panel setup (equivalent to createPanel but on existing ui.tabWidget)
+  ui.tabWidget->setMovable( true );
+  ui.tabWidget->setDocumentMode( true );
+  ui.tabWidget->setTabsClosable( true );
   ui.tabWidget->setContextMenuPolicy( Qt::CustomContextMenu );
 
-  ui.tabWidget->setCornerWidget( &addTab, Qt::TopLeftCorner );
-  // ui.tabWidget->setCornerWidget( &closeTab, Qt::TopRightCorner );
-
-  setupTabWidgetCommon( ui.tabWidget );
-
-  connect( &addTab, &QAbstractButton::clicked, this, [ this ]() {
+  // "+" button
+  auto * addBtn = new QToolButton( ui.tabWidget );
+  addBtn->setAutoRaise( true );
+  addBtn->setIcon( QIcon( ":/icons/addtab.svg" ) );
+  addBtn->setToolTip( tr( "New Tab" ) );
+  addBtn->setFocusPolicy( Qt::NoFocus );
+  ui.tabWidget->setCornerWidget( addBtn, Qt::TopLeftCorner );
+  connect( addBtn, &QAbstractButton::clicked, this, [ this ]() {
     createNewTab( true, tr( "(untitled)" ) )->load( QUrl( "gdinternal://untitle-page" ) );
   } );
 
-  connect( ui.tabWidget, &QTabWidget::tabCloseRequested, this, &MainWindow::tabCloseRequested );
+  // Tab list dropdown
+  auto * tlBtn = new QToolButton( ui.tabWidget );
+  tlBtn->setAutoRaise( true );
+  tlBtn->setIcon( QIcon( ":/icons/windows-list.svg" ) );
+  tlBtn->setToolTip( tr( "Open Tabs List" ) );
+  tlBtn->setPopupMode( QToolButton::InstantPopup );
+  tlBtn->setFocusPolicy( Qt::NoFocus );
+  ui.tabWidget->setCornerWidget( tlBtn, Qt::TopRightCorner );
+  tabListButton = tlBtn;
 
-  connect( ui.tabWidget, &QTabWidget::currentChanged, this, &MainWindow::tabSwitched );
+  auto * tlMenu = new QMenu( tr( "Opened tabs" ), ui.tabWidget );
+  tlBtn->setMenu( tlMenu );
+  connect( tlMenu, &QMenu::aboutToShow, this, &MainWindow::fillWindowsMenu );
+  connect( tlMenu, &QMenu::triggered, this, [ this ]( QAction * act ) {
+    ui.tabWidget->setCurrentIndex( act->data().toInt() );
+  } );
 
+  // Double-click empty tab bar
+  connect( ui.tabWidget->tabBar(), &QTabBar::tabBarDoubleClicked, this, [ this ]( int index ) {
+    if ( index == -1 )
+      createNewTab( true, tr( "(untitled)" ) )->load( QUrl( "gdinternal://untitle-page" ) );
+  } );
+
+  // Right-click context menu
   connect( ui.tabWidget, &QWidget::customContextMenuRequested, this, [ this ]( const QPoint & pos ) {
     int tabIdx = ui.tabWidget->tabBar()->tabAt( pos );
     if ( tabIdx >= 0 ) {
@@ -731,7 +745,13 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
     }
   } );
 
-  ui.tabWidget->setTabsClosable( true );
+  // Tab close
+  connect( ui.tabWidget, &QTabWidget::tabCloseRequested, this, [ this ]( int tabIndex ) {
+    closeTabInPanel( ui.tabWidget, tabIndex );
+  } );
+
+  // currentChanged keeps tabSwitched for group/UI syncing
+  connect( ui.tabWidget, &QTabWidget::currentChanged, this, &MainWindow::tabSwitched );
 
   connect( ui.quit, &QAction::triggered, this, &MainWindow::quitApp );
 
@@ -861,8 +881,6 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   setWindowTitle( "GoldenDict-ng" );
 
-  // Create tab list menu
-  createTabList();
 
 #if defined( Q_OS_MAC )
   defaultInterfaceStyle = "Fusion";
@@ -1216,8 +1234,8 @@ void MainWindow::clipboardChange( QClipboard::Mode m )
 
 void MainWindow::ctrlTabPressed()
 {
-  emit fillWindowsMenu();
-  tabListButton->click();
+  if ( tabListButton )
+    tabListButton->click();
 }
 
 void MainWindow::updateSearchPaneAndBar( bool searchInDock )
@@ -1461,60 +1479,67 @@ void MainWindow::closeTabInPanel( QTabWidget * panel, int tabIndex )
   }
 }
 
-void MainWindow::setupTabWidgetCommon( QTabWidget * panel )
+QTabWidget * MainWindow::createPanel()
 {
+  auto * panel = new QTabWidget();
   panel->setMovable( true );
   panel->setDocumentMode( true );
+  panel->setTabsClosable( true );
+  panel->setUsesScrollButtons( true );
+  panel->setContextMenuPolicy( Qt::CustomContextMenu );
+  panel->tabBar()->installEventFilter( this );
 
-  // Double-click empty tab bar space → new untitled tab
+  // "+" button — every panel gets one
+  auto * addBtn = new QToolButton( panel );
+  addBtn->setAutoRaise( true );
+  addBtn->setIcon( QIcon( ":/icons/addtab.svg" ) );
+  addBtn->setToolTip( tr( "New Tab" ) );
+  addBtn->setFocusPolicy( Qt::NoFocus );
+  panel->setCornerWidget( addBtn, Qt::TopLeftCorner );
+  connect( addBtn, &QAbstractButton::clicked, this, [ this, panel ]() {
+    addNewTabToPanel( panel );
+  } );
+
+  // Tab list dropdown
+  auto * tabListBtn = new QToolButton( panel );
+  tabListBtn->setAutoRaise( true );
+  tabListBtn->setIcon( QIcon( ":/icons/windows-list.svg" ) );
+  tabListBtn->setToolTip( tr( "Open Tabs List" ) );
+  tabListBtn->setPopupMode( QToolButton::InstantPopup );
+  tabListBtn->setFocusPolicy( Qt::NoFocus );
+  panel->setCornerWidget( tabListBtn, Qt::TopRightCorner );
+
+  auto * panelTabMenu = new QMenu( tr( "Opened tabs" ), panel );
+  tabListBtn->setMenu( panelTabMenu );
+  connect( panelTabMenu, &QMenu::aboutToShow, this, [ panel, panelTabMenu ]() {
+    panelTabMenu->clear();
+    for ( int i = 0; i < panel->count(); i++ ) {
+      QAction * act = panelTabMenu->addAction( panel->tabIcon( i ), panel->tabText( i ) );
+      act->setData( i );
+    }
+  } );
+  connect( panelTabMenu, &QMenu::triggered, this, [ panel ]( QAction * act ) {
+    panel->setCurrentIndex( act->data().toInt() );
+  } );
+
+  // Double-click empty tab bar → new tab in this panel
   connect( panel->tabBar(), &QTabBar::tabBarDoubleClicked, this, [ this, panel ]( int index ) {
-    if ( index == -1 ) {
-      if ( panel == ui.tabWidget )
-        createNewTab( true, tr( "(untitled)" ) )->load( QUrl( "gdinternal://untitle-page" ) );
-      else
-        addNewTabToPanel( panel );
+    if ( index == -1 )
+      addNewTabToPanel( panel );
+  } );
+
+  // Right-click context menu
+  connect( panel, &QWidget::customContextMenuRequested, this, [ this, panel ]( const QPoint & pos ) {
+    int tabIdx = panel->tabBar()->tabAt( pos );
+    if ( tabIdx >= 0 ) {
+      auto * av = qobject_cast< ArticleView * >( panel->widget( tabIdx ) );
+      if ( av )
+        lastFocusedArticleView = av;
+      showTabContextMenu( panel, tabIdx, panel->mapToGlobal( pos ) );
     }
   } );
 
-  // Tab list dropdown button (main panel has its own via createTabList)
-  if ( panel != ui.tabWidget ) {
-    auto * tabListBtn = new QToolButton( panel );
-    tabListBtn->setAutoRaise( true );
-    tabListBtn->setIcon( QIcon( ":/icons/windows-list.svg" ) );
-    tabListBtn->setToolTip( tr( "Open Tabs List" ) );
-    tabListBtn->setPopupMode( QToolButton::InstantPopup );
-    tabListBtn->setFocusPolicy( Qt::NoFocus );
-
-    auto * panelTabMenu = new QMenu( tr( "Opened tabs" ), panel );
-    tabListBtn->setMenu( panelTabMenu );
-    connect( panelTabMenu, &QMenu::aboutToShow, this, [ panel, panelTabMenu ]() {
-      panelTabMenu->clear();
-      for ( int i = 0; i < panel->count(); i++ ) {
-        QAction * act = panelTabMenu->addAction( panel->tabIcon( i ), panel->tabText( i ) );
-        act->setData( i );
-        if ( i == panel->currentIndex() )
-          panelTabMenu->setDefaultAction( act );
-      }
-    } );
-    connect( panelTabMenu, &QMenu::triggered, this, [ panel ]( QAction * act ) {
-      int idx = act->data().toInt();
-      panel->setCurrentIndex( idx );
-    } );
-
-    panel->setCornerWidget( tabListBtn );
-  }
-}
-
-QTabWidget * MainWindow::createNewSidePanel()
-{
-  QTabWidget * panel = new QTabWidget();
-  panel->setTabsClosable( true );
-  panel->setUsesScrollButtons( true );
-  panel->tabBar()->installEventFilter( this );
-
-  setupTabWidgetCommon( panel );
-
-  // Transfer focus to webview when side panel tab changes (group list syncs via focusChanged)
+  // Tab change → focus tracking
   connect( panel, &QTabWidget::currentChanged, this, [ this, panel ]( int index ) {
     if ( index >= 0 ) {
       auto * view = qobject_cast< ArticleView * >( panel->widget( index ) );
@@ -1525,10 +1550,17 @@ QTabWidget * MainWindow::createNewSidePanel()
     }
   } );
 
+  // Tab close
   connect( panel, &QTabWidget::tabCloseRequested, this, [ this, panel ]( int tabIndex ) {
     closeTabInPanel( panel, tabIndex );
   } );
 
+  return panel;
+}
+
+QTabWidget * MainWindow::createNewSidePanel()
+{
+  QTabWidget * panel = createPanel();
   ui.panelSplitter->addWidget( panel );
   return panel;
 }
@@ -2383,47 +2415,30 @@ const vector< sptr< Dictionary::Class > > & MainWindow::getActiveDicts()
   }
 }
 
-void MainWindow::createTabList()
-{
-  tabListMenu->setIcon( QIcon( ":/icons/windows-list.svg" ) );
-  connect( tabListMenu, &QMenu::aboutToShow, this, &MainWindow::fillWindowsMenu );
-  connect( tabListMenu, &QMenu::triggered, this, &MainWindow::switchToWindow );
-
-  tabListButton = new QToolButton( ui.tabWidget );
-  tabListButton->setAutoRaise( true );
-  tabListButton->setIcon( tabListMenu->icon() );
-  tabListButton->setMenu( tabListMenu );
-  tabListButton->setToolTip( tr( "Open Tabs List" ) );
-  tabListButton->setPopupMode( QToolButton::InstantPopup );
-  ui.tabWidget->setCornerWidget( tabListButton );
-  tabListButton->setFocusPolicy( Qt::NoFocus );
-}
-
 void MainWindow::fillWindowsMenu()
 {
-  tabListMenu->clear();
+  auto * menu = qobject_cast< QMenu * >( sender() );
+  if ( !menu )
+    return;
+  menu->clear();
 
   if ( cfg.preferences.mruTabOrder ) {
     for ( int i = 0; i < mruList.count(); i++ ) {
-      QAction * act = tabListMenu->addAction( ui.tabWidget->tabIcon( ui.tabWidget->indexOf( mruList.at( i ) ) ),
-                                              ui.tabWidget->tabText( ui.tabWidget->indexOf( mruList.at( i ) ) ) );
-
-      // remember the index of the Tab to be later used in ctrlReleased()
-      act->setData( ui.tabWidget->indexOf( mruList.at( i ) ) );
-
-      if ( ui.tabWidget->currentIndex() == ui.tabWidget->indexOf( mruList.at( i ) ) ) {
+      int idx = ui.tabWidget->indexOf( mruList.at( i ) );
+      if ( idx < 0 )
+        continue;
+      QAction * act = menu->addAction( ui.tabWidget->tabIcon( idx ), ui.tabWidget->tabText( idx ) );
+      act->setData( idx );
+      if ( ui.tabWidget->currentIndex() == idx ) {
         QFont f( act->font() );
         f.setBold( true );
         act->setFont( f );
       }
     }
-    if ( tabListMenu->actions().size() > 1 ) {
-      tabListMenu->setActiveAction( tabListMenu->actions().at( 1 ) );
-    }
   }
   else {
     for ( int i = 0; i < ui.tabWidget->count(); i++ ) {
-      QAction * act = tabListMenu->addAction( ui.tabWidget->tabIcon( i ), ui.tabWidget->tabText( i ) );
+      QAction * act = menu->addAction( ui.tabWidget->tabIcon( i ), ui.tabWidget->tabText( i ) );
       act->setData( i );
       if ( ui.tabWidget->currentIndex() == i ) {
         QFont f( act->font() );
@@ -2432,12 +2447,6 @@ void MainWindow::fillWindowsMenu()
       }
     }
   }
-}
-
-void MainWindow::switchToWindow( QAction * act )
-{
-  int idx = act->data().toInt();
-  ui.tabWidget->setCurrentIndex( idx );
 }
 
 void MainWindow::addNewTab()

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1073,7 +1073,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
       groupList->setCurrentGroup( av->getCurrentGroupId() );
       groupList->blockSignals( false );
       // Update dictionary bar to reflect the newly focused tab's group
-      unsigned grp_id = av->getCurrentGroupId();
+      unsigned grp_id     = av->getCurrentGroupId();
       cfg.lastMainGroupId = grp_id;
       dictionaryBar.updateToGroup( groupInstances.findGroup( grp_id ), &cfg.mutedDictionaries, cfg );
     }
@@ -1624,7 +1624,7 @@ void MainWindow::showTabContextMenu( QTabWidget * panel, int tabIdx, QPoint glob
 
   // Close all tabs except current (panel-scoped)
   if ( panel->count() > 1 ) {
-    QAction * closeRestAction = menu.addAction( tr( "Close all tabs except current" ) );
+    QAction * closeRestAction       = menu.addAction( tr( "Close all tabs except current" ) );
     QPointer< QTabWidget > panelPtr = panel;
     QWidget * keepWidget            = panel->widget( tabIdx );
     connect( closeRestAction, &QAction::triggered, this, [ this, panelPtr, keepWidget ]() {
@@ -1640,7 +1640,7 @@ void MainWindow::showTabContextMenu( QTabWidget * panel, int tabIdx, QPoint glob
   menu.addSeparator();
 
   // Close all tabs (panel-scoped)
-  QAction * closeAllAction        = menu.addAction( tr( "Close all tabs" ) );
+  QAction * closeAllAction = menu.addAction( tr( "Close all tabs" ) );
   closeAllAction->setShortcut( QKeySequence( "Ctrl+Shift+W" ) );
   closeAllAction->setShortcutVisibleInContextMenu( true );
   QPointer< QTabWidget > panelPtr = panel;
@@ -1695,10 +1695,10 @@ void MainWindow::showTabContextMenu( QTabWidget * panel, int tabIdx, QPoint glob
   if ( av ) {
 
     // Add to Favorites (blue star if already favorited)
-    QString headword          = av->getCurrentWord();
-    bool alreadyFav            = !headword.isEmpty() && ui.favoritesPaneWidget->isWordPresentInActiveFolder( headword );
-    QIcon favIcon              = alreadyFav ? blueStarIcon : starIcon;
-    QAction * favAction        = menu.addAction( favIcon, tr( "Add to Favorites" ) );
+    QString headword    = av->getCurrentWord();
+    bool alreadyFav     = !headword.isEmpty() && ui.favoritesPaneWidget->isWordPresentInActiveFolder( headword );
+    QIcon favIcon       = alreadyFav ? blueStarIcon : starIcon;
+    QAction * favAction = menu.addAction( favIcon, tr( "Add to Favorites" ) );
     connect( favAction, &QAction::triggered, this, [ this, av ]() {
       QString word = av->getCurrentWord();
       if ( !word.isEmpty() )
@@ -2519,8 +2519,8 @@ ArticleView * MainWindow::createNewTab( bool switchToIt, const QString & name )
 {
   ArticleView * view = createArticleView();
 
-  int index          = cfg.preferences.newTabsOpenAfterCurrentOne ? ui.tabWidget->currentIndex() + 1 : ui.tabWidget->count();
-  QString escaped    = Utils::escapeAmps( name );
+  int index = cfg.preferences.newTabsOpenAfterCurrentOne ? ui.tabWidget->currentIndex() + 1 : ui.tabWidget->count();
+  QString escaped = Utils::escapeAmps( name );
 
   ui.tabWidget->insertTab( index, view, escaped );
   mruList.append( dynamic_cast< QWidget * >( view ) );
@@ -2550,7 +2550,7 @@ void MainWindow::tabCloseRequested( int x )
 void MainWindow::closeCurrentTab()
 {
   QTabWidget * panel = activePanel();
-  int idx             = panel->currentIndex();
+  int idx            = panel->currentIndex();
   if ( idx < 0 )
     return;
   closeTabInPanel( panel, idx );
@@ -3304,7 +3304,7 @@ bool MainWindow::handleBackForwardMouseButtons( QMouseEvent * event )
 bool MainWindow::eventFilter( QObject * obj, QEvent * ev )
 {
   if ( ev->type() == QEvent::ShortcutOverride || ev->type() == QEvent::KeyPress ) {
-    auto * ke = dynamic_cast< QKeyEvent * >( ev );
+    auto * ke     = dynamic_cast< QKeyEvent * >( ev );
     const int key = ke->key();
 
     // Handle F3/Shift+F3 shortcuts
@@ -3699,7 +3699,6 @@ void MainWindow::showTranslationFor( const QString & word, unsigned inGroup, con
   }
 
   view->showDefinition( word, group, scrollTo );
-
 }
 
 void MainWindow::showTranslationForDicts( const QString & inWord,

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -735,19 +735,9 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   ui.tabWidget->setCornerWidget( &addTab, Qt::TopLeftCorner );
   // ui.tabWidget->setCornerWidget( &closeTab, Qt::TopRightCorner );
 
-  ui.tabWidget->setMovable( true );
-
-#if !defined( Q_OS_WIN )
-  ui.tabWidget->setDocumentMode( true );
-#endif
+  setupTabWidgetCommon( ui.tabWidget );
 
   connect( &addTab, &QAbstractButton::clicked, this, &MainWindow::addNewTab );
-
-  connect( ui.tabWidget->tabBar(), &QTabBar::tabBarDoubleClicked, this, [ this ]( const int index ) {
-    if ( -1 == index ) { // empty space at tabbar clicked.
-      this->addNewTab();
-    }
-  } );
 
   connect( ui.tabWidget, &QTabWidget::tabCloseRequested, this, &MainWindow::tabCloseRequested );
 
@@ -1438,47 +1428,58 @@ QTabWidget * MainWindow::panelForView( ArticleView * av )
   return nullptr;
 }
 
+void MainWindow::setupTabWidgetCommon( QTabWidget * panel )
+{
+  panel->setMovable( true );
+  panel->setDocumentMode( true );
+
+  // Double-click empty tab bar space → new untitled tab
+  connect( panel->tabBar(), &QTabBar::tabBarDoubleClicked, this, [ this, panel ]( int index ) {
+    if ( index == -1 ) {
+      if ( panel == ui.tabWidget )
+        addNewTab();
+      else
+        addNewTabToPanel( panel );
+    }
+  } );
+
+  // Tab list dropdown button (main panel has its own via createTabList)
+  if ( panel != ui.tabWidget ) {
+    auto * tabListBtn = new QToolButton( panel );
+    tabListBtn->setAutoRaise( true );
+    tabListBtn->setIcon( QIcon( ":/icons/windows-list.svg" ) );
+    tabListBtn->setToolTip( tr( "Open Tabs List" ) );
+    tabListBtn->setPopupMode( QToolButton::InstantPopup );
+    tabListBtn->setFocusPolicy( Qt::NoFocus );
+
+    auto * panelTabMenu = new QMenu( tr( "Opened tabs" ), panel );
+    tabListBtn->setMenu( panelTabMenu );
+    connect( panelTabMenu, &QMenu::aboutToShow, this, [ panel, panelTabMenu ]() {
+      panelTabMenu->clear();
+      for ( int i = 0; i < panel->count(); i++ ) {
+        QAction * act = panelTabMenu->addAction( panel->tabIcon( i ), panel->tabText( i ) );
+        act->setData( i );
+        if ( i == panel->currentIndex() )
+          panelTabMenu->setDefaultAction( act );
+      }
+    } );
+    connect( panelTabMenu, &QMenu::triggered, this, [ panel ]( QAction * act ) {
+      int idx = act->data().toInt();
+      panel->setCurrentIndex( idx );
+    } );
+
+    panel->setCornerWidget( tabListBtn );
+  }
+}
+
 QTabWidget * MainWindow::createNewSidePanel()
 {
   QTabWidget * panel = new QTabWidget();
   panel->setTabsClosable( true );
-  panel->setMovable( true );
   panel->setUsesScrollButtons( true );
-  panel->setDocumentMode( true );
   panel->tabBar()->installEventFilter( this );
 
-  // Double-click empty tab bar space → new untitled tab in this panel
-  connect( panel->tabBar(), &QTabBar::tabBarDoubleClicked, this, [ this, panel ]( int index ) {
-    if ( index == -1 ) {
-      addNewTabToPanel( panel );
-    }
-  } );
-
-  // Tab list dropdown button
-  auto * tabListBtn = new QToolButton( panel );
-  tabListBtn->setAutoRaise( true );
-  tabListBtn->setIcon( QIcon( ":/icons/windows-list.svg" ) );
-  tabListBtn->setToolTip( tr( "Open Tabs List" ) );
-  tabListBtn->setPopupMode( QToolButton::InstantPopup );
-  tabListBtn->setFocusPolicy( Qt::NoFocus );
-
-  auto * panelTabMenu = new QMenu( tr( "Opened tabs" ), panel );
-  tabListBtn->setMenu( panelTabMenu );
-  connect( panelTabMenu, &QMenu::aboutToShow, this, [ this, panel, panelTabMenu ]() {
-    panelTabMenu->clear();
-    for ( int i = 0; i < panel->count(); i++ ) {
-      QAction * act = panelTabMenu->addAction( panel->tabIcon( i ), panel->tabText( i ) );
-      act->setData( i );
-      if ( i == panel->currentIndex() )
-        panelTabMenu->setDefaultAction( act );
-    }
-  } );
-  connect( panelTabMenu, &QMenu::triggered, this, [ panel ]( QAction * act ) {
-    int idx = act->data().toInt();
-    panel->setCurrentIndex( idx );
-  } );
-
-  panel->setCornerWidget( tabListBtn );
+  setupTabWidgetCommon( panel );
 
   // Transfer focus to webview when side panel tab changes (group list syncs via focusChanged)
   connect( panel, &QTabWidget::currentChanged, this, [ this, panel ]( int index ) {

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1788,7 +1788,6 @@ void MainWindow::removeGroupComboBoxActionsFromDialog( QDialog * dialog, GroupCo
 void MainWindow::commitData()
 {
   isQuitting = true;
-  saveSession();
 
   // if the dictionaries is empty ,large chance that the config has corrupt.
   if ( cfg.preferences.removeInvalidIndexOnExit && !dictMap.isEmpty() ) {
@@ -2119,7 +2118,6 @@ void MainWindow::closeEvent( QCloseEvent * ev )
   // If tray icon is disabled or closing to tray is not enabled, quit the application
   if ( !cfg.preferences.enableTrayIcon || !cfg.preferences.closeToTray ) {
     ev->accept();
-    saveSession();
     quitApp();
     return;
   }
@@ -2426,7 +2424,6 @@ void MainWindow::addNewTabToPanel( QTabWidget * panel )
   connect( view, &ArticleView::sendWordToHistory, this, &MainWindow::addWordToHistory );
   connect( view, &ArticleView::sendWordToInputLine, this, &MainWindow::sendWordToInputLine );
   connect( view, &ArticleView::storeResourceSavePath, this, &MainWindow::storeResourceSavePath );
-  connect( view, &ArticleView::wordLookedUp, this, &MainWindow::forwardToAlwaysQueryTabs );
   connect( view, &ArticleView::zoomIn, this, &MainWindow::zoomin );
   connect( view, &ArticleView::zoomOut, this, &MainWindow::zoomout );
   connect( view, &ArticleView::saveBookmarkSignal, this, &MainWindow::addBookmarkToFavorite );
@@ -2743,10 +2740,10 @@ void MainWindow::tabMenuRequested( QPoint pos )
   tabMenuTabIndex = ui.tabWidget->tabBar()->tabAt( pos );
 
   bool hasSidePanels = ( ui.panelSplitter->count() > 1 );
-  if ( m_moveToMenu ) {
-    m_moveToMenu->menuAction()->setVisible( hasSidePanels );
+  if ( moveToMenu ) {
+    moveToMenu->menuAction()->setVisible( hasSidePanels );
     if ( hasSidePanels && tabMenuTabIndex >= 0 ) {
-      m_moveToMenu->clear();
+      moveToMenu->clear();
       for ( int i = 0; i < ui.panelSplitter->count(); i++ ) {
         auto * p = qobject_cast< QTabWidget * >( ui.panelSplitter->widget( i ) );
         if ( !p )
@@ -2758,7 +2755,7 @@ void MainWindow::tabMenuRequested( QPoint pos )
           continue;
 
         QString label        = ( i == 0 ) ? tr( "Main Panel" ) : tr( "Panel %1" ).arg( i );
-        QAction * moveAction = m_moveToMenu->addAction( label );
+        QAction * moveAction = moveToMenu->addAction( label );
         int targetIdx        = i;
         connect( moveAction, &QAction::triggered, this, [ this, targetIdx ]() {
           if ( tabMenuTabIndex >= 0 ) {

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -171,6 +171,8 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   focusHeadwordsDlgAction( this ),
   focusArticleViewAction( this ),
   addAllTabToFavoritesAction( this ),
+  togglePanelAction( this ),
+  togglePanelOrientationAction( this ),
   useSmallIconsInToolbarsAction( tr( "Show &Small Icons in Toolbars" ), this ),
   useLargeIconsInToolbarsAction( tr( "Show &Large Icons in Toolbars" ), this ),
   useNormalIconsInToolbarsAction( tr( "Show &Normal Icons in Toolbars" ), this ),
@@ -256,6 +258,14 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 #endif
 
   ui.setupUi( this );
+
+  // Single splitter: move tabWidget into panelSplitter so everything is equal peer
+  ui.centralLayout->removeWidget( ui.tabWidget );
+  ui.centralLayout->removeWidget( ui.panelSplitter );
+  ui.panelSplitter->insertWidget( 0, ui.tabWidget );
+  ui.panelSplitter->setOrientation( Qt::Horizontal ); // side-by-side default
+  ui.panelSplitter->setVisible( true );               // always visible
+  ui.centralLayout->addWidget( ui.panelSplitter );
 
   // Set own gesture recognizers
 #ifndef Q_OS_MAC
@@ -499,6 +509,20 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   addAction( &addTabAction );
 
+  // Panel toggle
+  togglePanelAction.setText( tr( "Toggle Panel" ) );
+  addGlobalAction( &togglePanelAction, [ this ]() {
+    togglePanel();
+  } );
+  togglePanelAction.setShortcut( QKeySequence( "Ctrl+Shift+P" ) );
+
+  // Panel orientation toggle
+  togglePanelOrientationAction.setText( tr( "Toggle Panel Orientation" ) );
+  addGlobalAction( &togglePanelOrientationAction, [ this ]() {
+    togglePanelOrientation();
+  } );
+  togglePanelOrientationAction.setShortcut( QKeySequence( "Ctrl+Shift+H" ) );
+
   closeCurrentTabAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
   closeCurrentTabAction.setShortcut( QKeySequence( "Ctrl+W" ) );
   closeCurrentTabAction.setText( tr( "Close current tab" ) );
@@ -546,6 +570,21 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   tabMenu->addSeparator();
   tabMenu->addAction( &closeAllTabAction );
   tabMenu->addSeparator();
+
+  // Move-to submenu is rebuilt dynamically in tabMenuRequested
+  moveToMenu = tabMenu->addMenu( tr( "Move to Panel" ) );
+
+  // Flat New Panel action — shown when no side panels exist (submenu hidden)
+  newPanelAction = tabMenu->addAction( tr( "Move to New Panel" ) );
+  connect( newPanelAction, &QAction::triggered, this, [ this ]() {
+    if ( tabMenuTabIndex >= 0 ) {
+      auto * av = qobject_cast< ArticleView * >( ui.tabWidget->widget( tabMenuTabIndex ) );
+      if ( av )
+        addPanel( av, -1 );
+    }
+  } );
+  tabMenu->addSeparator();
+
   tabMenu->addAction( addToFavorites );
   tabMenu->addAction( &addAllTabToFavoritesAction );
 
@@ -602,6 +641,9 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   connect( &lockPanelsAction, &QAction::toggled, this, &MainWindow::onLockPanelsToggled );
   ui.menuView->addAction( &lockPanelsAction );
   ui.menuView->addAction( ui.alwaysOnTop );
+  ui.menuView->addSeparator();
+  ui.menuView->addAction( &togglePanelAction );
+  ui.menuView->addAction( &togglePanelOrientationAction );
 
   // Dictionary bar
 
@@ -688,16 +730,16 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   ui.tabWidget->setHideSingleTab( cfg.preferences.hideSingleTab );
   ui.tabWidget->clear();
 
+  ui.tabWidget->setContextMenuPolicy( Qt::CustomContextMenu );
+
   ui.tabWidget->setCornerWidget( &addTab, Qt::TopLeftCorner );
-  //ui.tabWidget->setCornerWidget( &closeTab, Qt::TopRightCorner );
+  // ui.tabWidget->setCornerWidget( &closeTab, Qt::TopRightCorner );
 
   ui.tabWidget->setMovable( true );
 
 #if !defined( Q_OS_WIN )
   ui.tabWidget->setDocumentMode( true );
 #endif
-
-  ui.tabWidget->setContextMenuPolicy( Qt::CustomContextMenu );
 
   connect( &addTab, &QAbstractButton::clicked, this, &MainWindow::addNewTab );
 
@@ -768,7 +810,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   ui.dictsList->installEventFilter( this );
   ui.dictsList->viewport()->installEventFilter( this );
-  //tabWidget doesn't propagate Ctrl+Tab to the parent widget unless event filter is installed
+  // tabWidget doesn't propagate Ctrl+Tab to the parent widget unless event filter is installed
   ui.tabWidget->installEventFilter( this );
 
   ui.historyList->installEventFilter( this );
@@ -826,7 +868,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
            } );
   applyProxySettings();
 
-  //set  webengineview font
+  // set  webengineview font
   changeWebEngineViewFont();
 
   connect( &dictNetMgr, &QNetworkAccessManager::proxyAuthenticationRequired, this, &MainWindow::proxyAuthentication );
@@ -864,7 +906,8 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   // restore should be called after all UI initialized but not necessarily after show()
   // This must be called before show() as of Qt6.5 on Windows, not sure if it is a bug
-  // Due to a bug of WebEngine, this also must be called after WebEngine has a view loaded https://bugreports.qt.io/browse/QTBUG-115074
+  // Due to a bug of WebEngine, this also must be called after WebEngine has a view loaded
+  // https://bugreports.qt.io/browse/QTBUG-115074
   if ( cfg.mainWindowState.size() && !cfg.resetState ) {
     restoreState( cfg.mainWindowState );
   }
@@ -1008,6 +1051,23 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   // Handle Dock icon click on macOS: restore minimized window when application becomes active
   connect( qApp, &QApplication::applicationStateChanged, this, &MainWindow::handleApplicationStateChanged );
 #endif
+
+  // Sync group list to whichever ArticleView gains keyboard focus
+  connect( qApp, &QApplication::focusChanged, this, [ this ]( QWidget * /*old*/, QWidget * now ) {
+    if ( !now )
+      return;
+    // Walk up to find an ArticleView in our splitter
+    QWidget * w = now;
+    while ( w && w != ui.panelSplitter && !qobject_cast< ArticleView * >( w ) )
+      w = w->parentWidget();
+    auto * av = qobject_cast< ArticleView * >( w );
+    if ( av ) {
+      lastFocusedArticleView = av;
+      groupList->blockSignals( true );
+      groupList->setCurrentGroup( av->getCurrentGroupId() );
+      groupList->blockSignals( false );
+    }
+  } );
 }
 
 
@@ -1060,7 +1120,7 @@ void MainWindow::updateMatchResults( bool finished )
 
   if ( cfg.preferences.searchInDock ) {
     ui.wordList->setUpdatesEnabled( false );
-    //clear all existed items
+    // clear all existed items
     ui.wordList->clear();
 
     for ( const auto & result : results ) {
@@ -1301,12 +1361,362 @@ MainWindow::~MainWindow()
   delete ui.historyPaneWidget; // This should be deleted before shared History Object.
 }
 
+void MainWindow::addPanel( ArticleView * av, int targetPanelIdx )
+{
+  // Save title before removing from current location
+  QString title             = av->windowTitle();
+  QTabWidget * currentPanel = nullptr;
+  int tabIdx                = -1;
+
+  // Check main tab widget
+  tabIdx = ui.tabWidget->indexOf( av );
+  if ( tabIdx >= 0 ) {
+    if ( title.isEmpty() )
+      title = ui.tabWidget->tabText( tabIdx );
+    currentPanel = ui.tabWidget;
+  }
+  else {
+    // Check side panels
+    currentPanel = panelForView( av );
+    if ( currentPanel ) {
+      tabIdx = currentPanel->indexOf( av );
+      if ( title.isEmpty() )
+        title = currentPanel->tabText( tabIdx );
+    }
+  }
+  if ( title.isEmpty() )
+    title = tr( "(untitled)" );
+
+  // Remove from current panel
+  if ( currentPanel && tabIdx >= 0 )
+    currentPanel->removeTab( tabIdx );
+
+  // Auto-create empty tab if main panel just became empty
+  if ( currentPanel == ui.tabWidget && ui.tabWidget->count() == 0 ) {
+    createNewTab( true, tr( "(empty)" ) );
+  }
+
+  // Determine target panel
+  QTabWidget * target = nullptr;
+  if ( targetPanelIdx < 0 ) {
+    // "Move to New Panel" — always create fresh panel
+    target = createNewSidePanel();
+  }
+  else if ( targetPanelIdx == 0 ) {
+    target = ui.tabWidget;
+  }
+  else {
+    target = qobject_cast< QTabWidget * >( ui.panelSplitter->widget( targetPanelIdx ) );
+    if ( !target )
+      target = findOrCreateSidePanel();
+  }
+
+  // Add to target
+  int newIdx = target->addTab( av, title );
+  target->setCurrentIndex( newIdx );
+  updateTabTitleMarker( av );
+  av->focus();
+
+  // Clean up empty side panel
+  if ( currentPanel && currentPanel != ui.tabWidget && currentPanel->count() == 0 )
+    delete currentPanel;
+
+  distributePanelSizes();
+}
+
+QTabWidget * MainWindow::panelForView( ArticleView * av )
+{
+  for ( int i = 1; i < ui.panelSplitter->count(); i++ ) {
+    auto * panel = qobject_cast< QTabWidget * >( ui.panelSplitter->widget( i ) );
+    if ( panel && panel->indexOf( av ) >= 0 )
+      return panel;
+  }
+  return nullptr;
+}
+
+QTabWidget * MainWindow::createNewSidePanel()
+{
+  QTabWidget * panel = new QTabWidget();
+  panel->setTabsClosable( true );
+  panel->setMovable( true );
+  panel->setUsesScrollButtons( true );
+  panel->setDocumentMode( true );
+  panel->tabBar()->installEventFilter( this );
+
+  // Transfer focus to webview when side panel tab changes (group list syncs via focusChanged)
+  connect( panel, &QTabWidget::currentChanged, this, [ this, panel ]( int index ) {
+    if ( index >= 0 ) {
+      auto * view = qobject_cast< ArticleView * >( panel->widget( index ) );
+      if ( view ) {
+        lastFocusedArticleView = view;
+        view->focus();
+      }
+    }
+  } );
+
+  connect( panel, &QTabWidget::tabCloseRequested, this, [ this, panel ]( int tabIndex ) {
+    auto * w       = panel->widget( tabIndex );
+    auto * avClose = qobject_cast< ArticleView * >( w );
+    if ( !avClose )
+      return;
+    QString tabTitle = panel->tabText( tabIndex );
+    panel->removeTab( tabIndex );
+    int newIdx = ui.tabWidget->addTab( avClose, tabTitle );
+    ui.tabWidget->setCurrentIndex( newIdx );
+    updateTabTitleMarker( avClose );
+    if ( panel->count() == 0 ) {
+      delete panel;
+      distributePanelSizes();
+    }
+  } );
+
+  ui.panelSplitter->addWidget( panel );
+  return panel;
+}
+
+QTabWidget * MainWindow::findOrCreateSidePanel()
+{
+  for ( int i = 1; i < ui.panelSplitter->count(); i++ ) {
+    auto * panel = qobject_cast< QTabWidget * >( ui.panelSplitter->widget( i ) );
+    if ( panel )
+      return panel;
+  }
+  return createNewSidePanel();
+}
+
+QString MainWindow::formatTabTitle( ArticleView * av, const QString & baseTitle )
+{
+  return baseTitle;
+}
+
+void MainWindow::updateTabTitleMarker( ArticleView * av )
+{
+  if ( !av )
+    return;
+  // Clear tab text color on all panels
+  auto clearColor = [ av ]( QTabWidget * panel ) {
+    int idx = panel->indexOf( av );
+    if ( idx >= 0 )
+      panel->tabBar()->setTabTextColor( idx, QColor() );
+  };
+  clearColor( ui.tabWidget );
+  for ( int p = 1; p < ui.panelSplitter->count(); p++ ) {
+    auto * panel = qobject_cast< QTabWidget * >( ui.panelSplitter->widget( p ) );
+    if ( panel )
+      clearColor( panel );
+  }
+}
+
+void MainWindow::showTabContextMenu( QTabWidget * panel, int tabIdx, QPoint globalPos )
+{
+  QMenu menu( this );
+
+  // Close Tab
+  QAction * closeAction = menu.addAction( tr( "Close current tab" ) );
+  connect( closeAction, &QAction::triggered, this, [ panel, tabIdx ]() {
+    emit panel->tabCloseRequested( tabIdx );
+  } );
+
+  // Close all tabs except current (panel-scoped)
+  if ( panel->count() > 1 ) {
+    QAction * closeRestAction = menu.addAction( tr( "Close all tabs except current" ) );
+    connect( closeRestAction, &QAction::triggered, this, [ panel, tabIdx ]() {
+      for ( int i = panel->count() - 1; i >= 0; i-- ) {
+        if ( i != tabIdx )
+          emit panel->tabCloseRequested( i );
+      }
+    } );
+  }
+
+  menu.addSeparator();
+
+  // Close all tabs (panel-scoped)
+  QAction * closeAllAction = menu.addAction( tr( "Close all tabs" ) );
+  connect( closeAllAction, &QAction::triggered, this, [ panel ]() {
+    while ( panel->count() > 0 )
+      emit panel->tabCloseRequested( panel->count() - 1 );
+  } );
+
+  menu.addSeparator();
+
+  // Move to existing panels (submenu, only if side panels exist)
+  if ( ui.panelSplitter->count() > 1 ) {
+    QMenu * moveMenu = menu.addMenu( tr( "Move to Panel" ) );
+    for ( int i = 0; i < ui.panelSplitter->count(); i++ ) {
+      auto * p = qobject_cast< QTabWidget * >( ui.panelSplitter->widget( i ) );
+      if ( p == panel || !p )
+        continue;
+      QString label        = ( i == 0 ) ? tr( "Main Panel" ) : tr( "Panel %1" ).arg( i );
+      QAction * moveAction = moveMenu->addAction( label );
+      int targetIdx        = i;
+      connect( moveAction, &QAction::triggered, this, [ this, panel, tabIdx, targetIdx ]() {
+        auto * av = qobject_cast< ArticleView * >( panel->widget( tabIdx ) );
+        if ( av )
+          addPanel( av, targetIdx );
+      } );
+    }
+  }
+
+  // Move to New Panel — always available
+  QAction * newPanelAction = menu.addAction( tr( "Move to New Panel" ) );
+  connect( newPanelAction, &QAction::triggered, this, [ this, panel, tabIdx ]() {
+    auto * av = qobject_cast< ArticleView * >( panel->widget( tabIdx ) );
+    if ( av )
+      addPanel( av, -1 );
+  } );
+
+  menu.addSeparator();
+
+  auto * av = qobject_cast< ArticleView * >( panel->widget( tabIdx ) );
+  if ( av ) {
+
+    // Add to Favorites
+    QAction * favAction = menu.addAction( tr( "Add to Favorites" ) );
+    connect( favAction, &QAction::triggered, this, [ this, av ]() {
+      QString headword = av->getCurrentWord();
+      if ( !headword.isEmpty() )
+        ui.favoritesPaneWidget->addWordToActiveFav( headword );
+    } );
+
+    // Add all tabs to Favorites (panel-scoped)
+    QAction * favAllAction = menu.addAction( tr( "Add all tabs to Favorites" ) );
+    connect( favAllAction, &QAction::triggered, this, [ this, panel ]() {
+      for ( int i = 0; i < panel->count(); i++ ) {
+        auto * av2 = qobject_cast< ArticleView * >( panel->widget( i ) );
+        if ( av2 ) {
+          QString headword = av2->getCurrentWord();
+          if ( !headword.isEmpty() )
+            ui.favoritesPaneWidget->addWordToActiveFav( headword );
+        }
+      }
+    } );
+  }
+
+  menu.exec( globalPos );
+}
+
+void MainWindow::removePanel( ArticleView * av )
+{
+  QTabWidget * sourcePanel = panelForView( av );
+  if ( !sourcePanel )
+    return;
+
+  QString title = av->windowTitle();
+  int tabIdx    = sourcePanel->indexOf( av );
+  if ( title.isEmpty() && tabIdx >= 0 )
+    title = sourcePanel->tabText( tabIdx );
+  if ( title.isEmpty() )
+    title = tr( "(untitled)" );
+
+  // Remove from source
+  sourcePanel->removeTab( tabIdx );
+
+  // Add to main
+  int newIdx = ui.tabWidget->addTab( av, title );
+  ui.tabWidget->setCurrentIndex( newIdx );
+  av->focus();
+
+  // Clean up empty side panel
+  if ( sourcePanel->count() == 0 )
+    delete sourcePanel;
+
+  distributePanelSizes();
+}
+
+void MainWindow::distributePanelSizes()
+{
+  int count = ui.panelSplitter->count();
+  if ( count == 0 )
+    return;
+
+  // All children equal stretch
+  for ( int i = 0; i < count; i++ )
+    ui.panelSplitter->setStretchFactor( i, 1 );
+
+  // Explicit initial sizes (stretch only affects resize)
+  int total =
+    ( ui.panelSplitter->orientation() == Qt::Horizontal ) ? ui.panelSplitter->width() : ui.panelSplitter->height();
+  if ( total > 0 ) {
+    QList< int > sizes;
+    for ( int i = 0; i < count; i++ )
+      sizes << total / count;
+    ui.panelSplitter->setSizes( sizes );
+  }
+
+  // Minimum width so window grows, never eats dock space
+  ui.centralWidget->setMinimumWidth( count * 200 );
+}
+
+void MainWindow::togglePanel()
+{
+  if ( totalTabCount() <= 1 )
+    return;
+
+  // Find which panel (or main tab) has keyboard focus
+  QWidget * w               = QApplication::focusWidget();
+  QTabWidget * focusedPanel = nullptr;
+  while ( w && w != ui.panelSplitter ) {
+    if ( auto * pt = qobject_cast< QTabWidget * >( w ) ) {
+      if ( pt != ui.tabWidget )
+        focusedPanel = pt;
+      break;
+    }
+    w = w->parentWidget();
+  }
+
+  if ( focusedPanel && focusedPanel->currentWidget() ) {
+    // Focus in a panel → move its current tab back to main
+    auto * av = qobject_cast< ArticleView * >( focusedPanel->currentWidget() );
+    if ( av )
+      removePanel( av );
+  }
+  else if ( ui.tabWidget->currentWidget() ) {
+    // Focus in main tab or elsewhere → move main's current to panel
+    auto * av = qobject_cast< ArticleView * >( ui.tabWidget->currentWidget() );
+    if ( av )
+      addPanel( av );
+  }
+}
+
+void MainWindow::togglePanelOrientation()
+{
+  if ( ui.panelSplitter->orientation() == Qt::Horizontal )
+    ui.panelSplitter->setOrientation( Qt::Vertical );
+  else
+    ui.panelSplitter->setOrientation( Qt::Horizontal );
+  distributePanelSizes();
+}
+
+int MainWindow::totalTabCount() const
+{
+  int count = ui.tabWidget->count();
+  for ( int i = 1; i < ui.panelSplitter->count(); i++ ) {
+    auto * panel = qobject_cast< QTabWidget * >( ui.panelSplitter->widget( i ) );
+    if ( panel )
+      count += panel->count();
+  }
+  return count;
+}
+
+int MainWindow::panelCount() const
+{
+  int count = 0;
+  for ( int i = 1; i < ui.panelSplitter->count(); i++ ) {
+    auto * panel = qobject_cast< QTabWidget * >( ui.panelSplitter->widget( i ) );
+    if ( panel && panel->count() > 0 )
+      count++;
+  }
+  return count;
+}
+
 void MainWindow::addGlobalAction( QAction * action, const std::function< void() > & slotFunc )
 {
   action->setShortcutContext( Qt::WidgetWithChildrenShortcut );
   connect( action, &QAction::triggered, this, slotFunc );
 
   ui.centralWidget->addAction( action );
+  ui.tabWidget->addAction( action );
+  ui.panelSplitter->addAction( action );
   ui.dictsPane->addAction( action );
   ui.searchPaneWidget->addAction( action );
   ui.favoritesPane->addAction( action );
@@ -1340,8 +1750,9 @@ void MainWindow::removeGroupComboBoxActionsFromDialog( QDialog * dialog, GroupCo
 void MainWindow::commitData()
 {
   isQuitting = true;
+  saveSession();
 
-  //if the dictionaries is empty ,large chance that the config has corrupt.
+  // if the dictionaries is empty ,large chance that the config has corrupt.
   if ( cfg.preferences.removeInvalidIndexOnExit && !dictMap.isEmpty() ) {
     const QDir dir( Config::getIndexDir() );
 
@@ -1353,7 +1764,7 @@ void MainWindow::commitData()
       if ( dictMap.contains( fileName.toStdString() ) ) {
         continue;
       }
-      //remove both normal index and fts index.
+      // remove both normal index and fts index.
       auto filePath = file.absoluteFilePath();
       qDebug() << "remove invalid index files & fts dirs";
 
@@ -1362,7 +1773,7 @@ void MainWindow::commitData()
       if ( d.exists() ) {
         d.removeRecursively();
       }
-      //temp dir
+      // temp dir
       QDir dtemp( filePath + "_FTS_x_temp" );
       if ( dtemp.exists() ) {
         dtemp.removeRecursively();
@@ -1370,7 +1781,7 @@ void MainWindow::commitData()
     }
 
 
-    //remove temp directories.
+    // remove temp directories.
     const QFileInfoList dirs = dir.entryInfoList( QDir::Dirs | QDir::NoDotAndDotDot );
 
     for ( auto & file : dirs ) {
@@ -1383,7 +1794,7 @@ void MainWindow::commitData()
       const QFileInfo info( fileName );
       const QDateTime lastModified = info.lastModified();
 
-      //if the temp directory has not been modified within 7 days,remove the temp directory.
+      // if the temp directory has not been modified within 7 days,remove the temp directory.
       if ( lastModified.addDays( 7 ) > QDateTime::currentDateTime() ) {
         continue;
       }
@@ -1670,6 +2081,7 @@ void MainWindow::closeEvent( QCloseEvent * ev )
   // If tray icon is disabled or closing to tray is not enabled, quit the application
   if ( !cfg.preferences.enableTrayIcon || !cfg.preferences.closeToTray ) {
     ev->accept();
+    saveSession();
     quitApp();
     return;
   }
@@ -1769,7 +2181,7 @@ void MainWindow::makeDictionaries()
 
   loadDictionaries( this, cfg, dictionaries, dictNetMgr, false );
 
-  //create map
+  // create map
   dictMap = Dictionary::dictToMap( dictionaries );
 
   for ( unsigned x = 0; x < dictionaries.size(); x++ ) {
@@ -1915,7 +2327,7 @@ void MainWindow::fillWindowsMenu()
       QAction * act = tabListMenu->addAction( ui.tabWidget->tabIcon( ui.tabWidget->indexOf( mruList.at( i ) ) ),
                                               ui.tabWidget->tabText( ui.tabWidget->indexOf( mruList.at( i ) ) ) );
 
-      //remember the index of the Tab to be later used in ctrlReleased()
+      // remember the index of the Tab to be later used in ctrlReleased()
       act->setData( ui.tabWidget->indexOf( mruList.at( i ) ) );
 
       if ( ui.tabWidget->currentIndex() == ui.tabWidget->indexOf( mruList.at( i ) ) ) {
@@ -1998,7 +2410,7 @@ ArticleView * MainWindow::createNewTab( bool switchToIt, const QString & name )
 
   connect( ui.searchInPageAction, &QAction::triggered, view, [ this, view ]() {
 #ifdef Q_OS_MACOS
-    //workaround to fix macos popup page search Ctrl + F
+    // workaround to fix macos popup page search Ctrl + F
     if ( scanPopup && scanPopup->isActiveWindow() ) {
       scanPopup->openSearch();
       return;
@@ -2045,12 +2457,12 @@ void MainWindow::tabCloseRequested( int x )
   // In MRU case: First, we switch to the appropriate tab
   // and only then remove the old one.
 
-  //activate a tab in accordance with MRU
+  // activate a tab in accordance with MRU
   if ( cfg.preferences.mruTabOrder && !mruList.empty() ) {
     ui.tabWidget->setCurrentWidget( mruList.at( 0 ) );
   }
   else if ( ui.tabWidget->count() > 1 ) {
-    //activate neighboring tab
+    // activate neighboring tab
     int n = x >= ui.tabWidget->count() - 1 ? x - 1 : x + 1;
     if ( n >= 0 ) {
       ui.tabWidget->setCurrentIndex( n );
@@ -2139,10 +2551,10 @@ void MainWindow::forwardClicked()
 
 void MainWindow::titleChanged( ArticleView * view, const QString & title )
 {
-  //the title can be url if html title is empty.according to qwebenginepage title() document.
+  // the title can be url if html title is empty.according to qwebenginepage title() document.
   QString escaped;
   if ( title != nullptr && title.contains( ":" ) ) {
-    //check if the title is url.
+    // check if the title is url.
     QUrl url( title );
     escaped = Utils::Url::queryItemValue( url, "word" );
   }
@@ -2156,11 +2568,24 @@ void MainWindow::titleChanged( ArticleView * view, const QString & title )
   escaped                     = Utils::ellipsizeString( escaped, maxTabTitleLength );
 
   int index = ui.tabWidget->indexOf( view );
-  if ( !escaped.isEmpty() ) {
-    ui.tabWidget->setTabText( index, escaped );
+  if ( index >= 0 && !escaped.isEmpty() ) {
+    ui.tabWidget->setTabText( index, formatTabTitle( view, escaped ) );
+    updateTabTitleMarker( view );
   }
 
-  if ( index == ui.tabWidget->currentIndex() ) {
+  // Also update title in panel tab widgets
+  for ( int p = 0; p < ui.panelSplitter->count(); p++ ) {
+    auto * panel = qobject_cast< QTabWidget * >( ui.panelSplitter->widget( p ) );
+    if ( !panel )
+      continue;
+    int pidx = panel->indexOf( view );
+    if ( pidx >= 0 && !escaped.isEmpty() ) {
+      panel->setTabText( pidx, formatTabTitle( view, escaped ) );
+      updateTabTitleMarker( view );
+    }
+  }
+
+  if ( index >= 0 && index == ui.tabWidget->currentIndex() ) {
     updateFavIcon( title );
 
     updateWindowTitle();
@@ -2227,16 +2652,48 @@ void MainWindow::tabSwitched( int )
   updateFavIcon( headword );
 
   if ( view ) {
+    lastFocusedArticleView = view;
+    view->focus();
+    groupList->blockSignals( true );
     groupList->setCurrentGroup( view->getCurrentGroupId() );
+    groupList->blockSignals( false );
   }
 }
 
 void MainWindow::tabMenuRequested( QPoint pos )
 {
-  //  // do not show this menu for single tab
-  //  if ( ui.tabWidget->count() < 2 )
-  //    return;
+  tabMenuTabIndex = ui.tabWidget->tabBar()->tabAt( pos );
 
+  bool hasSidePanels = ( ui.panelSplitter->count() > 1 );
+  if ( m_moveToMenu ) {
+    m_moveToMenu->menuAction()->setVisible( hasSidePanels );
+    if ( hasSidePanels && tabMenuTabIndex >= 0 ) {
+      m_moveToMenu->clear();
+      for ( int i = 0; i < ui.panelSplitter->count(); i++ ) {
+        auto * p = qobject_cast< QTabWidget * >( ui.panelSplitter->widget( i ) );
+        if ( !p )
+          continue;
+        // Skip self
+        if ( p == ui.tabWidget && ui.tabWidget->indexOf( ui.tabWidget->widget( tabMenuTabIndex ) ) >= 0 )
+          continue;
+        if ( p->indexOf( ui.tabWidget->widget( tabMenuTabIndex ) ) >= 0 )
+          continue;
+
+        QString label        = ( i == 0 ) ? tr( "Main Panel" ) : tr( "Panel %1" ).arg( i );
+        QAction * moveAction = m_moveToMenu->addAction( label );
+        int targetIdx        = i;
+        connect( moveAction, &QAction::triggered, this, [ this, targetIdx ]() {
+          if ( tabMenuTabIndex >= 0 ) {
+            auto * av = qobject_cast< ArticleView * >( ui.tabWidget->widget( tabMenuTabIndex ) );
+            if ( av )
+              addPanel( av, targetIdx );
+          }
+        } );
+      }
+    }
+  }
+
+  // Hide Always Query for website tabs, sync checked state to right-clicked tab
   tabMenu->popup( ui.tabWidget->mapToGlobal( pos ) );
 }
 
@@ -2577,10 +3034,26 @@ void MainWindow::currentGroupChanged( int )
 
   if ( igrp ) {
     GlobalBroadcaster::instance()->currentGroupId = grg_id;
-    ui.tabWidget->setTabIcon( ui.tabWidget->currentIndex(), igrp->makeIcon() );
+    auto * view                                   = getCurrentArticleView();
+    if ( view ) {
+      auto * panel = panelForView( view );
+      if ( panel )
+        panel->setTabIcon( panel->indexOf( view ), igrp->makeIcon() );
+    }
+    else {
+      ui.tabWidget->setTabIcon( ui.tabWidget->currentIndex(), igrp->makeIcon() );
+    }
   }
   else {
-    ui.tabWidget->setTabIcon( ui.tabWidget->currentIndex(), QIcon() );
+    auto * view = getCurrentArticleView();
+    if ( view ) {
+      auto * panel = panelForView( view );
+      if ( panel )
+        panel->setTabIcon( panel->indexOf( view ), QIcon() );
+    }
+    else {
+      ui.tabWidget->setTabIcon( ui.tabWidget->currentIndex(), QIcon() );
+    }
   }
 
   dictionaryBar.updateToGroup( groupInstances.findGroup( groupList->getCurrentGroup() ), &cfg.mutedDictionaries, cfg );
@@ -2602,7 +3075,13 @@ void MainWindow::currentGroupChanged( int )
       }
       view->setCurrentGroupId( grg_id );
       QString word = Folding::unescapeWildcardSymbols( view->getWord() );
-      respondToTranslationRequest( word, false );
+      if ( panelForView( view ) != ui.tabWidget ) {
+        // Side panel: showDefinition directly, don't route through main panel
+        view->showDefinition( word, grg_id, QString() );
+      }
+      else {
+        respondToTranslationRequest( word, false );
+      }
     }
   }
 
@@ -2782,7 +3261,7 @@ bool MainWindow::eventFilter( QObject * obj, QEvent * ev )
       }
     }
 
-    //workaround to fix #660
+    // workaround to fix #660
     if ( obj == this && ev->type() == QEvent::KeyPress
          && ( key == Qt::Key_Up || key == Qt::Key_Down || key == Qt::Key_Space || key == Qt::Key_PageUp
               || key == Qt::Key_PageDown ) ) {
@@ -2809,6 +3288,29 @@ bool MainWindow::eventFilter( QObject * obj, QEvent * ev )
 
   if ( ev->type() == QEvent::MouseButtonPress ) {
     auto event = dynamic_cast< QMouseEvent * >( ev );
+
+    // Side panel tab bar clicks: track last focused view, handle context/close
+    for ( int i = 1; i < ui.panelSplitter->count(); i++ ) {
+      auto * panel = qobject_cast< QTabWidget * >( ui.panelSplitter->widget( i ) );
+      if ( panel && obj == panel->tabBar() ) {
+        int tabIdx = panel->tabBar()->tabAt( event->pos() );
+        if ( tabIdx < 0 )
+          continue;
+        // Any click on side panel tab updates last focused view
+        auto * view = qobject_cast< ArticleView * >( panel->widget( tabIdx ) );
+        if ( view )
+          lastFocusedArticleView = view;
+        if ( event->button() == Qt::MiddleButton ) {
+          emit panel->tabCloseRequested( tabIdx );
+          return true;
+        }
+        else if ( event->button() == Qt::RightButton ) {
+          showTabContextMenu( panel, tabIdx, event->globalPosition().toPoint() );
+          return true;
+        }
+        // Left-click: let Qt handle tab switch normally
+      }
+    }
 
     return handleBackForwardMouseButtons( event );
   }
@@ -3128,7 +3630,9 @@ void MainWindow::showTranslationFor( const QString & word, unsigned inGroup, con
 {
   GlobalBroadcaster::instance()->is_popup = false;
 
-  ArticleView * view = getFirstNonWebSiteArticleView();
+  ArticleView * view = getCurrentArticleView();
+  if ( !view )
+    view = getFirstNonWebSiteArticleView();
 
   navPronounce->setEnabled( false );
 
@@ -3139,7 +3643,6 @@ void MainWindow::showTranslationFor( const QString & word, unsigned inGroup, con
 
   view->showDefinition( word, group, scrollTo );
 
-  //ui.tabWidget->setTabText( ui.tabWidget->indexOf(ui.tab), inWord.trimmed() );
 }
 
 void MainWindow::showTranslationForDicts( const QString & inWord,
@@ -3470,7 +3973,7 @@ int MainWindow::getIconSize()
     extent = QApplication::style()->pixelMetric( QStyle::PM_SmallIconSize );
   }
   else {
-    //empty
+    // empty
   }
   return extent;
 }
@@ -3875,9 +4378,22 @@ void MainWindow::messageFromAnotherInstanceReceived( const QString & message )
 
 ArticleView * MainWindow::getCurrentArticleView()
 {
+  // Prefer the widget that actually has keyboard focus
+  QWidget * focus = QApplication::focusWidget();
+  while ( focus && !qobject_cast< ArticleView * >( focus ) ) {
+    focus = focus->parentWidget();
+  }
+  auto * focusView = qobject_cast< ArticleView * >( focus );
+  if ( focusView )
+    return focusView;
+
+  // If focus moved to non-ArticleView (combo box, toolbar), use last focused tab
+  if ( lastFocusedArticleView )
+    return lastFocusedArticleView;
+
+  // Fall back to main panel's current tab
   QWidget * currentWidget   = ui.tabWidget->currentWidget();
   ArticleView * currentView = qobject_cast< ArticleView * >( currentWidget );
-
   if ( currentView ) {
     return currentView;
   }
@@ -3898,8 +4414,8 @@ ArticleView * MainWindow::getFirstNonWebSiteArticleView()
     }
   }
 
-  //the following logic is under the condition that "openWebsiteInNewTab" is enabled.
-  // If current view is already a non-website tab, return it directly
+  // the following logic is under the condition that "openWebsiteInNewTab" is enabled.
+  //  If current view is already a non-website tab, return it directly
   if ( currentView && !currentView->isWebsite() ) {
     return currentView;
   }
@@ -3925,20 +4441,33 @@ ArticleView * MainWindow::findArticleViewByDictId( const QString & dictId )
 {
   // First check if openWebsiteInNewTab configuration is enabled
   if ( GlobalBroadcaster::instance()->getPreference()->openWebsiteInNewTab ) {
-    // Iterate through all tabs
+    // Iterate through all tabs in main tab widget
     for ( int i = 0; i < ui.tabWidget->count(); i++ ) {
       auto * view = qobject_cast< ArticleView * >( ui.tabWidget->widget( i ) );
       if ( view && view->isWebsite() ) {
-        // Check if current ArticleView's activeDictIds list contains the specified dictId
         QString dictIdActive = view->getActiveArticleId();
         if ( dictIdActive == dictId ) {
           return view;
         }
       }
     }
+    // Also search panel tab widgets
+    for ( int p = 0; p < ui.panelSplitter->count(); p++ ) {
+      auto * panel = qobject_cast< QTabWidget * >( ui.panelSplitter->widget( p ) );
+      if ( !panel )
+        continue;
+      for ( int i = 0; i < panel->count(); i++ ) {
+        auto * view = qobject_cast< ArticleView * >( panel->widget( i ) );
+        if ( view && view->isWebsite() ) {
+          QString dictIdActive = view->getActiveArticleId();
+          if ( dictIdActive == dictId ) {
+            return view;
+          }
+        }
+      }
+    }
   }
   qDebug() << "findArticleViewByDictId() return nullptr with dictId:" << dictId;
-  // If configuration is not enabled or no matching ArticleView found, return nullptr
   return nullptr;
 }
 
@@ -4130,7 +4659,7 @@ void MainWindow::on_importHistory_triggered()
     errorMessageOnStatusBar( errStr );
     return;
   }
-  //even without this line, the destructor of QFile will close the file as documented.
+  // even without this line, the destructor of QFile will close the file as documented.
   file.close();
   mainStatusBar->showMessage( tr( "History import complete" ), 5000 );
 }
@@ -4550,6 +5079,11 @@ void MainWindow::openWebsiteInNewTab( QString name, QString url, QString dictId,
     view->setWebsite( true );
     // Set the dictId for the website view
     view->setActiveArticleId( dictId );
+
+    // Move to panel if configured
+    if ( cfg.preferences.openWebsitesInPanel ) {
+      addPanel( view );
+    }
   }
 
   // Set the current word for the website view
@@ -4701,7 +5235,7 @@ void MainWindow::headwordFromFavorites( const QString & headword, const QString 
 
   setInputLineText( words[ 0 ], WildcardPolicy::EscapeWildcards, DisablePopup );
 
-  //must be a bookmark.
+  // must be a bookmark.
   if ( words.size() > 1 ) {
     auto view = getCurrentArticleView();
     if ( view ) {

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -142,10 +142,7 @@ private:
   QActionGroup * smallLargeIconGroup = new QActionGroup( this );
 
   QAction stopAudioAction;
-  int tabMenuTabIndex = -1; // tab index where context menu was opened
   QPointer< ArticleView > lastFocusedArticleView; // last ArticleView that had keyboard focus
-  QMenu * moveToMenu          = nullptr;
-  QAction * newPanelAction    = nullptr;
   QToolBar * navToolbar;
   MainStatusBar * mainStatusBar;
   QAction *navBack, *navForward, *navPronounce, *enableScanningAction;
@@ -156,7 +153,6 @@ private:
 #ifdef Q_OS_MACOS
   QMenu dockMenu; // Separate menu for macOS Dock
 #endif
-  QMenu * tabMenu;
   QAction * menuButtonAction;
   QToolButton * menuButton;
   MRUQMenu * tabListMenu;
@@ -379,7 +375,6 @@ private slots:
 
   void pageLoaded( ArticleView * );
   void tabSwitched( int );
-  void tabMenuRequested( QPoint pos );
 
   void dictionaryBarToggled( bool checked );
 

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -52,6 +52,21 @@ public:
   /// Set group for main/popup window
   void setGroupByName( const QString & name, bool main_window );
 
+  // Side-by-side panels
+  void addPanel( ArticleView * av, int targetPanelIdx = -1 );
+  void removePanel( ArticleView * av );
+  void showTabContextMenu( QTabWidget * panel, int tabIdx, QPoint globalPos );
+  QString formatTabTitle( ArticleView * av, const QString & baseTitle );
+  void updateTabTitleMarker( ArticleView * av );
+  QTabWidget * panelForView( ArticleView * av );
+  QTabWidget * findOrCreateSidePanel();
+  QTabWidget * createNewSidePanel();
+  void togglePanel();
+  void togglePanelOrientation();
+  int totalTabCount() const;
+  int panelCount() const;
+  void distributePanelSizes();
+
   enum class WildcardPolicy {
     EscapeWildcards,
     WildcardsAreAlreadyEscaped
@@ -117,13 +132,18 @@ private:
 
   QAction escAction, focusTranslateLineAction, addTabAction, closeCurrentTabAction, closeAllTabAction,
     closeRestTabAction, switchToNextTabAction, switchToPrevTabAction, showDictBarNamesAction, toggleMenuBarAction,
-    lockPanelsAction, focusHeadwordsDlgAction, focusArticleViewAction, addAllTabToFavoritesAction;
+    lockPanelsAction, focusHeadwordsDlgAction, focusArticleViewAction, addAllTabToFavoritesAction, togglePanelAction,
+    togglePanelOrientationAction;
 
   QAction useSmallIconsInToolbarsAction, useLargeIconsInToolbarsAction, useNormalIconsInToolbarsAction;
 
   QActionGroup * smallLargeIconGroup = new QActionGroup( this );
 
   QAction stopAudioAction;
+  int tabMenuTabIndex = -1; // tab index where context menu was opened
+  ArticleView * lastFocusedArticleView = nullptr; // last ArticleView that had keyboard focus
+  QMenu * moveToMenu          = nullptr;
+  QAction * newPanelAction    = nullptr;
   QToolBar * navToolbar;
   MainStatusBar * mainStatusBar;
   QAction *navBack, *navForward, *navPronounce, *enableScanningAction;

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -156,7 +156,7 @@ private:
   QAction * menuButtonAction;
   QToolButton * menuButton;
   QToolButton * tabListButton = nullptr; // main panel's tab list button (for Ctrl+Tab)
-  //List that contains indexes of tabs arranged in a most-recently-used order
+  // List that contains indexes of tabs arranged in a most-recently-used order
   QList< QWidget * > mruList;
   Config::Class & cfg;
   History history;

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -22,7 +22,6 @@
 #include "dictionarybar.hh"
 #include "history.hh"
 #include "mainstatusbar.hh"
-#include "mruqmenu.hh"
 #include "translatebox.hh"
 #include "dictheadwords.hh"
 #include "fulltextsearch.hh"
@@ -61,9 +60,9 @@ public:
   QTabWidget * panelForView( ArticleView * av );
   QTabWidget * activePanel();
   void closeTabInPanel( QTabWidget * panel, int tabIndex );
+  QTabWidget * createPanel();
   QTabWidget * findOrCreateSidePanel();
   QTabWidget * createNewSidePanel();
-  void setupTabWidgetCommon( QTabWidget * panel );
   void togglePanel();
   void togglePanelOrientation();
   int totalTabCount() const;
@@ -156,10 +155,9 @@ private:
 #endif
   QAction * menuButtonAction;
   QToolButton * menuButton;
-  MRUQMenu * tabListMenu;
+  QToolButton * tabListButton = nullptr; // main panel's tab list button (for Ctrl+Tab)
   //List that contains indexes of tabs arranged in a most-recently-used order
   QList< QWidget * > mruList;
-  QToolButton addTab, *tabListButton;
   Config::Class & cfg;
   History history;
   DictionaryBar dictionaryBar;
@@ -360,10 +358,7 @@ private slots:
   void switchToNextTab();
   void switchToPrevTab();
 
-  // Handling of active tab list
-  void createTabList();
   void fillWindowsMenu();
-  void switchToWindow( QAction * act );
 
   /// Triggered by the actions in the nav toolbar
   void backClicked();

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -59,6 +59,7 @@ public:
   QString formatTabTitle( ArticleView * av, const QString & baseTitle );
   void updateTabTitleMarker( ArticleView * av );
   QTabWidget * panelForView( ArticleView * av );
+  QTabWidget * activePanel();
   QTabWidget * findOrCreateSidePanel();
   QTabWidget * createNewSidePanel();
   void setupTabWidgetCommon( QTabWidget * panel );
@@ -142,7 +143,7 @@ private:
 
   QAction stopAudioAction;
   int tabMenuTabIndex = -1; // tab index where context menu was opened
-  ArticleView * lastFocusedArticleView = nullptr; // last ArticleView that had keyboard focus
+  QPointer< ArticleView > lastFocusedArticleView; // last ArticleView that had keyboard focus
   QMenu * moveToMenu          = nullptr;
   QAction * newPanelAction    = nullptr;
   QToolBar * navToolbar;

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -61,6 +61,7 @@ public:
   QTabWidget * panelForView( ArticleView * av );
   QTabWidget * findOrCreateSidePanel();
   QTabWidget * createNewSidePanel();
+  void setupTabWidgetCommon( QTabWidget * panel );
   void togglePanel();
   void togglePanelOrientation();
   int totalTabCount() const;

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -60,6 +60,7 @@ public:
   void updateTabTitleMarker( ArticleView * av );
   QTabWidget * panelForView( ArticleView * av );
   QTabWidget * activePanel();
+  void closeTabInPanel( QTabWidget * panel, int tabIndex );
   QTabWidget * findOrCreateSidePanel();
   QTabWidget * createNewSidePanel();
   void setupTabWidgetCommon( QTabWidget * panel );
@@ -412,6 +413,9 @@ private slots:
 
   void showDictsPane();
   void dictsPaneVisibilityChanged( bool );
+
+  /// Shared ArticleView construction + signal wiring for createNewTab / addNewTabToPanel
+  ArticleView * createArticleView();
 
   /// Creates a new tab, which is to be populated then with some content.
   ArticleView * createNewTab( bool switchToIt, const QString & name );

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -350,6 +350,8 @@ private slots:
 
   // Executed in response to a user click on an 'add tab' tool button
   void addNewTab();
+  // Creates a new tab in a specific panel
+  void addNewTabToPanel( QTabWidget * panel );
   // Executed in response to a user click on an 'close' button on a tab
   void tabCloseRequested( int );
   // Closes current tab.

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -14,7 +14,7 @@
    <string notr="true">GoldenDict-ng</string>
   </property>
   <widget class="QWidget" name="centralWidget">
-   <layout class="QHBoxLayout" name="horizontalLayout_2">
+   <layout class="QHBoxLayout" name="centralLayout">
     <property name="leftMargin">
      <number>1</number>
     </property>
@@ -40,6 +40,13 @@
       </property>
       <property name="elideMode">
        <enum>Qt::ElideRight</enum>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QSplitter" name="panelSplitter">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
       </property>
      </widget>
     </item>

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -379,6 +379,7 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   ui.removeInvalidIndexOnExit->setChecked( p.removeInvalidIndexOnExit );
   ui.enableApplicationLog->setChecked( p.enableApplicationLog );
   ui.openWebsiteInNewTab->setChecked( p.openWebsiteInNewTab );
+  ui.openWebsitesInPanel->setChecked( p.openWebsitesInPanel );
   ui.suppressWebDialogs->setChecked( p.suppressWebDialogs );
   ui.enableJavaScriptClipboard->setChecked( p.enableJavaScriptClipboardAccess );
 
@@ -527,6 +528,7 @@ Config::Preferences Preferences::getPreferences()
   p.ignoreDiacritics       = ui.ignoreDiacritics->isChecked();
   p.ignorePunctuation      = ui.ignorePunctuation->isChecked();
   p.sessionCollapse        = ui.sessionCollapse->isChecked();
+
   p.stripClipboard         = ui.stripClipboard->isChecked();
   p.raiseWindowOnSearch    = ui.raiseWindowOnSearch->isChecked();
 
@@ -568,6 +570,7 @@ Config::Preferences Preferences::getPreferences()
   p.removeInvalidIndexOnExit = ui.removeInvalidIndexOnExit->isChecked();
   p.enableApplicationLog     = ui.enableApplicationLog->isChecked();
   p.openWebsiteInNewTab             = ui.openWebsiteInNewTab->isChecked();
+p.openWebsitesInPanel            = ui.openWebsitesInPanel->isChecked();
   p.suppressWebDialogs       = ui.suppressWebDialogs->isChecked();
   p.enableJavaScriptClipboardAccess = ui.enableJavaScriptClipboard->isChecked();
 

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -570,7 +570,7 @@ Config::Preferences Preferences::getPreferences()
   p.removeInvalidIndexOnExit = ui.removeInvalidIndexOnExit->isChecked();
   p.enableApplicationLog     = ui.enableApplicationLog->isChecked();
   p.openWebsiteInNewTab             = ui.openWebsiteInNewTab->isChecked();
-p.openWebsitesInPanel            = ui.openWebsitesInPanel->isChecked();
+  p.openWebsitesInPanel             = ui.openWebsitesInPanel->isChecked();
   p.suppressWebDialogs       = ui.suppressWebDialogs->isChecked();
   p.enableJavaScriptClipboardAccess = ui.enableJavaScriptClipboard->isChecked();
 

--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -1932,6 +1932,13 @@ from Stardict, Babylon and GLS dictionaries</string>
            </widget>
           </item>
           <item>
+           <widget class="QCheckBox" name="openWebsitesInPanel">
+            <property name="text">
+             <string>Open websites in panels</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QCheckBox" name="suppressWebDialogs">
             <property name="toolTip">
              <string>Suppress JavaScript alerts, confirms, and prompts in the article view.</string>

--- a/website/docs/ui_shortcuts.md
+++ b/website/docs/ui_shortcuts.md
@@ -40,7 +40,6 @@
 | Ctrl+Tab              | (In main window) switch to next tab (can be changed in preferences)                                                              |
 | Ctrl+Shift+A          | Select current article only                                                                                                      |
 | Ctrl+Shift+C          | Copy selected as text                                                                                                            |
-| Ctrl+Shift+E          | Toggle Always Query on current tab                                                                                               |
 | Ctrl+Shift+F          | Open/switch to full-text search dialog                                                                                           |
 | Ctrl+Shift+H          | Toggle panel orientation (horizontal/vertical)                                                                                 |
 | Ctrl+Shift+P          | Toggle panel — move current tab between main view and side panel                                                               |

--- a/website/docs/ui_shortcuts.md
+++ b/website/docs/ui_shortcuts.md
@@ -40,7 +40,10 @@
 | Ctrl+Tab              | (In main window) switch to next tab (can be changed in preferences)                                                              |
 | Ctrl+Shift+A          | Select current article only                                                                                                      |
 | Ctrl+Shift+C          | Copy selected as text                                                                                                            |
+| Ctrl+Shift+E          | Toggle Always Query on current tab                                                                                               |
 | Ctrl+Shift+F          | Open/switch to full-text search dialog                                                                                           |
+| Ctrl+Shift+H          | Toggle panel orientation (horizontal/vertical)                                                                                 |
+| Ctrl+Shift+P          | Toggle panel — move current tab between main view and side panel                                                               |
 | Ctrl+Shift+W          | Close all tabs                                                                                                                   |
 | Ctrl+Shift+S          | Stop current playing sound                                                                                                       |
 | Del                   | (History) delete select line                                                                                                     |


### PR DESCRIPTION
## Summary

Adds side-by-side dictionary panels to goldendict-ng. Each panel operates independently with its own tabs, groups, and context menus.

## Features

### Multi-Panel Layout
- Side-by-side panels via splitter. Main panel plus N side panels.
- `Ctrl+Shift+P` — toggle current tab between main panel and side panel.
- `Ctrl+Shift+H` — toggle splitter orientation (horizontal ↔ vertical).
- "Move to Panel" submenu lists all existing panels for moving tabs.
- "Move to New Panel" always creates a fresh panel (never reuses existing).
- Auto-creation of empty tab when the last main panel tab moves to a side panel.
- Double-click empty tab bar space creates new tab on all panels.
- Tab list dropdown button on all panels for quick tab navigation.
- Close button and middle-click close tabs in side panels (instead of moving to main).

### Focus-Aware Group Switching
- Group list widget syncs to whichever panel has keyboard focus.
- Group changes via dropdown or hotkeys apply to the focused tab.
- Dictionary bar updates when keyboard focus changes between tabs across panels.

### Side Panel Context Menus
- Full parity with main panel: Close Tab, Close All Except Current, Close All Tabs, Move to Panel, Move to New Panel, Add to Favorites, Add All Tabs to Favorites.
- All options work panel-scoped.

## Keyboard Shortcuts
| Key | Action |
|-----|--------|
| `Ctrl+Shift+P` | Toggle panel |
| `Ctrl+Shift+H` | Toggle panel orientation |