### PR TITLE
[codex] macOS: improve status bar/tray mode, window geometry and permissions

### DIFF
--- a/cmake/Deps_macOS.cmake
+++ b/cmake/Deps_macOS.cmake
@@ -4,6 +4,10 @@ target_include_directories(${GOLDENDICT} PRIVATE /usr/local/include /opt/homebre
 find_library(CARBON_LIBRARY Carbon REQUIRED) # for accessibility API
 target_link_libraries(${GOLDENDICT} PRIVATE ${CARBON_LIBRARY})
 
+# ServiceManagement for macOS login-item (auto-start) support
+find_library(SERVICEMANAGEMENT_LIBRARY ServiceManagement REQUIRED)
+target_link_libraries(${GOLDENDICT} PRIVATE ${SERVICEMANAGEMENT_LIBRARY})
+
 find_package(PkgConfig REQUIRED)
 
 set(Optional_Pkgs "")

--- a/icons/trayicon.svg
+++ b/icons/trayicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24"
+     fill="none" stroke="#000000" stroke-width="2"
+     stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 5v16"/>
+  <path d="m16 12 2 2 4-4"/>
+  <path d="M22 6V5a2 2 0 0 0-1.999-2L16 3.002A5 5 0 0 0 12 5a5 5 0 0 0-4-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 1.999 2H8a5 5 0 0 1 4 2 5 5 0 0 1 4-2h4.001A2 2 0 0 0 22 17v-1.344"/>
+</svg>

--- a/resources.qrc
+++ b/resources.qrc
@@ -54,6 +54,7 @@
         <file>icons/folders.svg</file>
         <file>icons/hotkeys.svg</file>
         <file>icons/icon.svg</file>
+        <file>icons/trayicon.svg</file>
         <file>icons/icon32_zoombase.png</file>
         <file>icons/icon32_zoomin.png</file>
         <file>icons/icon32_zoomout.png</file>

--- a/src/config.cc
+++ b/src/config.cc
@@ -800,6 +800,12 @@ Class load()
     c.preferences.alwaysOnTop  = ( preferences.namedItem( "alwaysOnTop" ).toElement().text() == "1" );
     c.preferences.searchInDock = ( preferences.namedItem( "searchInDock" ).toElement().text() == "1" );
 
+    // "Start to tray" and "Close to tray" only make sense with a tray/status
+    // icon, so keep the two coupled for older configurations.
+    if ( c.preferences.startToTray || c.preferences.closeToTray ) {
+      c.preferences.enableTrayIcon = true;
+    }
+
     if ( !preferences.namedItem( "customFonts" ).isNull() ) {
       CustomFonts fonts         = CustomFonts::fromElement( preferences.namedItem( "customFonts" ).toElement() );
       c.preferences.customFonts = fonts;

--- a/src/hotkey/machotkeywrapper.mm
+++ b/src/hotkey/machotkeywrapper.mm
@@ -2,9 +2,7 @@
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
 #include "hotkeywrapper.hh"
-#include <QMessageBox>
 #include <QObject>
-#include <QPushButton>
 #include <QTimer>
 
 #include <memory>
@@ -161,17 +159,16 @@ void checkAndRequestAccessibilityPermission()
         return;
     }
 
-    auto msgBox = std::make_unique<QMessageBox>(nullptr);
-    auto* turnOnPermission = new QPushButton(QObject::tr("Turn on Accessibility"), msgBox.get());
+    // Use the system-native prompt: this registers GoldenDict-ng in the
+    // Accessibility list (and opens System Settings when the user agrees).
+    // The old approach of only opening the settings pane did not create
+    // the permission entry for the app.
+    [NSApp activateIgnoringOtherApps:YES];
 
-    msgBox->setInformativeText(QObject::tr("Global shortcut using ⌘+C needs Accessibility permission. Please grant it to Goldendict or change ⌘+C to something else."));
-
-    msgBox->addButton(QMessageBox::Ok);
-    msgBox->addButton(turnOnPermission, QMessageBox::AcceptRole); // the role is unused.
-    msgBox->setDefaultButton(turnOnPermission);
-    msgBox->exec();
-
-    if (msgBox->clickedButton() == turnOnPermission) {
+    NSDictionary *options = @{ (__bridge id)kAXTrustedCheckOptionPrompt : @YES };
+    if (!AXIsProcessTrustedWithOptions((__bridge CFDictionaryRef)options)) {
+        // Fallback for the case where the system prompt was already answered
+        // or cannot be shown again.
         [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"]];
     }
 }

--- a/src/macos/mactray.hh
+++ b/src/macos/mactray.hh
@@ -1,0 +1,19 @@
+#pragma once
+
+#ifdef __APPLE__
+
+/// macOS helper for menu-bar (status item) resident mode.
+class MacTray
+{
+public:
+  /// Hides the app from the Dock and Cmd+Tab when running as a tray app.
+  static void setDockIconVisible( bool visible );
+
+  /// Brings the accessory app to the foreground when the status item is clicked.
+  static void activateApplication();
+
+  /// Registers/unregisters the app as a macOS login item.
+  static bool setAutoStartEnabled( bool enabled );
+};
+
+#endif

--- a/src/macos/mactray.mm
+++ b/src/macos/mactray.mm
@@ -1,0 +1,37 @@
+#include "mactray.hh"
+
+#import <AppKit/AppKit.h>
+#import <ServiceManagement/SMAppService.h>
+
+void MacTray::setDockIconVisible( bool visible )
+{
+    NSApplicationActivationPolicy policy =
+        visible ? NSApplicationActivationPolicyRegular : NSApplicationActivationPolicyAccessory;
+    [NSApp setActivationPolicy:policy];
+}
+
+void MacTray::activateApplication()
+{
+    [NSApp activateIgnoringOtherApps:YES];
+}
+
+bool MacTray::setAutoStartEnabled( bool enabled )
+{
+    if ( @available(macOS 13.0, *) ) {
+        NSError *error = nil;
+        BOOL result;
+        if ( enabled ) {
+            result = [SMAppService.mainAppService registerAndReturnError:&error];
+        }
+        else {
+            result = [SMAppService.mainAppService unregisterAndReturnError:&error];
+        }
+        if ( !result && error ) {
+            NSLog( @"GoldenDict-ng: failed to %@ login item: %@",
+                   enabled ? @"register" : @"unregister", error );
+            return false;
+        }
+        return true;
+    }
+    return false;
+}

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -26,6 +26,10 @@
 #include <QList>
 #include <QToolBar>
 #include <QCloseEvent>
+#include <QMoveEvent>
+#include <QResizeEvent>
+#include <QShowEvent>
+#include <QHideEvent>
 #include <QDesktopServices>
 #include <QCryptographicHash>
 #include <QFileDialog>
@@ -59,6 +63,7 @@
 
 #ifdef Q_OS_MAC
   #include "macos/macmouseover.hh"
+  #include "macos/mactray.hh"
 #endif
 
 #if defined( Q_OS_WIN )
@@ -156,6 +161,7 @@ void MainWindow::changeWebEngineViewFont() const
 
 MainWindow::MainWindow( Config::Class & cfg_ ):
   trayIcon( nullptr ),
+  geometrySaveTimer( this ),
   foundInDictsLabel( &dictsPaneTitleBar ),
   escAction( this ),
   focusTranslateLineAction( this ),
@@ -868,15 +874,33 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   if ( cfg.mainWindowState.size() && !cfg.resetState ) {
     restoreState( cfg.mainWindowState );
   }
-  if ( cfg.mainWindowGeometry.size() ) {
+  if ( cfg.mainWindowGeometry.size() && !cfg.resetState ) {
     restoreGeometry( cfg.mainWindowGeometry );
   }
 
-  // Show window unless it is configured not to
-  if ( !cfg.preferences.enableTrayIcon || !cfg.preferences.startToTray ) {
+  geometrySaveTimer.setSingleShot( true );
+  geometrySaveTimer.setInterval( 500 );
+  connect( &geometrySaveTimer, &QTimer::timeout, this, [ this ]() {
+    saveMainWindowGeometry();
+  } );
+
+#ifdef Q_OS_MACOS
+  connect( qApp, &QGuiApplication::applicationStateChanged, this, [ this ]( Qt::ApplicationState ) {
+    updateMacDockAndMenu();
+  } );
+#endif
+
+  // Show window unless it is configured to start in the tray/status bar.
+  // "Start to tray" is honored even if the tray icon is disabled, so the
+  // main window stays out of the way after login.
+  if ( !cfg.preferences.startToTray ) {
     show();
     focusTranslateLine();
   }
+
+#ifdef Q_OS_MACOS
+  updateMacDockAndMenu();
+#endif
 
   // Scanpopup related
   // Deferred initialization until first use or if scanning is enabled
@@ -1607,6 +1631,7 @@ void MainWindow::trayIconUpdateOrInit()
 // Set dock menu for macOS
 #ifdef Q_OS_MACOS
   dockMenu.setAsDockMenu(); // Use separate dockMenu for Dock, not trayIconMenu
+  updateMacDockAndMenu();
 #endif
 
   if ( !cfg.preferences.enableTrayIcon ) {
@@ -1618,11 +1643,15 @@ void MainWindow::trayIconUpdateOrInit()
   }
   else {
     // Update the icon to reflect the scanning mode
-    QIcon icon = QIcon::fromTheme( "goldendict-tray", QIcon( ":/icons/programicon.png" ) );
+    QIcon icon;
 
 #ifdef Q_OS_MACOS
-    // On macOS, use the icon directly without mask for proper color display
-    // setIsMask(true) would convert it to black silhouette which is not desired
+    // A template (mask) icon lets macOS draw it in the right color for the
+    // current menu bar appearance, just like the built-in clock/weather icons.
+    icon = QIcon( ":/icons/trayicon.svg" );
+    icon.setIsMask( true );
+#else
+    icon = QIcon::fromTheme( "goldendict-tray", QIcon( ":/icons/programicon.png" ) );
 #endif
 
     if ( !trayIcon ) {
@@ -1660,6 +1689,74 @@ void MainWindow::wheelEvent( QWheelEvent * ev )
   }
 }
 
+void MainWindow::resizeEvent( QResizeEvent * ev )
+{
+  QMainWindow::resizeEvent( ev );
+  scheduleGeometrySave();
+}
+
+void MainWindow::moveEvent( QMoveEvent * ev )
+{
+  QMainWindow::moveEvent( ev );
+  scheduleGeometrySave();
+}
+
+void MainWindow::showEvent( QShowEvent * ev )
+{
+  QMainWindow::showEvent( ev );
+#ifdef Q_OS_MACOS
+  updateMacDockAndMenu();
+#endif
+}
+
+void MainWindow::hideEvent( QHideEvent * ev )
+{
+  QMainWindow::hideEvent( ev );
+#ifdef Q_OS_MACOS
+  updateMacDockAndMenu();
+#endif
+}
+
+#ifdef Q_OS_MACOS
+void MainWindow::updateMacDockAndMenu()
+{
+  // Changing the activation policy while the scan popup is on screen makes
+  // macOS hide the popup immediately. Leave the current policy untouched
+  // until the popup is gone.
+  if ( scanPopup && scanPopup->isVisible() ) {
+    return;
+  }
+
+  // macOS has no supported way to keep the top-left app menu while
+  // excluding the app from the Dock and Cmd+Tab at the same time.
+  // Keep the normal Dock/menu while the app is actually in the foreground;
+  // as soon as it is hidden to the tray or loses focus, drop it from the
+  // Dock and Cmd+Tab so it only lives in the status item.
+  const bool keepDock = !cfg.preferences.enableTrayIcon
+                        || ( isVisible() && QApplication::applicationState() == Qt::ApplicationActive );
+  MacTray::setDockIconVisible( keepDock );
+}
+#endif
+
+void MainWindow::scheduleGeometrySave()
+{
+  if ( !isVisible() || isMinimized() ) {
+    return;
+  }
+  geometrySaveTimer.start();
+}
+
+void MainWindow::saveMainWindowGeometry()
+{
+  if ( cfg.resetState ) {
+    return;
+  }
+  cfg.mainWindowState    = saveState();
+  cfg.mainWindowGeometry = saveGeometry();
+  cfg.dirty              = true;
+  Config::save( cfg );
+}
+
 void MainWindow::closeEvent( QCloseEvent * ev )
 {
   if ( isQuitting ) {
@@ -1667,8 +1764,8 @@ void MainWindow::closeEvent( QCloseEvent * ev )
     return;
   }
 
-  // If tray icon is disabled or closing to tray is not enabled, quit the application
-  if ( !cfg.preferences.enableTrayIcon || !cfg.preferences.closeToTray ) {
+  // If closing to tray is not enabled, quit the application
+  if ( !cfg.preferences.closeToTray ) {
     ev->accept();
     quitApp();
     return;
@@ -1695,6 +1792,7 @@ void MainWindow::closeEvent( QCloseEvent * ev )
 #else
   // On Windows and macOS (manual close), ignore the event and hide the window.
   // This ensures global hotkey hooks remain valid on Windows.
+  saveMainWindowGeometry();
   if ( trayIcon ) {
     trayIcon->showMessage(
       QApplication::applicationName(),
@@ -3380,6 +3478,7 @@ void MainWindow::trayIconActivated( QSystemTrayIcon::ActivationReason r )
       // macOS specific focus handling
 #ifdef Q_OS_MACOS
       // Ensure the window gets focus, especially when there are fullscreen apps
+      MacTray::activateApplication();
       if ( isVisible() ) {
         this->raise();
         this->activateWindow();
@@ -3584,6 +3683,10 @@ void MainWindow::setAutostart( bool autostart )
     reg.remove( ApplicationSettingName );
   }
   reg.sync();
+#elif defined( Q_OS_MACOS )
+  if ( !MacTray::setAutoStartEnabled( autostart ) ) {
+    qWarning() << "Failed to update macOS login item";
+  }
 #elif defined( Q_OS_UNIX ) && !defined( Q_OS_MACOS )
   const QString destinationPath = QDir::homePath() + "/.config/autostart/goldendict-owned-by-preferences.desktop";
   if ( autostart == QFile::exists( destinationPath ) )
@@ -3600,7 +3703,8 @@ void MainWindow::setAutostart( bool autostart )
 
 void MainWindow::on_actionCloseToTray_triggered()
 {
-  if ( cfg.preferences.enableTrayIcon && isVisible() ) {
+  if ( cfg.preferences.closeToTray && isVisible() ) {
+    saveMainWindowGeometry();
     hide();
   }
 }
@@ -3860,6 +3964,11 @@ bool MainWindow::handleStructuredMessage( const QString & message )
 void MainWindow::messageFromAnotherInstanceReceived( const QString & message )
 {
   if ( message == "bringToFront" ) {
+    // When "start to tray" is enabled, launching the app again should not
+    // force the hidden main window open.
+    if ( cfg.preferences.startToTray && !isVisible() ) {
+      return;
+    }
     toggleMainWindow( true );
     return;
   }

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -217,7 +217,19 @@ private:
   void trayIconUpdateOrInit();
 
   void wheelEvent( QWheelEvent * );
+  void resizeEvent( QResizeEvent * ) override;
+  void moveEvent( QMoveEvent * ) override;
+  void showEvent( QShowEvent * ) override;
+  void hideEvent( QHideEvent * ) override;
   void closeEvent( QCloseEvent * );
+  void scheduleGeometrySave();
+  void saveMainWindowGeometry();
+#ifdef Q_OS_MACOS
+  /// macOS keeps the app in the Dock/menu bar while the main window is
+  /// visible (so the app menu stays usable) and hides it when window is
+  /// hidden to the tray/status item.
+  void updateMacDockAndMenu();
+#endif
 
   void applyProxySettings();
   void makeDictionaries();

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -618,6 +618,28 @@ void Preferences::on_enableClipboardHotkey_toggled( bool checked )
   ui.clipboardHotkey->setEnabled( checked );
 }
 
+void Preferences::on_enableTrayIcon_toggled( bool checked )
+{
+  if ( !checked ) {
+    ui.startToTray->setChecked( false );
+    ui.closeToTray->setChecked( false );
+  }
+}
+
+void Preferences::on_startToTray_toggled( bool checked )
+{
+  if ( checked ) {
+    ui.enableTrayIcon->setChecked( true );
+  }
+}
+
+void Preferences::on_closeToTray_toggled( bool checked )
+{
+  if ( checked ) {
+    ui.enableTrayIcon->setChecked( true );
+  }
+}
+
 void Preferences::on_buttonBox_accepted()
 {
   QString promptText;

--- a/src/ui/preferences.hh
+++ b/src/ui/preferences.hh
@@ -44,6 +44,10 @@ private slots:
   void on_enableMainWindowHotkey_toggled( bool checked );
   void on_enableClipboardHotkey_toggled( bool checked );
 
+  void on_enableTrayIcon_toggled( bool checked );
+  void on_startToTray_toggled( bool checked );
+  void on_closeToTray_toggled( bool checked );
+
   void on_buttonBox_accepted();
 
   void on_useExternalPlayer_toggled( bool enabled );


### PR DESCRIPTION
## Summary

Improves the macOS status-bar/tray experience of GoldenDict-ng:

- Uses a menu-bar status icon with a template image, so it adapts automatically to light/dark menu bars.
- Keeps the app out of the Dock and Cmd+Tab while hidden to the tray.
- Makes "start to tray" and "close to tray" settings behave consistently, including migrating older configurations.
- Persists and restores main-window size/position, including when the window starts hidden.
- Fixes the lookup popup being dismissed when the app switches between tray and normal modes.
- Uses the system-native Accessibility permission prompt for the Cmd+C+C shortcut.
- Registers macOS login-item auto-start via SMAppService.

## Validation

- Built successfully with the local macOS toolchain.
- Tested tray icon, hidden start, geometry restore, lookup popup, and auto-start registration on macOS 26.
