### PR TITLE
refactor: rearrange DictHeadwords layout for more list space

### DIFF
--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -504,10 +504,6 @@ between classic and school orthography in cyrillic)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Search mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This element determines how filter string will be interpreted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -529,10 +525,6 @@ between classic and school orthography in cyrillic)</source>
     </message>
     <message>
         <source>Specify the maximum filtered headwords returned.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Filter max results:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -589,6 +581,10 @@ between classic and school orthography in cyrillic)</source>
     </message>
     <message>
         <source>Regular Expression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -528,14 +528,6 @@ between classic and school orthography in cyrillic)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>OK</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/dictheadwords.cc
+++ b/src/ui/dictheadwords.cc
@@ -23,8 +23,7 @@ enum SearchType {
 DictHeadwords::DictHeadwords( QWidget * parent, Config::Class & cfg_, Dictionary::Class * dict_ ):
   QDialog( parent ),
   cfg( cfg_ ),
-  dict( dict_ ),
-  helpAction( this )
+  dict( dict_ )
 {
   ui.setupUi( this );
 
@@ -46,7 +45,6 @@ DictHeadwords::DictHeadwords( QWidget * parent, Config::Class & cfg_, Dictionary
   ui.searchModeCombo->setCurrentIndex( cfg.headwordsDialog.searchMode );
 
   ui.exportButton->setAutoDefault( false );
-  ui.OKButton->setAutoDefault( false );
   ui.applyButton->setAutoDefault( true );
   ui.applyButton->setDefault( true );
 
@@ -82,23 +80,11 @@ DictHeadwords::DictHeadwords( QWidget * parent, Config::Class & cfg_, Dictionary
   connect( this, &QDialog::finished, this, &DictHeadwords::savePos );
 
   if ( !fromMainWindow ) {
-    ui.helpButton->hide();
     connect( this, &DictHeadwords::closeDialog, this, &QDialog::accept );
   }
   else {
-
-    helpAction.setShortcut( QKeySequence( "F1" ) );
-    helpAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
-
-    connect( ui.helpButton, &QAbstractButton::clicked, &helpAction, &QAction::trigger );
-    connect( &helpAction, &QAction::triggered, this, []() {
-      Help::openHelpWebpage( Help::section::ui_headwords );
-    } );
-
-    addAction( &helpAction );
   }
 
-  connect( ui.OKButton, &QAbstractButton::clicked, this, &DictHeadwords::okButtonClicked );
   connect( ui.exportButton, &QAbstractButton::clicked, this, &DictHeadwords::exportButtonClicked );
   connect( ui.applyButton, &QAbstractButton::clicked, this, &DictHeadwords::filterChanged );
 

--- a/src/ui/dictheadwords.hh
+++ b/src/ui/dictheadwords.hh
@@ -28,8 +28,6 @@ protected:
   WordListItemDelegate * delegate;
   QString dictId;
 
-  QAction helpAction;
-
   void saveHeadersToFile();
   bool eventFilter( QObject * obj, QEvent * ev );
 

--- a/src/ui/dictheadwords.ui
+++ b/src/ui/dictheadwords.ui
@@ -81,19 +81,6 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="exportButton">
-       <property name="toolTip">
-        <string>Exports headwords to file</string>
-       </property>
-       <property name="text">
-        <string>Export</string>
-       </property>
-       <property name="autoDefault">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QLabel" name="label_2">
        <property name="toolTip">
         <string>Specify the maximum filtered headwords returned.</string>
@@ -133,26 +120,19 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="helpButton">
+      <widget class="QPushButton" name="exportButton">
+       <property name="toolTip">
+        <string>Exports headwords to file</string>
+       </property>
        <property name="text">
-        <string>Help</string>
+        <string>Export</string>
        </property>
        <property name="autoDefault">
         <bool>false</bool>
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QPushButton" name="OKButton">
-       <property name="text">
-        <string>OK</string>
-       </property>
-       <property name="autoDefault">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   </layout>
    </item>
    <item>
     <widget class="QListView" name="headersListView"/>
@@ -169,3 +149,4 @@
  <resources/>
  <connections/>
 </ui>
+

--- a/src/ui/dictheadwords.ui
+++ b/src/ui/dictheadwords.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>458</width>
-    <height>550</height>
+    <width>520</width>
+    <height>500</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,8 +15,22 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <layout class="QGridLayout" name="gridLayout">
-     <item row="1" column="1">
+    <layout class="QHBoxLayout" name="filterLayout">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Filter:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="filterLine">
+       <property name="toolTip">
+        <string>Filter string (fixed string, wildcards or regular expression)</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QCheckBox" name="autoApply">
        <property name="toolTip">
         <string>If checked any filter changes will we immediately applied to headwords list</string>
@@ -26,10 +40,7 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
-      <widget class="QListView" name="headersListView"/>
-     </item>
-     <item row="2" column="1">
+     <item>
       <widget class="QPushButton" name="applyButton">
        <property name="toolTip">
         <string>Press this button to apply filter to headwords list</string>
@@ -40,128 +51,111 @@
        <property name="autoDefault">
         <bool>false</bool>
        </property>
-       <property name="default">
-        <bool>true</bool>
-       </property>
       </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLineEdit" name="filterLine">
-       <property name="toolTip">
-        <string>Filter string (fixed string, wildcards or regular expression)</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Filter:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <item>
-        <widget class="QGroupBox" name="groupBox">
-         <property name="title">
-          <string>Search mode</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout">
-          <item>
-           <widget class="QComboBox" name="searchModeCombo">
-            <property name="toolTip">
-             <string>This element determines how filter string will be interpreted</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="matchCase">
-            <property name="toolTip">
-             <string>If checked on the symbols case will be take in account when filtering</string>
-            </property>
-            <property name="text">
-             <string>Match case</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="exportButton">
-         <property name="toolTip">
-          <string>Exports headwords to file</string>
-         </property>
-         <property name="text">
-          <string>Export</string>
-         </property>
-         <property name="autoDefault">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-           <widget class="QLabel" name="label_2">
-               <property name="toolTip">
-                   <string>Specify the maximum filtered headwords returned.</string>
-               </property>
-               <property name="text">
-                   <string>Filter max results:</string>
-               </property>
-           </widget>
-       </item>
-          <item>
-              <widget class="QSpinBox" name="filterMaxResult">
-                  <property name="toolTip">
-                      <string/>
-                  </property>
-                  <property name="minimum">
-                      <number>10</number>
-                  </property>
-                  <property name="maximum">
-                      <number>3000</number>
-                  </property>
-                  <property name="singleStep">
-                      <number>10</number>
-                  </property>
-              </widget>
-          </item>
-          <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QPushButton" name="helpButton">
-         <property name="text">
-          <string>Help</string>
-         </property>
-         <property name="autoDefault">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="OKButton">
-         <property name="text">
-          <string>OK</string>
-         </property>
-         <property name="autoDefault">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-      </layout>
      </item>
     </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="toolbarLayout">
+     <item>
+      <widget class="QComboBox" name="searchModeCombo">
+       <property name="toolTip">
+        <string>This element determines how filter string will be interpreted</string>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="matchCase">
+       <property name="toolTip">
+        <string>If checked on the symbols case will be take in account when filtering</string>
+       </property>
+       <property name="text">
+        <string>Match case</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="exportButton">
+       <property name="toolTip">
+        <string>Exports headwords to file</string>
+       </property>
+       <property name="text">
+        <string>Export</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="toolTip">
+        <string>Specify the maximum filtered headwords returned.</string>
+       </property>
+       <property name="text">
+        <string>Max:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="filterMaxResult">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="minimum">
+        <number>10</number>
+       </property>
+       <property name="maximum">
+        <number>3000</number>
+       </property>
+       <property name="singleStep">
+        <number>10</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="helpButton">
+       <property name="text">
+        <string>Help</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="OKButton">
+       <property name="text">
+        <string>OK</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QListView" name="headersListView"/>
    </item>
    <item>
     <widget class="QLabel" name="headersNumber">


### PR DESCRIPTION
based on  #3015
close  #3015

<img width="609" height="574" alt="PixPin_2026-07-15_17-21-51" src="https://github.com/user-attachments/assets/1f04606b-57a3-405c-9d9d-9ce92a7aaba4" />
