### PR TITLE
fix: resolve -Werror=maybe-uninitialized warnings

### DIFF
--- a/src/common/iconv.cc
+++ b/src/common/iconv.cc
@@ -75,7 +75,7 @@ QString Iconv::convert( const void *& inBuf, size_t & inBytesLeft )
   void * outBufPtr = &outBuf.front();
 
   size_t outBufLeft = outBuf.size();
-  size_t result;
+  size_t result = (size_t)( -1 );
   while ( inBytesLeft > 0 ) {
     result = iconv( state, (char **)&inBuf, &inBytesLeft, (char **)&outBufPtr, &outBufLeft );
     if ( result == (size_t)-1 ) {

--- a/src/common/iconv.cc
+++ b/src/common/iconv.cc
@@ -75,7 +75,7 @@ QString Iconv::convert( const void *& inBuf, size_t & inBytesLeft )
   void * outBufPtr = &outBuf.front();
 
   size_t outBufLeft = outBuf.size();
-  size_t result = (size_t)( -1 );
+  size_t result     = (size_t)( -1 );
   while ( inBytesLeft > 0 ) {
     result = iconv( state, (char **)&inBuf, &inBytesLeft, (char **)&outBufPtr, &outBufLeft );
     if ( result == (size_t)-1 ) {

--- a/src/dict/epwing.cc
+++ b/src/dict/epwing.cc
@@ -621,7 +621,8 @@ void EpwingArticleRequest::run()
     // Now grab that article
 
     string headword, articleText;
-    int articlePage, articleOffset;
+    int articlePage   = 0;
+    int articleOffset = 0;
 
     try {
       dict.loadArticle( x.articleOffset, headword, articleText, articlePage, articleOffset );


### PR DESCRIPTION
Resolve compilation warnings treated as errors:

1. **src/common/iconv.cc**: Initialize 'result' variable to (size_t)(-1) to avoid uninitialized use when input buffer is empty

2. **src/dict/epwing.cc**: Add 'continue' in catch block when article loading fails, preventing:
   - Use of uninitialized articlePage/articleOffset variables
