### PR TITLE
feat(popup): add tab context menu with external browser and tab management

### DIFF
--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -3755,6 +3755,22 @@ from Stardict, Babylon and GLS dictionaries</source>
         <source>Definition</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Close current tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close all tabs except current</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close all tabs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open in &amp;External Browser</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ScanPopupToolBar</name>

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -6,6 +6,7 @@
 #include "articlesaver.hh"
 #include "utils.hh"
 #include <QCursor>
+#include <QDesktopServices>
 #include <QPixmap>
 #include <QDateTime>
 #include <QMenu>
@@ -105,6 +106,32 @@ ScanPopup::ScanPopup( QWidget * parent,
       widget->deleteLater();
     }
   } );
+
+  // Tab bar context menu: offer closing tabs and opening website dictionaries
+  // in an external browser, mirroring the main window's tab context menu behavior.
+  tabWidget->setContextMenuPolicy( Qt::CustomContextMenu );
+  connect( tabWidget, &QWidget::customContextMenuRequested, this, &ScanPopup::tabMenuRequested );
+
+  tabMenu = new QMenu( this );
+
+  closeCurrentTabAction = new QAction( tr( "Close current tab" ), this );
+  tabMenu->addAction( closeCurrentTabAction );
+  connect( closeCurrentTabAction, &QAction::triggered, this, &ScanPopup::closeCurrentTab );
+
+  closeRestTabsAction = new QAction( tr( "Close all tabs except current" ), this );
+  tabMenu->addAction( closeRestTabsAction );
+  connect( closeRestTabsAction, &QAction::triggered, this, &ScanPopup::closeRestTabs );
+
+  closeAllTabsAction = new QAction( tr( "Close all tabs" ), this );
+  tabMenu->addAction( closeAllTabsAction );
+  connect( closeAllTabsAction, &QAction::triggered, this, &ScanPopup::closeAllTabs );
+
+  tabMenu->addSeparator();
+
+  openInExternalBrowserAction = new QAction( QIcon( ":/icons/internet.svg" ), tr( "Open in &External Browser" ), this );
+  openInExternalBrowserAction->setVisible( false );
+  tabMenu->addAction( openInExternalBrowserAction );
+  connect( openInExternalBrowserAction, &QAction::triggered, this, &ScanPopup::openCurrentTabInExternalBrowser );
 
   definition = new ArticleView( tabWidget,
                                 articleNetMgr,
@@ -1424,6 +1451,92 @@ void ScanPopup::openWebsiteInNewTab( QString name, QString url, QString dictId, 
   tabWidget->setCurrentIndex( index );
 
   view->load( url, name );
+}
+
+void ScanPopup::tabMenuRequested( QPoint pos )
+{
+  int tabIndex = tabWidget->tabBar()->tabAt( pos );
+  if ( tabIndex == -1 ) {
+    return;
+  }
+
+  ArticleView * view = qobject_cast< ArticleView * >( tabWidget->widget( tabIndex ) );
+
+  // Open in external browser: only for website dictionary tabs
+  if ( view && view->isWebsite() ) {
+    openInExternalBrowserAction->setVisible( true );
+    openInExternalBrowserAction->setData( tabIndex );
+  }
+  else {
+    openInExternalBrowserAction->setVisible( false );
+  }
+
+  // The Definition tab (index 0) cannot be closed
+  bool isClosableTab = tabIndex > 0;
+
+  closeCurrentTabAction->setEnabled( isClosableTab );
+  closeCurrentTabAction->setData( tabIndex );
+
+  bool hasClosableOthers = false;
+  for ( int i = 1; i < tabWidget->count(); ++i ) {
+    if ( i != tabIndex ) {
+      hasClosableOthers = true;
+      break;
+    }
+  }
+  closeRestTabsAction->setEnabled( isClosableTab && hasClosableOthers );
+  closeRestTabsAction->setData( tabIndex );
+
+  bool hasAnyClosable = tabWidget->count() > 1;
+  closeAllTabsAction->setEnabled( hasAnyClosable );
+
+  tabMenu->popup( tabWidget->mapToGlobal( pos ) );
+}
+
+void ScanPopup::openCurrentTabInExternalBrowser()
+{
+  int tabIndex = openInExternalBrowserAction->data().toInt();
+  ArticleView * view = qobject_cast< ArticleView * >( tabWidget->widget( tabIndex ) );
+  if ( view ) {
+    QDesktopServices::openUrl( view->page()->url() );
+  }
+}
+
+void ScanPopup::closeCurrentTab()
+{
+  int tabIndex = closeCurrentTabAction->data().toInt();
+  if ( tabIndex <= 0 ) {
+    return;
+  }
+
+  auto widget = tabWidget->widget( tabIndex );
+  tabWidget->removeTab( tabIndex );
+  widget->deleteLater();
+}
+
+void ScanPopup::closeRestTabs()
+{
+  int tabIndex = closeRestTabsAction->data().toInt();
+  if ( tabIndex <= 0 ) {
+    return;
+  }
+
+  for ( int i = tabWidget->count() - 1; i >= 1; --i ) {
+    if ( i != tabIndex ) {
+      auto widget = tabWidget->widget( i );
+      tabWidget->removeTab( i );
+      widget->deleteLater();
+    }
+  }
+}
+
+void ScanPopup::closeAllTabs()
+{
+  for ( int i = tabWidget->count() - 1; i >= 1; --i ) {
+    auto widget = tabWidget->widget( i );
+    tabWidget->removeTab( i );
+    widget->deleteLater();
+  }
 }
 
 bool ScanPopup::isWordPresentedInFavorites( const QString & word ) const

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -1532,11 +1532,18 @@ void ScanPopup::closeRestTabs()
 
 void ScanPopup::closeAllTabs()
 {
+  // Close all tabs except the Definition tab, then clear its content.
+  // The Definition tab must remain because the `definition` pointer is used
+  // throughout ScanPopup (translateWord, showDefinition, etc.).
   for ( int i = tabWidget->count() - 1; i >= 1; --i ) {
     auto widget = tabWidget->widget( i );
     tabWidget->removeTab( i );
     widget->deleteLater();
   }
+
+  // Reset the Definition tab to a clean state
+  definition->clearContent();
+  tabWidget->setTabText( 0, tr( "Definition" ) );
 }
 
 bool ScanPopup::isWordPresentedInFavorites( const QString & word ) const

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -1460,7 +1460,7 @@ void ScanPopup::tabMenuRequested( QPoint pos )
     return;
   }
 
