### PR TITLE
Fix Linux crash when custom proxy host or port is unset

### DIFF
--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1741,7 +1741,8 @@ void MainWindow::applyProxySettings()
 
   QNetworkProxy proxy( type );
 
- if ( cfg.preferences.proxyServer.enabled && !cfg.preferences.proxyServer.host.isEmpty() && cfg.preferences.proxyServer.port != 0) {
+  if ( cfg.preferences.proxyServer.enabled && !cfg.preferences.proxyServer.host.isEmpty()
+       && cfg.preferences.proxyServer.port != 0 ) {
 
     proxy.setHostName( cfg.preferences.proxyServer.host );
     proxy.setPort( cfg.preferences.proxyServer.port );
@@ -1754,8 +1755,8 @@ void MainWindow::applyProxySettings()
       proxy.setPassword( cfg.preferences.proxyServer.password );
     }
   }
-  else{
-    proxy.setType(QNetworkProxy::NoProxy);
+  else {
+    proxy.setType( QNetworkProxy::NoProxy );
   }
 
   QNetworkProxy::setApplicationProxy( proxy );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1741,7 +1741,8 @@ void MainWindow::applyProxySettings()
 
   QNetworkProxy proxy( type );
 
-  if ( cfg.preferences.proxyServer.enabled ) {
+ if ( cfg.preferences.proxyServer.enabled && !cfg.preferences.proxyServer.host.isEmpty() && cfg.preferences.proxyServer.port != 0) {
+
     proxy.setHostName( cfg.preferences.proxyServer.host );
     proxy.setPort( cfg.preferences.proxyServer.port );
 
@@ -1752,6 +1753,9 @@ void MainWindow::applyProxySettings()
     if ( cfg.preferences.proxyServer.password.size() ) {
       proxy.setPassword( cfg.preferences.proxyServer.password );
     }
+  }
+  else{
+    proxy.setType(QNetworkProxy::NoProxy);
   }
 
   QNetworkProxy::setApplicationProxy( proxy );


### PR DESCRIPTION
Problem:
Linux crash occurs when proxy is active and host is NULL.

Solution:
Validate that host is not empty and port is non-zero before proceeding. Otherwise, downgrade the proxy type to NoProxy.