### PR TITLE
feat(articleview): add Open in External Browser context menu for website tabs

### DIFF
--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -576,7 +576,7 @@ between classic and school orthography in cyrillic)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max:</source>
+        <source>Maximum:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2637,6 +2637,10 @@ To find &apos;*&apos;, &apos;?&apos;, &apos;[&apos;, &apos;]&apos; symbols use &
     </message>
     <message>
         <source>Application is still running in the background. Click the tray icon to show the window.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open in &amp;External Browser</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -546,8 +546,12 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   tabMenu->addSeparator();
   tabMenu->addAction( &closeAllTabAction );
   tabMenu->addSeparator();
+  openInExternalBrowserAction = new QAction( QIcon( ":/icons/internet.svg" ), tr( "Open in &External Browser" ), this );
+  openInExternalBrowserAction->setVisible( false );
+  tabMenu->addAction( openInExternalBrowserAction );
   tabMenu->addAction( addToFavorites );
   tabMenu->addAction( &addAllTabToFavoritesAction );
+  connect( openInExternalBrowserAction, &QAction::triggered, this, &MainWindow::openCurrentTabInExternalBrowser );
 
   // Dictionary bar names
   showDictBarNamesAction.setCheckable( true );
@@ -2238,9 +2242,19 @@ void MainWindow::tabSwitched( int )
 
 void MainWindow::tabMenuRequested( QPoint pos )
 {
-  //  // do not show this menu for single tab
-  //  if ( ui.tabWidget->count() < 2 )
-  //    return;
+  int tabIndex = ui.tabWidget->tabBar()->tabAt( pos );
+  if ( tabIndex == -1 ) {
+    return;
+  }
+
+  ArticleView * view = qobject_cast< ArticleView * >( ui.tabWidget->widget( tabIndex ) );
+  if ( view && view->isWebsite() ) {
+    openInExternalBrowserAction->setVisible( true );
+    openInExternalBrowserAction->setData( tabIndex );
+  }
+  else {
+    openInExternalBrowserAction->setVisible( false );
+  }
 
   tabMenu->popup( ui.tabWidget->mapToGlobal( pos ) );
 }
@@ -4563,6 +4577,15 @@ void MainWindow::openWebsiteInNewTab( QString name, QString url, QString dictId,
   }
 
   view->load( url, name );
+}
+
+void MainWindow::openCurrentTabInExternalBrowser()
+{
+  int tabIndex = openInExternalBrowserAction->data().toInt();
+  ArticleView * view = qobject_cast< ArticleView * >( ui.tabWidget->widget( tabIndex ) );
+  if ( view ) {
+    QDesktopServices::openUrl( view->page()->url() );
+  }
 }
 
 void MainWindow::addCurrentTabToFavorites()

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -4581,7 +4581,7 @@ void MainWindow::openWebsiteInNewTab( QString name, QString url, QString dictId,
 
 void MainWindow::openCurrentTabInExternalBrowser()
 {
-  int tabIndex = openInExternalBrowserAction->data().toInt();
+  int tabIndex       = openInExternalBrowserAction->data().toInt();
   ArticleView * view = qobject_cast< ArticleView * >( ui.tabWidget->widget( tabIndex ) );
   if ( view ) {
     QDesktopServices::openUrl( view->page()->url() );

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -135,6 +135,7 @@ private:
   QMenu dockMenu; // Separate menu for macOS Dock
 #endif
   QMenu * tabMenu;
+  QAction * openInExternalBrowserAction;
   QAction * menuButtonAction;
   QToolButton * menuButton;
   MRUQMenu * tabListMenu;
@@ -356,6 +357,7 @@ private slots:
   void pageLoaded( ArticleView * );
   void tabSwitched( int );
   void tabMenuRequested( QPoint pos );
+  void openCurrentTabInExternalBrowser();
 
   void dictionaryBarToggled( bool checked );
 


### PR DESCRIPTION
Adds a right-click context menu option 'Open in External Browser' for website dictionary tabs when openWebsiteInNewTab is enabled. This allows users to open the current web page in their system default browser.