-  ArticleView * view = qobject_cast< ArticleView * >( tabWidget->widget( tabIndex ) );
+  const ArticleView * view = qobject_cast< ArticleView * >( tabWidget->widget( tabIndex ) );
 
   // Open in external browser: only for website dictionary tabs
   if ( view && view->isWebsite() ) {

--- a/src/ui/scanpopup.hh
+++ b/src/ui/scanpopup.hh
@@ -21,6 +21,7 @@
   #include "scanflag.hh"
 #endif
 
+class QMenu;
 
 /// This is a popup dialog to show translations when clipboard scanning mode
 /// is enabled.
@@ -141,6 +142,11 @@ private:
   QActionGroup * actionGroup = nullptr;
   MainStatusBar * mainStatusBar;
   MainTabWidget * tabWidget;
+  QMenu * tabMenu;
+  QAction * openInExternalBrowserAction;
+  QAction * closeCurrentTabAction;
+  QAction * closeRestTabsAction;
+  QAction * closeAllTabsAction;
   ArticleNetworkAccessManager & articleNetMgr;
   /// Fonts saved before words zooming is in effect, so it could be reset back.
   QFont wordListDefaultFont, translateLineDefaultFont, groupListDefaultFont;
@@ -239,4 +245,11 @@ private slots:
   void activeArticleChanged( const ArticleView *, const QString & id );
   void updateFoundInDictsList();
   void onActionTriggered();
+
+  void tabMenuRequested( QPoint pos );
+  void openCurrentTabInExternalBrowser();
+
+  void closeCurrentTab();
+  void closeRestTabs();
+  void closeAllTabs();
 };


### PR DESCRIPTION
Add right-click context menu to popup tab bar, mirroring the main window behavior:

- Open in External Browser for website dictionary tabs
- Close current tab / Close all tabs except current / Close all tabs
- Definition tab (index 0) is non-closable
- Closing does not distinguish website type; uses index-based logic