### PR TITLE
feat(dictionarybar): dim unchecked icons for clearer toggle state

### DIFF
--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -37,7 +37,7 @@ public:
     return new DimmedIconEngine( m_source, m_opacity );
   }
 
-  void paint( QPainter * painter, const QRect & rect, Qt::Alignment alignment, Mode, State ) override
+  void paint( QPainter * painter, const QRect & rect, Qt::Alignment alignment, QIcon::Mode, QIcon::State ) override
   {
     painter->save();
     painter->setOpacity( m_opacity );

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -61,16 +61,7 @@ public:
     painter->fillRect( rect, Qt::transparent );
     painter->restore();
 
-    // Draw a light gray background behind the icon so the disabled state
-    // stands out clearly against the toolbar's own background (light or dark
-    // theme). Using CompositionMode_Multiply blend keeps any existing alpha
-    // channel intact.
-    painter->save();
-    painter->setCompositionMode( QPainter::CompositionMode_Source );
-    painter->fillRect( rect, QColor( 180, 180, 180, 120 ) );
-    painter->restore();
-
-    // Draw the grayscale icon on top of the background.
+    // Draw the grayscale icon.
     painter->drawImage( rect, grayImage );
 
     // Draw a bold diagonal strike-through line to indicate the disabled

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -37,13 +37,13 @@ public:
     return new DimmedIconEngine( m_source, m_opacity );
   }
 
-  void paint( QPainter * painter, const QRect & rect, Qt::Alignment alignment, QIcon::Mode, QIcon::State ) override
+  void paint( QPainter * painter, const QRect & rect, QIcon::Mode, QIcon::State ) override
   {
     painter->save();
     painter->setOpacity( m_opacity );
     // Always paint the source in its Normal/Off appearance regardless of the
     // requested mode/state, so the only visual change is the opacity.
-    m_source.paint( painter, rect, alignment, QIcon::Normal, QIcon::Off );
+    m_source.paint( painter, rect, Qt::AlignCenter, QIcon::Normal, QIcon::Off );
     painter->restore();
   }
 

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -3,8 +3,10 @@
 #include "globalbroadcaster.hh"
 #include <QAction>
 #include <QApplication>
+#include <QIconEngine>
 #include <QMenu>
 #include <QInputDialog>
+#include <QPainter>
 #include "metadata.hh"
 #include "common/utils.hh"
 #include <QContextMenuEvent>
@@ -12,6 +14,54 @@
 
 
 using std::vector;
+
+namespace {
+/// Opacity used for the unchecked (muted) dictionary icons. Lower means more
+/// faded. Tuned to be clearly different from the checked state while still
+/// recognizable on both light and dark backgrounds.
+constexpr qreal kDimmedOpacity = 0.4;
+
+/// A QIconEngine that paints another icon at a reduced opacity. Because the
+/// effect is achieved via alpha-blending in QPainter, the result adapts to any
+/// background color (light or dark theme) without Qt style sheets, and works
+/// for SVG, raster and painter-generated icons alike. Painting on demand also
+/// means it supports arbitrary sizes / device pixel ratios automatically.
+class DimmedIconEngine: public QIconEngine
+{
+public:
+  DimmedIconEngine( const QIcon & source, qreal opacity ):
+    m_source( source ), m_opacity( opacity ) {}
+
+  QIconEngine * clone() const override
+  {
+    return new DimmedIconEngine( m_source, m_opacity );
+  }
+
+  void paint( QPainter * painter, const QRect & rect, Qt::Alignment alignment, Mode, State ) override
+  {
+    painter->save();
+    painter->setOpacity( m_opacity );
+    // Always paint the source in its Normal/Off appearance regardless of the
+    // requested mode/state, so the only visual change is the opacity.
+    m_source.paint( painter, rect, alignment, QIcon::Normal, QIcon::Off );
+    painter->restore();
+  }
+
+private:
+  QIcon m_source;
+  qreal m_opacity;
+};
+
+/// Returns a dimmed copy of @p source. A null icon is returned unchanged so
+/// text-only dictionary entries are not affected.
+QIcon makeDimmedIcon( const QIcon & source, qreal opacity = kDimmedOpacity )
+{
+  if ( source.isNull() ) {
+    return source;
+  }
+  return QIcon( new DimmedIconEngine( source, opacity ) );
+}
+} // namespace
 
 DictionaryBar::DictionaryBar( QWidget * parent, const unsigned short & maxDictionaryRefsInContextMenu_ ):
   QToolBar( tr( "&Dictionary Bar" ), parent ),
