### PR TITLE
ci: install clang-format via pip instead of Homebrew

### DIFF
--- a/.github/workflows/auto format.yml
+++ b/.github/workflows/auto format.yml
@@ -23,14 +23,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-
           fetch-depth: 2
-      # format the latest commit
-      - name: ubuntu install clang-format
-        run: |
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          brew install clang-format
-          (/home/linuxbrew/.linuxbrew/opt/clang-format/bin/git-clang-format --binary=/home/linuxbrew/.linuxbrew/opt/clang-format/bin/clang-format --style=file HEAD^) || true
+      - name: install clang-format
+        run: pip install clang-format
+      # HEAD^ is the base branch tip: pull_request checks out the merge commit
+      - name: clang-format PR changes
+        run: git-clang-format --binary=clang-format --style=file HEAD^ || true
       - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a
 
 


### PR DESCRIPTION
## Why

The clang-format job in `auto format.yml` fails on `ubuntu-latest`:

```
Error: unknown install step: run
```

GitHub's `ubuntu-latest` runner sets `HOMEBREW_NO_AUTO_UPDATE`, so the preinstalled Homebrew never updates itself. Its version is too old for the current `ca-certificates` formula (which now uses a `run` install step), so the install crashes while pouring `ca-certificates` — a transitive dependency of `clang-format`.

## What changed

- Replace Homebrew with `pip install clang-format`. Installs both `clang-format` and `git-clang-format` in seconds, no transitive dependency churn, and sidesteps the stale-brew problem entirely.
- Drop `brew shellenv` / full-path invocation — pip puts the binaries on `PATH`.
- Clarify the format range: for `pull_request` events, `actions/checkout` checks out the merge commit, so `HEAD^` is already the base branch tip and `git-clang-format HEAD^` covers the full PR diff. The old `# format the latest commit` comment was misleading; `fetch-depth: 2` is sufficient.
