### PR TITLE
fix: prevent main window from opening with scan popup on macOS

### DIFF
--- a/src/common/globalbroadcaster.hh
+++ b/src/common/globalbroadcaster.hh
@@ -7,6 +7,8 @@
 #include "sptr.hh"
 #include <QMap>
 #include <QScopedPointer>
+#include <QDateTime>
+#include <atomic>
 #include <vector>
 #include "instances.hh"
 #include "audio/audioplayerinterface.hh"
@@ -43,6 +45,7 @@ class GlobalBroadcaster: public QObject
 
 public:
   std::atomic_bool is_popup;
+  std::atomic<qint64> lastPopupEngageMs{ 0 };
 
   void setConfig( Config::Class * _config );
   Config::Class * getConfig() const;

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -3425,11 +3425,20 @@ void MainWindow::trayIconActivated( QSystemTrayIcon::ActivationReason r )
 #ifdef Q_OS_MACOS
 void MainWindow::handleApplicationStateChanged( Qt::ApplicationState state )
 {
-  // When the application becomes active (e.g., user clicks on Dock icon)
-  // and the main window is minimized or hidden, restore it
-  if ( state == Qt::ApplicationActive && ( isMinimized() || !isVisible() ) ) {
-    toggleMainWindow( true );
+  if ( state != Qt::ApplicationActive || ( !isMinimized() && isVisible() ) ) {
+    return;
   }
+
+  // Activation caused by the scan popup (hotkey, or clicking into a
+  // pinned popup) must not restore the main window.
+  if ( scanPopup && scanPopup->isVisible()
+       && ( QApplication::activeWindow() == scanPopup
+            || QDateTime::currentMSecsSinceEpoch()
+                 - GlobalBroadcaster::instance()->lastPopupEngageMs.load() < 3000 ) ) {
+    return;
+  }
+
+  toggleMainWindow( true );
 }
 #endif
 

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -7,6 +7,7 @@
 #include "utils.hh"
 #include <QCursor>
 #include <QPixmap>
+#include <QDateTime>
 #include <QMenu>
 #include <QMouseEvent>
 #include <QFileDialog>
@@ -581,6 +582,8 @@ void ScanPopup::showEngagePopup()
 
 void ScanPopup::engagePopup( bool forcePopup, bool giveFocus )
 {
+  GlobalBroadcaster::instance()->lastPopupEngageMs.store( QDateTime::currentMSecsSinceEpoch() );
+
   if ( cfg.preferences.scanToMainWindow && !forcePopup ) {
     // Send translated word to main window istead of show popup
     emit sendPhraseToMainWindow( pendingWord );


### PR DESCRIPTION
On macOS, pressing the Cmd+C+C hotkey to trigger the scan popup would also activate the main window, because activateWindow() in engagePopup() triggers applicationStateChanged which causes handleApplicationStateChanged() to restore the main window.

Fix: track the last popup engagement timestamp in GlobalBroadcaster, and skip the main window restore in handleApplicationStateChanged() when the activation came from the scan popup.