### PR TITLE
Add macOS support for the icon hiding from dock

### DIFF
--- a/cmake/Deps_macOS.cmake
+++ b/cmake/Deps_macOS.cmake
@@ -2,7 +2,8 @@ set(ENV{PATH} "$ENV{PATH}:/usr/local/bin/:/opt/homebrew/bin") # add brew command
 target_include_directories(${GOLDENDICT} PRIVATE /usr/local/include /opt/homebrew/include)
 
 find_library(CARBON_LIBRARY Carbon REQUIRED) # for accessibility API
-target_link_libraries(${GOLDENDICT} PRIVATE ${CARBON_LIBRARY})
+find_library(APPKIT_LIBRARY AppKit REQUIRED) # for Dock and application activation policy
+target_link_libraries(${GOLDENDICT} PRIVATE ${CARBON_LIBRARY} ${APPKIT_LIBRARY})
 
 find_package(PkgConfig REQUIRED)
 
@@ -27,9 +28,13 @@ if (WITH_ZIM)
     set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:${ICU_REQUIRED_BY_ZIM_PREFIX}/lib/pkgconfig")
     message(STATUS "Updated pkg_config_path -> $ENV{PKG_CONFIG_PATH}")
 
-    # icu4c as transitive dependency of libzim may not be automatically copied into app bundle
-    # so we manually discover the icu4c from homebrew, then find the relevent dylibs
-    set(BREW_ICU_ADDITIONAL_DYLIBS "${ICU_REQUIRED_BY_ZIM_PREFIX}/lib/libicudata.dylib ${ICU_REQUIRED_BY_ZIM_PREFIX}/lib/libicui18n.dylib ${ICU_REQUIRED_BY_ZIM_PREFIX}/lib/libicuuc.dylib")
+    # icu4c as a transitive dependency of libzim may not be automatically copied
+    # into the app bundle. Keep these as a CMake list; Package_macOS.cmake copies
+    # them into the bundle before allowing macdeployqt to rewrite install names.
+    set(BREW_ICU_ADDITIONAL_DYLIBS
+            "${ICU_REQUIRED_BY_ZIM_PREFIX}/lib/libicudata.dylib"
+            "${ICU_REQUIRED_BY_ZIM_PREFIX}/lib/libicui18n.dylib"
+            "${ICU_REQUIRED_BY_ZIM_PREFIX}/lib/libicuuc.dylib")
     message(STATUS "Additional ICU `.dylib`s -> ${BREW_ICU_ADDITIONAL_DYLIBS}")
 endif ()
 
@@ -55,4 +60,3 @@ if (WITH_EPWING_SUPPORT)
     find_library(EB_LIBRARY eb REQUIRED)
     target_link_libraries(${GOLDENDICT} PRIVATE ${EB_LIBRARY})
 endif ()
-

--- a/cmake/Package_macOS.cmake
+++ b/cmake/Package_macOS.cmake
@@ -13,17 +13,53 @@ set(Redistributable_APP "${Assembling_Dir}/${App_Name}")
 # if anything wrong, delete this and affect lines, and see what's Qt will generate by default.
 set(QtConfPath "${Redistributable_APP}/Contents/Resources/qt.conf")
 