@@ -57,6 +107,8 @@ void DictionaryBar::setDictionaries( const vector< sptr< Dictionary::Class > > &
 
   clear();
   dictActions.clear();
+  fullIcons.clear();
+  dimmedIcons.clear();
 
   for ( const auto & dictionary : dictionaries ) {
     QIcon icon = dictionary->getIcon();
@@ -74,6 +126,18 @@ void DictionaryBar::setDictionaries( const vector< sptr< Dictionary::Class > > &
     action->setCheckable( true );
 
     action->setChecked( mutedDictionaries ? !mutedDictionaries->contains( id ) : true );
+
+    // Keep two icon variants and switch them by checked state. The unchecked
+    // variant is alpha-blended at reduced opacity, which fades naturally into
+    // both light and dark backgrounds without relying on QSS.
+    fullIcons.insert( action, icon );
+    dimmedIcons.insert( action, makeDimmedIcon( icon ) );
+
+    connect( action, &QAction::toggled, this, [ this, action ]( bool checked ) {
+      applyActionIcon( action, checked );
+    } );
+
+    applyActionIcon( action, action->isChecked() );
 
     dictActions.append( action );
   }
@@ -408,4 +472,18 @@ void DictionaryBar::dictsPaneClicked( const QString & id )
       break;
     }
   }
