### PR TITLE
style(preferences): move parallelThreads setting outside ftsGroupBox

### DIFF
--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -1580,6 +1580,19 @@ download page.</string>
            </property>
           </widget>
          </item>
+         <item>
+          <spacer name="horizontalSpacer_11">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
         </layout>
        </item>
        <item>

--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -1561,26 +1561,26 @@ download page.</string>
             </property>
            </widget>
           </item>
-          <item row="8" column="0">
-           <layout class="QHBoxLayout" name="horizontalLayout_18">
-            <item>
-             <widget class="QLabel" name="label_7">
-              <property name="text">
-               <string>Create fulltext index with parallel threads </string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QSpinBox" name="parallelThreads">
-              <property name="minimum">
-               <number>1</number>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
          </layout>
         </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_18">
+         <item>
+          <widget class="QLabel" name="label_7">
+           <property name="text">
+            <string>Create fulltext index with parallel threads </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="parallelThreads">
+           <property name="minimum">
+            <number>1</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
         <spacer name="verticalSpacer_7">


### PR DESCRIPTION
Move 'Create fulltext index with parallel threads' setting outside the FTS groupbox so it remains accessible even when global full-text search is disabled. This allows users to configure parallel indexing threads for dictionaries that may have FTS enabled via metadata.