+# Copy Homebrew's ICU libraries into the bundle before macdeployqt scans it.
+# Passing them as ADDITIONAL_LIBRARIES would make macdeployqt treat them as
+# extra executables and repeatedly rewrite them instead of simply deploying the
+# application's dependency graph.
+set(MACOS_DEPLOY_ICU_SETUP "")
+if (BREW_ICU_ADDITIONAL_DYLIBS)
+    string(REPLACE ";" "\" \"" BREW_ICU_COPY_ARGUMENTS "${BREW_ICU_ADDITIONAL_DYLIBS}")
+    set(BREW_ICU_COPY_ARGUMENTS "\"${BREW_ICU_COPY_ARGUMENTS}\"")
+    set(MACOS_DEPLOY_ICU_SETUP
+            "file(MAKE_DIRECTORY \"${Redistributable_APP}/Contents/Frameworks\")
+             file(COPY ${BREW_ICU_COPY_ARGUMENTS}
+                  DESTINATION \"${Redistributable_APP}/Contents/Frameworks\"
+                  FOLLOW_SYMLINK_CHAIN)")
+endif ()
+
 qt_generate_deploy_script(
         TARGET ${GOLDENDICT}
         OUTPUT_SCRIPT deploy_script
         CONTENT "
         set(QT_DEPLOY_PREFIX \"${Redistributable_APP}\")
         set(QT_DEPLOY_TRANSLATIONS_DIR \"Contents/Resources/translations\")
+        ${MACOS_DEPLOY_ICU_SETUP}
         qt_deploy_runtime_dependencies(
                     EXECUTABLE \"${Redistributable_APP}\"
-                    ADDITIONAL_LIBRARIES ${BREW_ICU_ADDITIONAL_DYLIBS}
+                    DEPLOY_TOOL_OPTIONS
+                        \"-no-codesign\"
                     GENERATE_QT_CONF
                     NO_APP_STORE_COMPLIANCE)
+        # Homebrew's aggregate Qt package exposes an optional virtual-keyboard
+        # input plugin without its split framework on macdeployqt's default
+        # search path. GoldenDict does not use this QML-only input method.
+        file(REMOVE
+             \"${Redistributable_APP}/Contents/PlugIns/platforminputcontexts/libqtvirtualkeyboardplugin.dylib\")
+        # macdeployqt rewrites deployed framework references to
+        # @executable_path/../Frameworks. That path is correct for the main
+        # executable, but QtWebEngineProcess is nested several bundles deep.
+        # Give the helper the same Frameworks view so dyld can start Chromium.
+        if (NOT EXISTS
+            \"${Redistributable_APP}/Contents/Frameworks/QtWebEngineCore.framework/Versions/A/Helpers/QtWebEngineProcess.app/Contents/Frameworks\"
+            AND NOT IS_SYMLINK
+            \"${Redistributable_APP}/Contents/Frameworks/QtWebEngineCore.framework/Versions/A/Helpers/QtWebEngineProcess.app/Contents/Frameworks\")
+            file(CREATE_LINK
+                 \"../../../../../..\"
+                 \"${Redistributable_APP}/Contents/Frameworks/QtWebEngineCore.framework/Versions/A/Helpers/QtWebEngineProcess.app/Contents/Frameworks\"
+                 SYMBOLIC)
+        endif()
+
         qt_deploy_translations()
         qt_deploy_qt_conf(\"${QtConfPath}\"
                      PLUGINS_DIR PlugIns
@@ -49,13 +85,42 @@ install(DIRECTORY "${OPENCC_DATA_PATH_FOR_REAL}" DESTINATION "${Redistributable_
 
 install(SCRIPT ${deploy_script})
 
-install(CODE "execute_process(COMMAND codesign --force --deep -s - ${Redistributable_APP})")
+set(QT_WEBENGINE_CORE_FRAMEWORK
+        "${Redistributable_APP}/Contents/Frameworks/QtWebEngineCore.framework")
+set(QT_WEBENGINE_HELPER_APP
+        "${QT_WEBENGINE_CORE_FRAMEWORK}/Versions/A/Helpers/QtWebEngineProcess.app")
+set(QT_WEBENGINE_HELPER_ENTITLEMENTS
+        "${QT_WEBENGINE_HELPER_APP}/Contents/Resources/QtWebEngineProcess.entitlements")
+
+install(CODE "
+    # First sign every nested component, then restore the WebEngine helper's
+    # required JIT entitlements. Re-sign its containing framework and the main
+    # app from the inside out so all resource seals remain valid.
+    execute_process(
+        COMMAND codesign --force --deep --sign - \"${Redistributable_APP}\"
+        COMMAND_ERROR_IS_FATAL ANY)
+    execute_process(
+        COMMAND codesign --force --sign -
+                --entitlements \"${QT_WEBENGINE_HELPER_ENTITLEMENTS}\"
+                \"${QT_WEBENGINE_HELPER_APP}\"
+        COMMAND_ERROR_IS_FATAL ANY)
+    execute_process(
+        COMMAND codesign --force --sign - \"${QT_WEBENGINE_CORE_FRAMEWORK}\"
+        COMMAND_ERROR_IS_FATAL ANY)
+    execute_process(
+        COMMAND codesign --force --sign - \"${Redistributable_APP}\"
+        COMMAND_ERROR_IS_FATAL ANY)
+    execute_process(
+        COMMAND codesign --verify --deep --strict \"${Redistributable_APP}\"
+        COMMAND_ERROR_IS_FATAL ANY)
+")
 
 find_program(CREATE-DMG "create-dmg")
 if (CREATE-DMG)
     install(CODE "
     execute_process(COMMAND ${CREATE-DMG} \
         --skip-jenkins \
+        --overwrite \
         --format \"ULMO\"
         --volname ${CMAKE_PROJECT_NAME}-${CMAKE_PROJECT_VERSION}-${CMAKE_SYSTEM_PROCESSOR} \
         --volicon ${CMAKE_SOURCE_DIR}/icons/macicon.icns \

--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -3500,6 +3500,14 @@ from Stardict, Babylon and GLS dictionaries</source>
         <source>Customize Fonts</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The Dock icon is always shown while the main window is open so that macOS can display the application name and menus. Enable this option to keep the Dock icon visible after the main window is hidden.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Keep Dock icon visible in background</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ProgramTypeEditor</name>

--- a/redist/mac_info_plist_template_cmake.plist
+++ b/redist/mac_info_plist_template_cmake.plist
@@ -14,6 +14,8 @@
 	<string>org.xiaoyifang</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
 
 	<key>CFBundleURLTypes</key>
     <array>

--- a/src/config.cc
+++ b/src/config.cc
@@ -796,6 +796,9 @@ Class load()
     }
     c.preferences.startToTray    = ( preferences.namedItem( "startToTray" ).toElement().text() == "1" );
     c.preferences.closeToTray    = ( preferences.namedItem( "closeToTray" ).toElement().text() == "1" );
+    if ( !preferences.namedItem( "showDockIcon" ).isNull() ) {
+      c.preferences.showDockIcon = ( preferences.namedItem( "showDockIcon" ).toElement().text() == "1" );
+    }
     c.preferences.autoStart    = ( preferences.namedItem( "autoStart" ).toElement().text() == "1" );
     c.preferences.alwaysOnTop  = ( preferences.namedItem( "alwaysOnTop" ).toElement().text() == "1" );
     c.preferences.searchInDock = ( preferences.namedItem( "searchInDock" ).toElement().text() == "1" );
@@ -1743,6 +1746,10 @@ void save( const Class & c )
 
     opt = dd.createElement( "closeToTray" );
     opt.appendChild( dd.createTextNode( c.preferences.closeToTray ? "1" : "0" ) );
+    preferences.appendChild( opt );
+
+    opt = dd.createElement( "showDockIcon" );
+    opt.appendChild( dd.createTextNode( c.preferences.showDockIcon ? "1" : "0" ) );
     preferences.appendChild( opt );
 
     opt = dd.createElement( "autoStart" );

--- a/src/config.hh
+++ b/src/config.hh
@@ -283,6 +283,7 @@ struct Preferences
   bool enableTrayIcon = true;
   bool closeToTray    = true;
   bool startToTray    = false;
+  bool showDockIcon   = false;
 
   bool autoStart;
   bool doubleClickTranslates;

--- a/src/macos/mac_app_activation.hh
+++ b/src/macos/mac_app_activation.hh
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace MacAppActivation {
+
+/// Switch between a regular macOS application (Dock icon and application
+/// menu) and a menu-bar accessory application.
+void setDockIconVisible( bool visible );
+
+/// Bring the application and its main menu to the foreground after switching
+/// from accessory mode.
+void activate();
+
+} // namespace MacAppActivation

--- a/src/macos/mac_app_activation.mm
+++ b/src/macos/mac_app_activation.mm
@@ -1,0 +1,31 @@
+#include "mac_app_activation.hh"
+
+#import <AppKit/NSApplication.h>
+
+namespace MacAppActivation {
+
+void setDockIconVisible( bool visible )
+{
+  const NSApplicationActivationPolicy policy =
+    visible ? NSApplicationActivationPolicyRegular : NSApplicationActivationPolicyAccessory;
+
+  if ( NSApp.activationPolicy != policy ) {
+    [ NSApp setActivationPolicy:policy ];
+  }
+}
+
+void activate()
+{
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 140000
+  if ( @available( macOS 14.0, * ) ) {
+    [ NSApp activate ];
+  }
+  else {
+    [ NSApp activateIgnoringOtherApps:YES ];
+  }
+#else
+  [ NSApp activateIgnoringOtherApps:YES ];
+#endif
+}
+
+} // namespace MacAppActivation

--- a/src/main.cc
+++ b/src/main.cc
@@ -423,6 +423,14 @@ int main( int argc, char ** argv )
     break;
   }
 
+#ifdef Q_OS_MACOS
+  // The application starts in regular mode so Qt can initialize the native
+  // macOS application menu. It switches to menu-bar-only mode at runtime after
+  // the main window is hidden unless the user keeps the Dock icon visible.
+  cfg.preferences.enableTrayIcon = true;
+  cfg.preferences.closeToTray    = true;
+#endif
+
   if ( gdcl.notts ) {
     cfg.notts = true;
 #ifdef TTS_SUPPORT

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -58,6 +58,7 @@
 #include "globalregex.hh"
 
 #ifdef Q_OS_MAC
+  #include "macos/mac_app_activation.hh"
   #include "macos/macmouseover.hh"
 #endif
 
@@ -880,7 +881,19 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   if ( !cfg.preferences.enableTrayIcon || !cfg.preferences.startToTray ) {
     show();
     focusTranslateLine();
+#ifdef Q_OS_MACOS
+    // Run activation after Qt has finished creating the native window and its
+    // menu bar. This also makes a launch from Terminal become the active app.
+    QTimer::singleShot( 0, this, []() { MacAppActivation::activate(); } );
+#endif
   }
+#ifdef Q_OS_MACOS
+  else {
+    // A start-to-tray launch has no visible main window. Enter accessory mode
+    // unless the user explicitly asked to keep the Dock icon visible.
+    MacAppActivation::setDockIconVisible( cfg.preferences.showDockIcon );
+  }
+#endif
 
   // Scanpopup related
   // Deferred initialization until first use or if scanning is enabled
@@ -1711,6 +1724,16 @@ void MainWindow::closeEvent( QCloseEvent * ev )
 #endif
 }
 
+void MainWindow::hideEvent( QHideEvent * event )
+{
+  QMainWindow::hideEvent( event );
+#ifdef Q_OS_MACOS
+  if ( !cfg.preferences.showDockIcon ) {
+    MacAppActivation::setDockIconVisible( false );
+  }
+#endif
+}
+
 void MainWindow::quitApp()
 {
   performCleanup();
@@ -2493,6 +2516,10 @@ void MainWindow::editPreferences()
 
     cfg.preferences = p;
 
+#ifdef Q_OS_MACOS
+    MacAppActivation::setDockIconVisible( cfg.preferences.showDockIcon || isVisible() );
+#endif
+
     // Loop through all tabs and reload pages due to ArticleMaker's change.
     for ( int x = 0; x < ui.tabWidget->count(); ++x ) {
       auto & view = dynamic_cast< ArticleView & >( *( ui.tabWidget->widget( x ) ) );
@@ -3185,6 +3212,15 @@ void MainWindow::toggleMainWindow( bool ensureShow )
     translateBox->setPopupEnabled( false );
   }
 
+#ifdef Q_OS_MACOS
+  // Switch to regular-app mode before asking Qt to expose or restore the
+  // native window. Doing this from showEvent is too late and can interfere
+  // with Qt's initial window painting and native menu setup.
+  if ( !isVisible() || isMinimized() ) {
+    MacAppActivation::setDockIconVisible( true );
+  }
+#endif
+
   if ( !isVisible() ) {
     show();
 
@@ -3215,8 +3251,8 @@ void MainWindow::toggleMainWindow( bool ensureShow )
     // On Windows and Linux, a hidden window won't show a task bar icon
     // When trayicon is enabled, the duplication is unneeded
 
-    // On macOS, a hidden window will still show on the Dock,
-    // but click it won't bring it back, thus we can only minimize it.
+    // On macOS, minimizing triggers the accessory-mode transition when the
+    // user has chosen not to keep a Dock icon in the background.
 
 #ifdef Q_OS_MAC
     showMinimized();
@@ -3238,6 +3274,9 @@ void MainWindow::toggleMainWindow( bool ensureShow )
   }
 
   if ( shown ) {
+#ifdef Q_OS_MACOS
+    MacAppActivation::activate();
+#endif
     if ( headwordsDlg ) {
       headwordsDlg->show();
     }

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -217,8 +217,8 @@ private:
   /// current configuration and situation.
   void trayIconUpdateOrInit();
 
-  void wheelEvent( QWheelEvent * );
-  void closeEvent( QCloseEvent * );
+  void wheelEvent( QWheelEvent * ) override;
+  void closeEvent( QCloseEvent * ) override;
   void hideEvent( QHideEvent * event ) override;
 
   void applyProxySettings();
@@ -236,7 +236,7 @@ private:
   /// muting or unmuting dictionaries, or showing/hiding dictionary bar.
   void applyMutedDictionariesState();
 
-  virtual bool eventFilter( QObject *, QEvent * );
+  bool eventFilter( QObject *, QEvent * ) override;
 
 #if defined( Q_OS_WIN )
   /// Handle theme change events as fallback when colorSchemeChanged signal is not available
@@ -256,7 +256,7 @@ private:
   void applyZoomFactor();
   void adjustCurrentZoomFactor();
 
-  void mousePressEvent( QMouseEvent * event );
+  void mousePressEvent( QMouseEvent * event ) override;
 
 
   /// Handles backward and forward mouse buttons and

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -219,6 +219,7 @@ private:
 
   void wheelEvent( QWheelEvent * );
   void closeEvent( QCloseEvent * );
+  void hideEvent( QHideEvent * event ) override;
 
   void applyProxySettings();
   void makeDictionaries();

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -178,10 +178,19 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   ui.mruTabOrder->setChecked( p.mruTabOrder );
   ui.enableTrayIcon->setChecked( p.enableTrayIcon );
 
-  // Enable tray icon option for all platforms
-
   ui.startToTray->setChecked( p.startToTray );
   ui.closeToTray->setChecked( p.closeToTray );
+  ui.showDockIcon->setChecked( p.showDockIcon );
+#ifdef Q_OS_MACOS
+  // Menu-bar-only mode has no Dock icon, so its status icon is mandatory.
+  // Keep "Start to system tray" configurable, but prevent configurations that
+  // would leave no way to restore a hidden main window.
+  ui.enableTrayIcon->setCheckable( false );
+  ui.closeToTray->setChecked( true );
+  ui.closeToTray->setEnabled( false );
+#else
+  ui.showDockIcon->hide();
+#endif
   ui.cbAutostart->setChecked( p.autoStart );
   ui.doubleClickTranslates->setChecked( p.doubleClickTranslates );
   ui.selectBySingleClick->setChecked( p.selectWordBySingleClick );
@@ -482,6 +491,13 @@ Config::Preferences Preferences::getPreferences()
   p.enableTrayIcon             = ui.enableTrayIcon->isChecked();
   p.startToTray                = ui.startToTray->isChecked();
   p.closeToTray                = ui.closeToTray->isChecked();
+  p.showDockIcon               = ui.showDockIcon->isChecked();
+#ifdef Q_OS_MACOS
+  // These keep the application reachable after its main window and optional
+  // Dock icon have been hidden.
+  p.enableTrayIcon = true;
+  p.closeToTray    = true;
+#endif
   p.autoStart                  = ui.cbAutostart->isChecked();
   p.doubleClickTranslates      = ui.doubleClickTranslates->isChecked();
   p.selectWordBySingleClick    = ui.selectBySingleClick->isChecked();

--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -226,6 +226,16 @@ the application.</string>
               </property>
              </widget>
             </item>
+            <item>
+             <widget class="QCheckBox" name="showDockIcon">
+              <property name="toolTip">
+               <string>The Dock icon is always shown while the main window is open so that macOS can display the application name and menus. Enable this option to keep the Dock icon visible after the main window is hidden.</string>
+              </property>
+              <property name="text">
+               <string>Keep Dock icon visible in background</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </widget>
          </item>


### PR DESCRIPTION
# macOS Menu Bar, Dock, Background Mode, and Packaging Improvements

## Summary

This change improves GoldenDict-ng’s native macOS behavior and fixes packaging issues affecting Qt WebEngine rendering.

## Changes

### Native macOS application behavior

- Added a macOS menu-bar status icon.
- Closing the main window with the red window button now hides the application instead of quitting it.
- GoldenDict-ng continues running in the background after the main window is closed.
- Clicking the menu-bar icon can restore the main window.
- Restored normal macOS application activation so:
  - `GoldenDict-ng` appears beside the Apple menu.
  - Native application menus are displayed.
  - The application is brought to the foreground correctly.
- Added native AppKit activation-policy handling.

### Dock icon preference

Added the following option to Preferences:

> **Keep Dock icon visible in background**

Behavior:

- The Dock icon is always visible while the main window is open, allowing macOS to display the application name and menus.
- When the main window is hidden, the Dock icon disappears by default.
- Enabling the preference keeps the Dock icon visible while GoldenDict-ng runs in the background.
- The preference is saved and restored through the existing configuration system.

### Tray safety on macOS

- The system tray/menu-bar icon and close-to-tray behavior are enforced on macOS.
- This prevents configurations where the application becomes hidden without a way to restore or quit it.

### Qt WebEngine rendering fix

Fixed blank dictionary articles and welcome pages in packaged builds.

The deployed `QtWebEngineProcess` was unable to locate frameworks such as `QtWebChannel.framework` because `macdeployqt` generated paths relative to the main executable, while the WebEngine helper is nested inside `QtWebEngineCore.framework`.

The packaging process now:

- Gives the nested WebEngine helper access to the application’s main `Contents/Frameworks` directory.
- Signs `QtWebEngineProcess.app` with Qt’s supplied WebEngine entitlements.
- Re-signs the containing framework and application from the inside out.
- Performs strict deep signature verification.
- Preserves the JIT and executable-memory permissions required by Chromium.

### macOS graphics compatibility

Added:

```xml
<key>NSSupportsAutomaticGraphicsSwitching</key>
<true/>
```

This follows Qt’s recommendation for avoiding Qt WebEngine rendering problems during macOS GPU switching.

### Packaging improvements

- Added AppKit framework linking.
- Improved Homebrew ICU library deployment for ZIM support.
- Prevented deployment tools from modifying Homebrew’s original libraries.
- Removed the unused Qt Virtual Keyboard plugin that caused deployment failures.
- Added reliable final application signing and validation.
- Allowed an existing DMG to be overwritten during repeated packaging.

## Fully enabled build configuration

```bash
cd /Users/uzeyir/Downloads/goldendict-ng-staged

export PKG_CONFIG_PATH="$(brew --prefix ffmpeg@6)/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"

cmake -S . -B build_full -G Ninja \
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_PREFIX_PATH="$(brew --prefix qt)" \
  -DWITH_FFMPEG_PLAYER=ON \
  -DWITH_QT_MULTIMEDIA=ON \
  -DWITH_EPWING_SUPPORT=ON \
  -DWITH_ZIM=ON \
  -DWITH_TTS=ON

cmake --build build_full --parallel
```

For local testing, run the build bundle directly:

```bash
open build_full/GoldenDict-ng.app
```

Create the final standalone application and DMG only after testing:

```bash
cmake --install build_full
```

## Validation

Completed:

- Preferences UI XML validation.
- macOS `Info.plist` validation.
- CMake configuration and generation with all requested features enabled.
- Verification of generated deployment and signing instructions.
- Diagnosis of the packaged WebEngine helper using `dyld`, `otool`, `codesign`, and macOS process inspection.

## Screenshots
<img width="587" height="504" alt="image" src="https://github.com/user-attachments/assets/33ba0ddd-50fd-41bf-b9bf-64c33f339427" />
<img width="786" height="676" alt="image" src="https://github.com/user-attachments/assets/d97b3f08-efc4-463b-a62b-fe663229fe07" />