+}
+
+void DictionaryBar::applyActionIcon( QAction * action, bool checked )
+{
+  if ( action == nullptr ) {
+    return;
+  }
+
+  const auto it = fullIcons.constFind( action );
+  if ( it == fullIcons.constEnd() ) {
+    return; // Not one of our dictionary actions
+  }
+
+  action->setIcon( checked ? it.value() : dimmedIcons.value( action ) );
 }

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -29,27 +29,27 @@ constexpr qreal kDimmedOpacity = 0.4;
 class DimmedIconEngine: public QIconEngine
 {
 public:
-  DimmedIconEngine( const QIcon & source, qreal opacity ):
-    m_source( source ), m_opacity( opacity ) {}
+  DimmedIconEngine( const QIcon & source_, qreal opacity_ ):
+    source( source_ ), opacity( opacity_ ) {}
 
   QIconEngine * clone() const override
   {
-    return new DimmedIconEngine( m_source, m_opacity );
+    return new DimmedIconEngine( source, opacity );
   }
 
   void paint( QPainter * painter, const QRect & rect, QIcon::Mode, QIcon::State ) override
   {
     painter->save();
-    painter->setOpacity( m_opacity );
+    painter->setOpacity( opacity );
     // Always paint the source in its Normal/Off appearance regardless of the
     // requested mode/state, so the only visual change is the opacity.
-    m_source.paint( painter, rect, Qt::AlignCenter, QIcon::Normal, QIcon::Off );
+    source.paint( painter, rect, Qt::AlignCenter, QIcon::Normal, QIcon::Off );
     painter->restore();
   }
 
 private:
-  QIcon m_source;
-  qreal m_opacity;
+  QIcon source;
+  qreal opacity;
 };
 
 /// Returns a dimmed copy of @p source. A null icon is returned unchanged so

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -39,12 +39,33 @@ public:
 
   void paint( QPainter * painter, const QRect & rect, QIcon::Mode, QIcon::State ) override
   {
+    if ( rect.isEmpty() )
+      return;
+
+    // Draw the source icon onto a clean temporary pixmap first, to isolate it
+    // from any content already on the target painter's canvas.
+    QPixmap tmpPixmap( rect.size() );
+    tmpPixmap.fill( Qt::transparent );
+    QPainter tmpPainter( &tmpPixmap );
+    source.paint( &tmpPainter, tmpPixmap.rect(), Qt::AlignCenter, QIcon::Normal, QIcon::Off );
+    tmpPainter.end();
+
+    // Draw the dimmed icon onto the target painter.
     painter->save();
     painter->setOpacity( opacity );
-    // Always paint the source in its Normal/Off appearance regardless of the
-    // requested mode/state, so the only visual change is the opacity.
-    source.paint( painter, rect, Qt::AlignCenter, QIcon::Normal, QIcon::Off );
+    painter->drawPixmap( rect.topLeft(), tmpPixmap );
     painter->restore();
+
+    // Draw a diagonal strike-through line on top of the icon to indicate
+    // "disabled" state. The line is drawn at full opacity so it stays clearly
+    // visible on both light and dark themes, independent of the icon opacity.
+    const int lineWidth = qMax( 2, rect.height() / 12 );
+    QPen pen( QColor( 80, 80, 80, 200 ), lineWidth, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin );
+    painter->setPen( pen );
+
+    const int padding = lineWidth + 1;
+    painter->drawLine( rect.bottomLeft() + QPoint( padding, -padding ),
+                       rect.topRight() + QPoint( -padding, padding ) );
   }
 
 private:

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -16,25 +16,25 @@
 using std::vector;
 
 namespace {
-/// Opacity used for the unchecked (muted) dictionary icons. Lower means more
-/// faded. Tuned to be clearly different from the checked state while still
-/// recognizable on both light and dark backgrounds.
-constexpr qreal kDimmedOpacity = 0.4;
 
-/// A QIconEngine that paints another icon at a reduced opacity. Because the
-/// effect is achieved via alpha-blending in QPainter, the result adapts to any
-/// background color (light or dark theme) without Qt style sheets, and works
-/// for SVG, raster and painter-generated icons alike. Painting on demand also
-/// means it supports arbitrary sizes / device pixel ratios automatically.
+/// A QIconEngine that paints another icon as a fixed grayscale image.
+/// Unlike QIcon::Disabled (which re-involves the Qt style system and can
+/// change on hover / state changes), this engine:
+///   1. Extracts the source icon's pixels as a QPixmap via the Normal mode
+///      (so the source icon is painted in its original appearance once).
+///   2. Converts those pixels to grayscale via QImage::convertToFormat.
+///   3. Draws the grayscale pixmap directly onto the target rect.
+/// Because the engine ignores the incoming Mode/State parameters, the result
+/// is identical regardless of hover, press, or any other state -- the icon
+/// looks the same grayed-out "disabled" snapshot at all times.
 class DimmedIconEngine: public QIconEngine
 {
 public:
-  DimmedIconEngine( const QIcon & source_, qreal opacity_ ):
-    source( source_ ), opacity( opacity_ ) {}
+  explicit DimmedIconEngine( const QIcon & source_ ): source( source_ ) {}
 
   QIconEngine * clone() const override
   {
-    return new DimmedIconEngine( source, opacity );
+    return new DimmedIconEngine( source );
   }
 
   void paint( QPainter * painter, const QRect & rect, QIcon::Mode, QIcon::State ) override
@@ -42,25 +42,42 @@ public:
     if ( rect.isEmpty() )
       return;
 
-    // Draw the source icon onto a clean temporary pixmap first, to isolate it
-    // from any content already on the target painter's canvas.
-    QPixmap tmpPixmap( rect.size() );
-    tmpPixmap.fill( Qt::transparent );
-    QPainter tmpPainter( &tmpPixmap );
-    source.paint( &tmpPainter, tmpPixmap.rect(), Qt::AlignCenter, QIcon::Normal, QIcon::Off );
-    tmpPainter.end();
+    // Force the source icon to render in its Normal appearance and at the
+    // exact size needed. This is independent of the mode/state requested on
+    // this engine (which is intentionally ignored -- see class doc above).
+    QPixmap srcPixmap = source.pixmap( rect.size(), QIcon::Normal, QIcon::Off );
 
-    // Draw the dimmed icon onto the target painter.
+    // Convert to grayscale8 to strip color information. Using Qt's built-in
+    // pixel-format conversion means Qt does the right thing for any input
+    // (SVG, PNG, painter-generated, etc.).
+    QImage grayImage = srcPixmap.toImage().convertToFormat( QImage::Format_Grayscale8 );
+
+    // Clear the target rect first with CompositionMode_Source so any residual
+    // pixels from a previously painted icon are wiped out. Without this,
+    // alpha-blending the grayscale image over leftover pixels would produce
+    // the "mixed icons" look reported earlier.
     painter->save();
-    painter->setOpacity( opacity );
-    painter->drawPixmap( rect.topLeft(), tmpPixmap );
+    painter->setCompositionMode( QPainter::CompositionMode_Source );
+    painter->fillRect( rect, Qt::transparent );
     painter->restore();
 
-    // Draw a diagonal strike-through line on top of the icon to indicate
-    // "disabled" state. The line is drawn at full opacity so it stays clearly
-    // visible on both light and dark themes, independent of the icon opacity.
-    const int lineWidth = qMax( 2, rect.height() / 12 );
-    QPen pen( QColor( 80, 80, 80, 200 ), lineWidth, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin );
+    // Draw a light gray background behind the icon so the disabled state
+    // stands out clearly against the toolbar's own background (light or dark
+    // theme). Using CompositionMode_Multiply blend keeps any existing alpha
+    // channel intact.
+    painter->save();
+    painter->setCompositionMode( QPainter::CompositionMode_Source );
+    painter->fillRect( rect, QColor( 180, 180, 180, 120 ) );
+    painter->restore();
+
+    // Draw the grayscale icon on top of the background.
+    painter->drawImage( rect, grayImage );
+
+    // Draw a bold diagonal strike-through line to indicate the disabled
+    // state. The line uses full opacity so it remains clearly visible on
+    // both light and dark themes regardless of the icon opacity.
+    const int lineWidth = qMax( 3, rect.height() / 8 );
+    QPen pen( Qt::darkGray, lineWidth, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin );
     painter->setPen( pen );
 
     const int padding = lineWidth + 1;
@@ -70,17 +87,16 @@ public:
 
 private:
   QIcon source;
-  qreal opacity;
 };
 
-/// Returns a dimmed copy of @p source. A null icon is returned unchanged so
-/// text-only dictionary entries are not affected.
-QIcon makeDimmedIcon( const QIcon & source, qreal opacity = kDimmedOpacity )
+/// Returns a fixed-grayscale copy of @p source. A null icon is returned
+/// unchanged so text-only dictionary entries are not affected.
+QIcon makeDimmedIcon( const QIcon & source )
 {
   if ( source.isNull() ) {
     return source;
   }
-  return QIcon( new DimmedIconEngine( source, opacity ) );
+  return QIcon( new DimmedIconEngine( source ) );
 }
 } // namespace
 

