### PR TITLE
ci(sonar): use environment secret for SONAR_TOKEN on pull_request events

### DIFF
--- a/.github/workflows/Sonar Cloud.yml
+++ b/.github/workflows/Sonar Cloud.yml
@@ -18,6 +18,7 @@ jobs:
   build:
     name: Build and analyze
     runs-on: ubuntu-24.04
+    environment: sonar-cloud
     steps:            
       - name: ubuntu install thirdparty dependencies
         run: |


### PR DESCRIPTION
## Summary

Fix SonarCloud workflow failing on PR triggered events due to GitHub security policy restricting repository secrets access.

## Change

Add \environment: sonar-cloud\ to the SonarCloud CI job, binding it to an environment that has \SONAR_TOKEN\ configured as an environment secret. This allows \pull_request\ triggered workflows to access the token.

## Note

Before merging, the following setup is required on GitHub:
1. Go to **Settings → Environments** 
2. Create environment named \sonar-cloud\
3. Add \SONAR_TOKEN\ as an environment secret under it