### PR TITLE
fix(macOS): fix .dmg packaging in release pipeline

### DIFF
--- a/.github/workflows/Release-all.yml
+++ b/.github/workflows/Release-all.yml
@@ -94,15 +94,15 @@ jobs:
       - name: Print package content
         run: |
           ls -Rl ./build_dir/redist
-          echo "--- .dmg files in build_dir/ ---"
-          ls -l build_dir/*.dmg 2>/dev/null || echo "(none)"
+          echo "--- .dmg files in  ---"
+          ls -l *.dmg 2>/dev/null || echo "(none)"
       - uses: actions/upload-artifact@v7
         with:
           name: macOS-${{ matrix.os }}-Qt${{ matrix.qt_ver }}
           if-no-files-found: error
           retention-days: 7
           archive: false
-          path: 'build_dir/*.dmg'
+          path: '*.dmg'
 
   build_Windows:
     permissions:

--- a/.github/workflows/Release-all.yml
+++ b/.github/workflows/Release-all.yml
@@ -94,13 +94,15 @@ jobs:
       - name: Print package content
         run: |
           ls -Rl ./build_dir/redist
+          echo "--- .dmg files in build_dir/ ---"
+          ls -l build_dir/*.dmg 2>/dev/null || echo "(none)"
       - uses: actions/upload-artifact@v7
         with:
           name: macOS-${{ matrix.os }}-Qt${{ matrix.qt_ver }}
           if-no-files-found: error
           retention-days: 7
           archive: false
-          path: '*.dmg'
+          path: 'build_dir/*.dmg'
 
   build_Windows:
     permissions:

--- a/cmake/Package_macOS.cmake
+++ b/cmake/Package_macOS.cmake
@@ -115,18 +115,23 @@ install(CODE "
 
 find_program(CREATE-DMG "create-dmg")
 if (CREATE-DMG)
+    set(DMG_OUTPUT_NAME "GoldenDict-ng-${CMAKE_PROJECT_VERSION}-Qt${Qt6_VERSION}-macOS-${CMAKE_SYSTEM_PROCESSOR}.dmg")
     install(CODE "
+    # The shell-version of create-dmg shipped by Homebrew does not always ship with
+    # the --overwrite flag (it was added very recently). Mirror the upstream README's
+    # example by removing any existing output file beforehand, and drop --overwrite.
+    file(REMOVE \"${CMAKE_CURRENT_BINARY_DIR}/${DMG_OUTPUT_NAME}\")
     execute_process(COMMAND ${CREATE-DMG} \
         --skip-jenkins \
-        --overwrite \
         --format \"ULMO\"
         --volname ${CMAKE_PROJECT_NAME}-${CMAKE_PROJECT_VERSION}-${CMAKE_SYSTEM_PROCESSOR} \
         --volicon ${CMAKE_SOURCE_DIR}/icons/macicon.icns \
         --icon \"${App_Name}\" 100 100
         --app-drop-link 300 100 \
-        \"GoldenDict-ng-${CMAKE_PROJECT_VERSION}-Qt${Qt6_VERSION}-macOS-${CMAKE_SYSTEM_PROCESSOR}.dmg\" \
-        \"${Assembling_Dir}\")"
+        \"${DMG_OUTPUT_NAME}\" \
+        \"${Assembling_Dir}\"
+        COMMAND_ERROR_IS_FATAL ANY)"
     )
 else ()
-    message(WARNING "create-dmg not found. No .dmg will be created")
+    message(FATAL_ERROR "create-dmg not found. Install it via `brew install create-dmg` before running cmake --install, otherwise no .dmg artifact will be produced.")
 endif ()


### PR DESCRIPTION
## Summary

Fixes the macOS `.dmg` packaging step in the Release-all pipeline so artifacts are actually produced and uploaded.

## Background

After the previous `-no-codesign` fix, the macOS release job still failed to upload a `.dmg` artifact because:

1. `create-dmg` was invoked with `--overwrite`, but the Homebrew-shipped shell version does not always include that flag (it was added recently upstream), causing the packaging step to fail.
2. The artifact upload path was `*.dmg` at the workflow root, but the `.dmg` is actually generated inside `build_dir/`, so `if-no-files-found: error` aborted the upload.
3. When `create-dmg` was missing entirely, CMake only emitted a `WARNING` and silently produced no `.dmg`, masking the misconfiguration.

## Changes

### `cmake/Package_macOS.cmake`
- Extract DMG output filename into `DMG_OUTPUT_NAME` variable for reuse.
- Drop `--overwrite` from `create-dmg` invocation; mirror the upstream README by calling `file(REMOVE)` on the output file beforehand.
- Add `COMMAND_ERROR_IS_FATAL ANY` so `create-dmg` failures actually fail the install step instead of being swallowed.
- Promote missing `create-dmg` from `WARNING` to `FATAL_ERROR` with a hint to `brew install create-dmg`.
