### PR TITLE
[codex] fix: persist main window geometry reliably on macOS

### DIFF
--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -80,6 +80,10 @@
 #endif
 
 #include <QGuiApplication>
+#include <QScreen>
+#include <QResizeEvent>
+#include <QMoveEvent>
+#include <QShowEvent>
 #include <QWindow>
 #include <QWebEngineSettings>
 #include <QProxyStyle>
@@ -154,6 +158,57 @@ void MainWindow::changeWebEngineViewFont() const
                                                                     cfg.preferences.customFonts.monospace );
   }
 }
+
+namespace {
+
+/// Decodes the saved geometry and checks whether it is usable: the window must
+/// be reasonably large and at least partially visible on one of the screens.
+/// This guards against corrupted configs (e.g. a tiny window saved at an
+/// off-screen position) that would otherwise make the main window open in a
+/// broken size on every launch.
+bool isMainWindowGeometryUsable( const QByteArray & geometry )
+{
+  if ( geometry.isEmpty() ) {
+    return false;
+  }
+
+  QWidget probe;
+  if ( !probe.restoreGeometry( geometry ) ) {
+    return false;
+  }
+
+  const QRect r = probe.geometry();
+  if ( r.width() < 500 || r.height() < 400 ) {
+    return false;
+  }
+
+  const QList< QScreen * > screens = QGuiApplication::screens();
+  for ( QScreen * screen : screens ) {
+    if ( r.intersects( screen->availableGeometry() ) ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// Returns true if the given rectangle is large enough and at least partially
+/// visible on one of the screens.
+bool isRectUsable( const QRect & r )
+{
+  if ( !r.isValid() || r.width() < 500 || r.height() < 400 ) {
+    return false;
+  }
+
+  const QList< QScreen * > screens = QGuiApplication::screens();
+  for ( QScreen * screen : screens ) {
+    if ( r.intersects( screen->availableGeometry() ) ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace
 
 MainWindow::MainWindow( Config::Class & cfg_ ):
   trayIcon( nullptr ),
@@ -873,8 +928,15 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   if ( cfg.mainWindowState.size() && !cfg.resetState ) {
     restoreState( cfg.mainWindowState );
   }
-  if ( cfg.mainWindowGeometry.size() ) {
+  if ( cfg.mainWindowGeometry.size() && isMainWindowGeometryUsable( cfg.mainWindowGeometry ) ) {
     restoreGeometry( cfg.mainWindowGeometry );
+  }
+  else {
+    // Missing or invalid saved geometry (e.g. a tiny off-screen window):
+    // fall back to a sane default size centered on the primary screen.
+    const QRect screenRect = QGuiApplication::primaryScreen()->availableGeometry();
+    resize( 900, 700 );
+    move( screenRect.center() - QPoint( 450, 350 ) );
   }
 
   // Show window unless it is configured not to
@@ -1412,8 +1474,14 @@ void MainWindow::commitData()
 
   try {
     // Save MainWindow state and geometry
-    cfg.mainWindowState    = saveState();
-    cfg.mainWindowGeometry = saveGeometry();
+    cfg.mainWindowState = saveState();
+    // Only persist geometry while the window is actually visible. When it is
+    // hidden (e.g. started to tray or closed to tray), saveGeometry() may
+    // return an un-applied default frame on macOS, which would clobber the
+    // last validated geometry saved by the debounced handler.
+    if ( isVisible() ) {
+      cfg.mainWindowGeometry = saveGeometry();
+    }
 
     // Save popup window state and geometry
     if ( scanPopup ) {
@@ -1732,6 +1800,69 @@ void MainWindow::hideEvent( QHideEvent * event )
     MacAppActivation::setDockIconVisible( false );
   }
 #endif
+}
+
+void MainWindow::showEvent( QShowEvent * event )
+{
+  QMainWindow::showEvent( event );
+
+  // On macOS, a window that is restored while hidden (e.g. "start to tray")
+  // may not have its saved size applied to the native frame until it is first
+  // shown. Re-apply the validated saved geometry on that first show so the
+  // window opens at the size the user last chose instead of the UI default.
+  if ( !geometryReappliedOnFirstShow && cfg.mainWindowGeometry.size()
+       && isMainWindowGeometryUsable( cfg.mainWindowGeometry ) ) {
+    geometryReappliedOnFirstShow = true;
+    restoreGeometry( cfg.mainWindowGeometry );
+  }
+}
+
+void MainWindow::resizeEvent( QResizeEvent * event )
+{
+  QMainWindow::resizeEvent( event );
+  scheduleGeometrySave();
+}
+
+void MainWindow::moveEvent( QMoveEvent * event )
+{
+  QMainWindow::moveEvent( event );
+  scheduleGeometrySave();
+}
+
+void MainWindow::scheduleGeometrySave()
+{
+  if ( isQuitting ) {
+    return;
+  }
+
+  if ( !geometrySaveTimer ) {
+    geometrySaveTimer = new QTimer( this );
+    geometrySaveTimer->setSingleShot( true );
+    geometrySaveTimer->setInterval( 1000 );
+    connect( geometrySaveTimer, &QTimer::timeout, this, &MainWindow::saveMainWindowGeometry );
+  }
+  geometrySaveTimer->start();
+}
+
+void MainWindow::saveMainWindowGeometry()
+{
+  if ( isQuitting || !isVisible() || isMinimized() ) {
+    return;
+  }
+
+  // Only persist a geometry that is large enough and still on screen, so a
+  // corrupted value can never be written back into the config.
+  if ( !isRectUsable( normalGeometry() ) ) {
+    return;
+  }
+
+  cfg.mainWindowGeometry = saveGeometry();
+  try {
+    Config::save( cfg );
+  }
+  catch ( std::exception & e ) {
+    qWarning() << "Failed to save main window geometry:" << e.what();
+  }
 }
 
 void MainWindow::quitApp()

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -39,6 +39,10 @@
 using std::string;
 using std::vector;
 
+class QMoveEvent;
+class QResizeEvent;
+class QShowEvent;
+
 class MainWindow: public QMainWindow
 {
   Q_OBJECT
@@ -186,6 +190,9 @@ private:
   QTimer ftsRestartTimer;       // Timer to delay FTS indexing restart after state change
   bool ftsStateChanged = false; // Track if FTS state was changed in DictInfo
 
+  QTimer * geometrySaveTimer = nullptr; // Debounce timer for persisting main window geometry
+  bool geometryReappliedOnFirstShow = false;
+
   FTS::FullTextSearchDialog * ftsDlg;
 
   QIcon starIcon, blueStarIcon;
@@ -220,6 +227,14 @@ private:
   void wheelEvent( QWheelEvent * ) override;
   void closeEvent( QCloseEvent * ) override;
   void hideEvent( QHideEvent * event ) override;
+  void resizeEvent( QResizeEvent * ) override;
+  void moveEvent( QMoveEvent * ) override;
+  void showEvent( QShowEvent * event ) override;
+
+  /// Schedules a debounced (1s) save of the main window geometry.
+  void scheduleGeometrySave();
+  /// Persists the current validated main window geometry to the config.
+  void saveMainWindowGeometry();
 
   void applyProxySettings();
   void makeDictionaries();


### PR DESCRIPTION
## What changed

Fixes the main window size not being remembered across restarts on macOS when the app is configured to start to the tray.

- **Debounced geometry persistence** (`resizeEvent` / `moveEvent` + a 1s `QTimer`): the current validated geometry is written to the config while the user drags/resizes the window, instead of only at quit time.
- **Skip saving while hidden**: both the debounced handler and `commitData()` now skip writing `mainWindowGeometry` when the window is not visible. On macOS, `saveGeometry()` on a window that was never shown (or was closed to the tray) can return an un-applied default frame, which clobbered the last good value in the config.
- **Re-apply geometry on first show** (`showEvent`): a window restored while hidden ("start to tray") can come up with the UI-default size because the saved frame is not applied to the native window until it is first shown. Re-applying the validated saved geometry on the first show makes it open at the size the user last chose.
- **Validation of saved geometry**: geometry that is too small (< 500×400) or that does not intersect any screen's available area is rejected, and a sane 900×700 centered default is used instead. This prevents already-corrupted configs (e.g. a tiny window saved off-screen) from reproducing on every launch.

## Why

With "start to tray" enabled and the window closed to the tray before quitting, the main window would open at the UI default size after every restart, regardless of the size the user had set:

1. At launch the window stays hidden, so the saved frame is not applied by AppKit yet.
2. On quit, `saveGeometry()` returned the un-applied default frame and wrote it into the config.
3. The next launch restored that default frame.

## Impact

Users on macOS who resize the main window and quit from the tray (the default close-to-tray flow) keep their chosen window size across restarts. Corrupted or off-screen saved geometries also no longer reproduce a broken tiny window.

## Root cause

The geometry was only saved at quit time from a hidden window, and the saved frame was never re-applied at first show when the window had been hidden since startup.

## Validation

Verified locally on macOS (Qt 6.11, arm64):

- Resize → close to tray → quit from tray → restart: size is preserved.
- Start to tray → show window: opens at the saved size, not the UI default.
- Config with a tiny/off-screen geometry: falls back to the centered default instead of opening a broken window.
- Full app build passes (Release, macOS arm64).
