### PR TITLE
fix(scanpopup): make Alt+W shortcut work when toolbar is hidden

### DIFF
--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -3779,10 +3779,6 @@ from Stardict, Babylon and GLS dictionaries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Alt+W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Add word to Favorites (Ctrl+E)</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -145,6 +145,11 @@ ScanPopup::ScanPopup( QWidget * parent,
   connect( ui.sendWordButton, &QToolButton::pressed, this, &ScanPopup::sendWordButton_clicked );
   connect( ui.sendWordToFavoritesButton, &QToolButton::pressed, this, &ScanPopup::sendWordToFavoritesButton_clicked );
 
+  sendWordAction.setShortcut( QKeySequence( "Alt+W" ) );
+  sendWordAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
+  addAction( &sendWordAction );
+  connect( &sendWordAction, &QAction::triggered, this, &ScanPopup::sendWordButton_clicked );
+
   openSearchAction.setShortcut( QKeySequence( "Ctrl+F" ) );
   openSearchAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
   addAction( &openSearchAction );

--- a/src/ui/scanpopup.hh
+++ b/src/ui/scanpopup.hh
@@ -133,6 +133,7 @@ private:
   QAction escapeAction, switchExpandModeAction, focusTranslateLineAction;
   QAction stopAudioAction;
   QAction openSearchAction;
+  QAction sendWordAction;
   QString pendingWord; // Word that is going to be translated
   WordFinder wordFinder;
   DictionaryBar dictionaryBar;

--- a/src/ui/scanpopup_toolbar.ui
+++ b/src/ui/scanpopup_toolbar.ui
@@ -131,9 +131,6 @@
       <iconset resource="../../resources.qrc">
        <normaloff>:/icons/programicon.png</normaloff>:/icons/programicon.png</iconset>
      </property>
-     <property name="shortcut">
-      <string>Alt+W</string>
-     </property>
      <property name="iconSize">
       <size>
        <width>24</width>


### PR DESCRIPTION
## Problem

In older versions, pressing Alt+W in the Scan Popup would switch the current lookup result to the main window, regardless of whether the toolbar was visible.

In recent versions, Alt+W only works when the Scan Popup toolbar is shown. Once the toolbar is hidden, the shortcut no longer responds.

## Root Cause

The Alt+W shortcut was set directly on the \sendWordButton\ QToolButton's \shortcut\ property in the UI file. When the toolbar containing the button is hidden, the button and its shortcut are disabled.

## Solution

Move the Alt+W shortcut from the button's \shortcut\ property to a window-level \QAction\, similar to how other shortcuts (Esc, Alt+D, Ctrl+F) are implemented in ScanPopup.

### Changes

1. **scanpopup.hh**: Add \QAction sendWordAction\ member variable
2. **scanpopup.cc**: Configure the action with Alt+W shortcut and connect to the sendWordButton_clicked slot
3. **scanpopup_toolbar.ui**: Remove the \shortcut\ property from the button

### Benefits

- Alt+W now works regardless of toolbar visibility
- Aligns with other shortcut implementations in ScanPopup
- Uses \Qt::WidgetWithChildrenShortcut\ context for proper scope

## Testing

Tested scenarios:
- Alt+W works with toolbar visible
- Alt+W works with toolbar hidden
- Button click still works as expected