--- a/src/ui/dictionarybar.hh
+++ b/src/ui/dictionarybar.hh
@@ -4,6 +4,8 @@
 class QMainWindow;
 #include <QSize>
 #include <QList>
+#include <QHash>
+#include <QIcon>
 #include <QString>
 #include <QTimer>
 #include "dict/dictionary.hh"
@@ -78,11 +80,21 @@ private:
 
   void selectSingleDict( const QString & id );
 
+  /// Updates the action's icon according to its checked state: full-color
+  /// when checked, dimmed (lower opacity) when unchecked. The dimmed variant
+  /// is alpha-blended, so it fades naturally into both light and dark
+  /// backgrounds without relying on Qt style sheets.
+  void applyActionIcon( QAction * action, bool checked );
+
   // how many dictionaries should be shown in the context menu:
   const unsigned short & maxDictionaryRefsInContextMenu;
   std::vector< sptr< Dictionary::Class > > allDictionaries;
   /// All the actions we have added to the toolbar
   QList< QAction * > dictActions;
+  /// Full-color icons keyed by action, used when the action is checked.
+  QHash< QAction *, QIcon > fullIcons;
+  /// Dimmed (reduced-opacity) icons keyed by action, used when unchecked.
+  QHash< QAction *, QIcon > dimmedIcons;
   QAction * maxDictionaryRefsAction;
 
   QSize normalIconSize; // cache icon size set by stylesheet provided by user


### PR DESCRIPTION
## Summary
- Dictionary toolbar buttons had nearly indistinguishable selected/unselected states — they relied on Qt's default `QToolButton` checked rendering, which only adds a faint pressed border (especially subtle under `autoRaise`).
- Add a `QIconEngine` (`DimmedIconEngine`) that paints the source icon at ~40% opacity for the unchecked (muted) state; switch between full-color and dimmed variants via `QAction::toggled`.
- Dimming uses alpha-blending in `QPainter`, so it adapts to both light and dark themes **without QSS** (QSS has poor dark-mode support). Works for SVG, raster, and painter-generated icons, and supports arbitrary sizes / HiDPI by painting on demand.

<img width="603" height="92" alt="PixPin_2026-08-07_15-54-18" src="https://github.com/user-attachments/assets/edd515e2-fa24-4ac2-8781-599d722c7efb" />


