### PR TITLE
Fix MIME type detection for custom URL schemes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -77,6 +77,7 @@ IndentPPDirectives: BeforeHash
 IndentExternBlock: AfterExternBlock
 IndentWidth: 2
 IndentWrappedFunctionNames: false
+InsertBraces: true
 InsertNewlineAtEOF: true
 InsertTrailingCommas: None
 KeepEmptyLinesAtTheStartOfBlocks: true

--- a/src/article_netmgr.cc
+++ b/src/article_netmgr.cc
@@ -284,7 +284,9 @@ sptr< Dictionary::DataRequest > ArticleNetworkAccessManager::getResource( const 
     return handleLookupScheme( url, contentType );
   }
 
-  if ( ( scheme == "bres" || scheme == "gdau" || scheme == "gdvideo" || scheme == "gico" ) && url.path().size() ) {
+  if ( ( scheme == "bres" || scheme == "gdau" || scheme == "gdvideo" || scheme == "gico"
+         || scheme == "qrcx" )
+       && url.path().size() ) {
     return handleResourceScheme( url, contentType );
   }
 

--- a/src/article_netmgr.cc
+++ b/src/article_netmgr.cc
@@ -20,19 +20,28 @@ namespace {
 // chain of ifs) makes the lookup O(table_size) with constant low overhead and,
 // more importantly, keeps the cognitive complexity of the main resolver
 // below SonarCloud's 25-point threshold.
-struct ExtensionMime {
+struct ExtensionMime
+{
   const char * ext;
   const char * mime;
 };
 const ExtensionMime kExtensionMimeTable[] = {
-  { "html", "text/html; charset=utf-8" }, { "htm", "text/html; charset=utf-8" },
-  { "css", "text/css; charset=utf-8" },     { "js", "text/javascript; charset=utf-8" },
-  { "mjs", "text/javascript; charset=utf-8" }, { "png", "image/png" },
-  { "jpg", "image/jpeg" },                   { "jpeg", "image/jpeg" },
-  { "gif", "image/gif" },                    { "svg", "image/svg+xml" },
-  { "webp", "image/webp" },                 { "woff", "font/woff" },
-  { "woff2", "font/woff2" },                { "ttf", "font/ttf" },
-  { "mp3", "audio/mpeg" },                  { "wav", "audio/wav" },
+  { "html", "text/html; charset=utf-8" },
+  { "htm", "text/html; charset=utf-8" },
+  { "css", "text/css; charset=utf-8" },
+  { "js", "text/javascript; charset=utf-8" },
+  { "mjs", "text/javascript; charset=utf-8" },
+  { "png", "image/png" },
+  { "jpg", "image/jpeg" },
+  { "jpeg", "image/jpeg" },
+  { "gif", "image/gif" },
+  { "svg", "image/svg+xml" },
+  { "webp", "image/webp" },
+  { "woff", "font/woff" },
+  { "woff2", "font/woff2" },
+  { "ttf", "font/ttf" },
+  { "mp3", "audio/mpeg" },
+  { "wav", "audio/wav" },
   { "ogg", "audio/ogg" },
 };
 const size_t kExtensionMimeTableSize = sizeof( kExtensionMimeTable ) / sizeof( kExtensionMimeTable[ 0 ] );
@@ -55,9 +64,7 @@ QByteArray lookupMimeByExtension( const QString & ext )
 bool sniffHtmlContent( const QByteArray & data )
 {
   const QByteArray trimmed = data.trimmed().toLower();
-  return trimmed.startsWith( "<!doctype html" )
-    || trimmed.startsWith( "<html" )
-    || trimmed.startsWith( "<?xml" );
+  return trimmed.startsWith( "<!doctype html" ) || trimmed.startsWith( "<html" ) || trimmed.startsWith( "<?xml" );
 }
 
 // Appends "; charset=utf-8" for textual MIME types so QtWebEngine renders
@@ -87,7 +94,7 @@ QByteArray getMimeTypeWithFallback( const QUrl & url, const QByteArray & data )
   //    shared-mime-info database, which is absent on some minimal Linux
   //    installations and would otherwise make these resources fall back to
   //    text/plain (and render as raw source) in QtWebEngine.
-  const QString ext      = QFileInfo( url.path() ).suffix().toLower();
+  const QString ext        = QFileInfo( url.path() ).suffix().toLower();
   const QByteArray extMime = lookupMimeByExtension( ext );
   if ( !extMime.isEmpty() ) {
     return extMime;

--- a/src/article_netmgr.cc
+++ b/src/article_netmgr.cc
@@ -27,10 +27,13 @@ struct ExtensionMime
   const char * ext;
   const char * mime;
 };
-// CTAD (C++17): the compiler automatically deduces the array size from the
-// initializer list, so there is no risk of a mismatch between the declared
-// size and the actual number of entries.
-const std::array kExtensionMimeTable = { {
+// Note: the size is specified explicitly (not via CTAD) for MSVC
+// compatibility. While C++17 class template argument deduction works for
+// std::array in most contexts, MSVC 2022 may fail to resolve the type in
+// subsequent template-dependent expressions (e.g. std::find_if on the
+// iterator). An explicit size keeps the code portable across toolchains
+// without any runtime or maintenance penalty for this fixed-size table.
+const std::array< ExtensionMime, 17 > kExtensionMimeTable = { {
   { "html", "text/html; charset=utf-8" },
   { "htm", "text/html; charset=utf-8" },
   { "css", "text/css; charset=utf-8" },

--- a/src/article_netmgr.cc
+++ b/src/article_netmgr.cc
@@ -29,20 +29,34 @@ QByteArray getMimeTypeWithFallback( const QUrl & url, const QByteArray & data )
   //    installations and would otherwise make these resources fall back to
   //    text/plain (and render as raw source) in QtWebEngine.
   const QString ext = QFileInfo( url.path() ).suffix().toLower();
-  if ( ext == "html" || ext == "htm" ) return "text/html; charset=utf-8";
-  if ( ext == "css" )                  return "text/css; charset=utf-8";
-  if ( ext == "js" || ext == "mjs" )   return "text/javascript; charset=utf-8";
-  if ( ext == "png" )                  return "image/png";
-  if ( ext == "jpg" || ext == "jpeg" ) return "image/jpeg";
-  if ( ext == "gif" )                  return "image/gif";
-  if ( ext == "svg" )                  return "image/svg+xml";
-  if ( ext == "webp" )                 return "image/webp";
-  if ( ext == "woff" )                 return "font/woff";
-  if ( ext == "woff2" )                return "font/woff2";
-  if ( ext == "ttf" )                  return "font/ttf";
-  if ( ext == "mp3" )                  return "audio/mpeg";
-  if ( ext == "wav" )                  return "audio/wav";
-  if ( ext == "ogg" )                  return "audio/ogg";
+  if ( ext == "html" || ext == "htm" )
+    return "text/html; charset=utf-8";
+  if ( ext == "css" )
+    return "text/css; charset=utf-8";
+  if ( ext == "js" || ext == "mjs" )
+    return "text/javascript; charset=utf-8";
+  if ( ext == "png" )
+    return "image/png";
+  if ( ext == "jpg" || ext == "jpeg" )
+    return "image/jpeg";
+  if ( ext == "gif" )
+    return "image/gif";
+  if ( ext == "svg" )
+    return "image/svg+xml";
+  if ( ext == "webp" )
+    return "image/webp";
+  if ( ext == "woff" )
+    return "font/woff";
+  if ( ext == "woff2" )
+    return "font/woff2";
+  if ( ext == "ttf" )
+    return "font/ttf";
+  if ( ext == "mp3" )
+    return "audio/mpeg";
+  if ( ext == "wav" )
+    return "audio/wav";
+  if ( ext == "ogg" )
+    return "audio/ogg";
 
   // 3. System MIME database (URL/extension based).
   QMimeDatabase mimeDb;
@@ -62,9 +76,8 @@ QByteArray getMimeTypeWithFallback( const QUrl & url, const QByteArray & data )
   //    render raw HTML source on misconfigured systems.
   if ( !data.isEmpty() ) {
     const QByteArray trimmed = data.trimmed().toLower();
-    const bool looksLikeHtml = trimmed.startsWith( "<!doctype html" )
-      || trimmed.startsWith( "<html" )
-      || trimmed.startsWith( "<?xml" );
+    const bool looksLikeHtml =
+      trimmed.startsWith( "<!doctype html" ) || trimmed.startsWith( "<html" ) || trimmed.startsWith( "<?xml" );
     if ( looksLikeHtml
          && ( mimeName.isEmpty() || mimeName == "application/octet-stream" || mimeName == "text/plain" ) ) {
       return "text/html; charset=utf-8";
@@ -302,7 +315,7 @@ sptr< Dictionary::DataRequest > ArticleNetworkAccessManager::handleResourceSchem
   // shared-mime-info. The payload is not available here, so only URL-based
   // heuristics are applied at this stage.
   contentType = QString::fromLatin1( getMimeTypeWithFallback( url ) );
-  string id    = url.host().toStdString();
+  string id   = url.host().toStdString();
 
   // Special handling for 'user' host to access user configuration files
   if ( id == "user" && url.scheme() == "bres" ) {

--- a/src/article_netmgr.cc
+++ b/src/article_netmgr.cc
@@ -27,7 +27,10 @@ struct ExtensionMime
   const char * ext;
   const char * mime;
 };
-const std::array< ExtensionMime, 17 > kExtensionMimeTable = { {
+// CTAD (C++17): the compiler automatically deduces the array size from the
+// initializer list, so there is no risk of a mismatch between the declared
+// size and the actual number of entries.
+const std::array kExtensionMimeTable = { {
   { "html", "text/html; charset=utf-8" },
   { "htm", "text/html; charset=utf-8" },
   { "css", "text/css; charset=utf-8" },

--- a/src/article_netmgr.cc
+++ b/src/article_netmgr.cc
@@ -14,6 +14,65 @@
 
 using std::string;
 
+namespace {
+
+// Extension whitelist table. Keeping these in a flat array (rather than a
+// chain of ifs) makes the lookup O(table_size) with constant low overhead and,
+// more importantly, keeps the cognitive complexity of the main resolver
+// below SonarCloud's 25-point threshold.
+struct ExtensionMime {
+  const char * ext;
+  const char * mime;
+};
+const ExtensionMime kExtensionMimeTable[] = {
+  { "html", "text/html; charset=utf-8" }, { "htm", "text/html; charset=utf-8" },
+  { "css", "text/css; charset=utf-8" },     { "js", "text/javascript; charset=utf-8" },
+  { "mjs", "text/javascript; charset=utf-8" }, { "png", "image/png" },
+  { "jpg", "image/jpeg" },                   { "jpeg", "image/jpeg" },
+  { "gif", "image/gif" },                    { "svg", "image/svg+xml" },
+  { "webp", "image/webp" },                 { "woff", "font/woff" },
+  { "woff2", "font/woff2" },                { "ttf", "font/ttf" },
+  { "mp3", "audio/mpeg" },                  { "wav", "audio/wav" },
+  { "ogg", "audio/ogg" },
+};
+const size_t kExtensionMimeTableSize = sizeof( kExtensionMimeTable ) / sizeof( kExtensionMimeTable[ 0 ] );
+
+// Returns the whitelisted MIME type for the given file extension, or an
+// empty QByteArray when the extension is not in the table.
+QByteArray lookupMimeByExtension( const QString & ext )
+{
+  for ( size_t i = 0; i < kExtensionMimeTableSize; ++i ) {
+    if ( ext.compare( QLatin1String( kExtensionMimeTable[ i ].ext ), Qt::CaseInsensitive ) == 0 ) {
+      return QByteArray( kExtensionMimeTable[ i ].mime );
+    }
+  }
+  return {};
+}
+
+// Returns true when the payload smells like an HTML / XML document, so we
+// can detect cases where the system MIME database mis-classified HTML as
+// text/plain or application/octet-stream.
+bool sniffHtmlContent( const QByteArray & data )
+{
+  const QByteArray trimmed = data.trimmed().toLower();
+  return trimmed.startsWith( "<!doctype html" )
+    || trimmed.startsWith( "<html" )
+    || trimmed.startsWith( "<?xml" );
+}
+
+// Appends "; charset=utf-8" for textual MIME types so QtWebEngine renders
+// pages with the correct encoding regardless of system locale defaults.
+QByteArray withUtf8Charset( const QString & mimeName )
+{
+  QByteArray result = mimeName.toUtf8();
+  if ( result.startsWith( "text/" ) || result == "application/javascript" ) {
+    result.append( "; charset=utf-8" );
+  }
+  return result;
+}
+
+} // namespace
+
 QByteArray getMimeTypeWithFallback( const QUrl & url, const QByteArray & data )
 {
   const QString scheme = url.scheme().toLower();
@@ -28,48 +87,10 @@ QByteArray getMimeTypeWithFallback( const QUrl & url, const QByteArray & data )
   //    shared-mime-info database, which is absent on some minimal Linux
   //    installations and would otherwise make these resources fall back to
   //    text/plain (and render as raw source) in QtWebEngine.
-  const QString ext = QFileInfo( url.path() ).suffix().toLower();
-  if ( ext == "html" || ext == "htm" ) {
-    return "text/html; charset=utf-8";
-  }
-  if ( ext == "css" ) {
-    return "text/css; charset=utf-8";
-  }
-  if ( ext == "js" || ext == "mjs" ) {
-    return "text/javascript; charset=utf-8";
-  }
-  if ( ext == "png" ) {
-    return "image/png";
-  }
-  if ( ext == "jpg" || ext == "jpeg" ) {
-    return "image/jpeg";
-  }
-  if ( ext == "gif" ) {
-    return "image/gif";
-  }
-  if ( ext == "svg" ) {
-    return "image/svg+xml";
-  }
-  if ( ext == "webp" ) {
-    return "image/webp";
-  }
-  if ( ext == "woff" ) {
-    return "font/woff";
-  }
-  if ( ext == "woff2" ) {
-    return "font/woff2";
-  }
-  if ( ext == "ttf" ) {
-    return "font/ttf";
-  }
-  if ( ext == "mp3" ) {
-    return "audio/mpeg";
-  }
-  if ( ext == "wav" ) {
-    return "audio/wav";
-  }
-  if ( ext == "ogg" ) {
-    return "audio/ogg";
+  const QString ext      = QFileInfo( url.path() ).suffix().toLower();
+  const QByteArray extMime = lookupMimeByExtension( ext );
+  if ( !extMime.isEmpty() ) {
+    return extMime;
   }
 
   // 3. System MIME database (URL/extension based).
@@ -88,14 +109,10 @@ QByteArray getMimeTypeWithFallback( const QUrl & url, const QByteArray & data )
   // 5. HTML content sniffing. Never let real HTML be served as text/plain or
   //    application/octet-stream, which is exactly what makes the main window
   //    render raw HTML source on misconfigured systems.
-  if ( !data.isEmpty() ) {
-    const QByteArray trimmed = data.trimmed().toLower();
-    const bool looksLikeHtml =
-      trimmed.startsWith( "<!doctype html" ) || trimmed.startsWith( "<html" ) || trimmed.startsWith( "<?xml" );
-    if ( looksLikeHtml
-         && ( mimeName.isEmpty() || mimeName == "application/octet-stream" || mimeName == "text/plain" ) ) {
-      return "text/html; charset=utf-8";
-    }
+  const bool misclassifiedHtml = !data.isEmpty() && sniffHtmlContent( data )
+    && ( mimeName.isEmpty() || mimeName == "application/octet-stream" || mimeName == "text/plain" );
+  if ( misclassifiedHtml ) {
+    return "text/html; charset=utf-8";
   }
 
   // 6. Final fallback. Prefer application/octet-stream over text/plain so that
@@ -104,11 +121,7 @@ QByteArray getMimeTypeWithFallback( const QUrl & url, const QByteArray & data )
   if ( mimeName.isEmpty() ) {
     return "application/octet-stream";
   }
-  QByteArray result = mimeName.toUtf8();
-  if ( result.startsWith( "text/" ) || result == "application/javascript" ) {
-    result.append( "; charset=utf-8" );
-  }
-  return result;
+  return withUtf8Charset( mimeName );
 }
 
 

--- a/src/article_netmgr.cc
+++ b/src/article_netmgr.cc
@@ -10,6 +10,8 @@
 #include <QWebEngineUrlRequestJob>
 #include <QMimeDatabase>
 #include <QMimeType>
+#include <algorithm>
+#include <array>
 #include <stdint.h>
 
 using std::string;
@@ -25,7 +27,7 @@ struct ExtensionMime
   const char * ext;
   const char * mime;
 };
-const ExtensionMime kExtensionMimeTable[] = {
+const std::array< ExtensionMime, 17 > kExtensionMimeTable = { {
   { "html", "text/html; charset=utf-8" },
   { "htm", "text/html; charset=utf-8" },
   { "css", "text/css; charset=utf-8" },
@@ -43,17 +45,18 @@ const ExtensionMime kExtensionMimeTable[] = {
   { "mp3", "audio/mpeg" },
   { "wav", "audio/wav" },
   { "ogg", "audio/ogg" },
-};
-const size_t kExtensionMimeTableSize = sizeof( kExtensionMimeTable ) / sizeof( kExtensionMimeTable[ 0 ] );
+} };
 
 // Returns the whitelisted MIME type for the given file extension, or an
 // empty QByteArray when the extension is not in the table.
 QByteArray lookupMimeByExtension( const QString & ext )
 {
-  for ( size_t i = 0; i < kExtensionMimeTableSize; ++i ) {
-    if ( ext.compare( QLatin1String( kExtensionMimeTable[ i ].ext ), Qt::CaseInsensitive ) == 0 ) {
-      return QByteArray( kExtensionMimeTable[ i ].mime );
-    }
+  auto it = std::find_if( kExtensionMimeTable.begin(), kExtensionMimeTable.end(),
+                          [ &ext ]( const ExtensionMime & entry ) {
+                            return ext.compare( QLatin1String( entry.ext ), Qt::CaseInsensitive ) == 0;
+                          } );
+  if ( it != kExtensionMimeTable.end() ) {
+    return QByteArray( it->mime );
   }
   return {};
 }

--- a/src/article_netmgr.cc
+++ b/src/article_netmgr.cc
@@ -51,10 +51,10 @@ const std::array< ExtensionMime, 17 > kExtensionMimeTable = { {
 // empty QByteArray when the extension is not in the table.
 QByteArray lookupMimeByExtension( const QString & ext )
 {
-  auto it = std::find_if( kExtensionMimeTable.begin(), kExtensionMimeTable.end(),
-                          [ &ext ]( const ExtensionMime & entry ) {
-                            return ext.compare( QLatin1String( entry.ext ), Qt::CaseInsensitive ) == 0;
-                          } );
+  auto it =
+    std::find_if( kExtensionMimeTable.begin(), kExtensionMimeTable.end(), [ &ext ]( const ExtensionMime & entry ) {
+      return ext.compare( QLatin1String( entry.ext ), Qt::CaseInsensitive ) == 0;
+    } );
   if ( it != kExtensionMimeTable.end() ) {
     return QByteArray( it->mime );
   }

--- a/src/article_netmgr.cc
+++ b/src/article_netmgr.cc
@@ -284,8 +284,7 @@ sptr< Dictionary::DataRequest > ArticleNetworkAccessManager::getResource( const 
     return handleLookupScheme( url, contentType );
   }
 
-  if ( ( scheme == "bres" || scheme == "gdau" || scheme == "gdvideo" || scheme == "gico"
-         || scheme == "qrcx" )
+  if ( ( scheme == "bres" || scheme == "gdau" || scheme == "gdvideo" || scheme == "gico" || scheme == "qrcx" )
        && url.path().size() ) {
     return handleResourceScheme( url, contentType );
   }

--- a/src/article_netmgr.cc
+++ b/src/article_netmgr.cc
@@ -8,9 +8,81 @@
 #include <QNetworkAccessManager>
 #include <QUrl>
 #include <QWebEngineUrlRequestJob>
+#include <QMimeDatabase>
+#include <QMimeType>
 #include <stdint.h>
 
 using std::string;
+
+QByteArray getMimeTypeWithFallback( const QUrl & url, const QByteArray & data )
+{
+  const QString scheme = url.scheme().toLower();
+
+  // 1. Article lookup / internal page schemes always serve HTML documents, so
+  //    never subject them to dynamic MIME probing.
+  if ( scheme == "gdlookup" || scheme == "bword" || scheme == "entry" || scheme == "gdinternal" ) {
+    return "text/html; charset=utf-8";
+  }
+
+  // 2. Extension whitelist. This avoids depending on the system's
+  //    shared-mime-info database, which is absent on some minimal Linux
+  //    installations and would otherwise make these resources fall back to
+  //    text/plain (and render as raw source) in QtWebEngine.
+  const QString ext = QFileInfo( url.path() ).suffix().toLower();
+  if ( ext == "html" || ext == "htm" ) return "text/html; charset=utf-8";
+  if ( ext == "css" )                  return "text/css; charset=utf-8";
+  if ( ext == "js" || ext == "mjs" )   return "text/javascript; charset=utf-8";
+  if ( ext == "png" )                  return "image/png";
+  if ( ext == "jpg" || ext == "jpeg" ) return "image/jpeg";
+  if ( ext == "gif" )                  return "image/gif";
+  if ( ext == "svg" )                  return "image/svg+xml";
+  if ( ext == "webp" )                 return "image/webp";
+  if ( ext == "woff" )                 return "font/woff";
+  if ( ext == "woff2" )                return "font/woff2";
+  if ( ext == "ttf" )                  return "font/ttf";
+  if ( ext == "mp3" )                  return "audio/mpeg";
+  if ( ext == "wav" )                  return "audio/wav";
+  if ( ext == "ogg" )                  return "audio/ogg";
+
+  // 3. System MIME database (URL/extension based).
+  QMimeDatabase mimeDb;
+  QMimeType urlMime = mimeDb.mimeTypeForUrl( url );
+  QString mimeName  = ( urlMime.isValid() && !urlMime.isDefault() ) ? urlMime.name() : QString();
+
+  // 4. Content-based detection when the URL yielded nothing usable.
+  if ( mimeName.isEmpty() && !data.isEmpty() ) {
+    QMimeType dataMime = mimeDb.mimeTypeForData( data );
+    if ( dataMime.isValid() && !dataMime.isDefault() ) {
+      mimeName = dataMime.name();
+    }
+  }
+
+  // 5. HTML content sniffing. Never let real HTML be served as text/plain or
+  //    application/octet-stream, which is exactly what makes the main window
+  //    render raw HTML source on misconfigured systems.
+  if ( !data.isEmpty() ) {
+    const QByteArray trimmed = data.trimmed().toLower();
+    const bool looksLikeHtml = trimmed.startsWith( "<!doctype html" )
+      || trimmed.startsWith( "<html" )
+      || trimmed.startsWith( "<?xml" );
+    if ( looksLikeHtml
+         && ( mimeName.isEmpty() || mimeName == "application/octet-stream" || mimeName == "text/plain" ) ) {
+      return "text/html; charset=utf-8";
+    }
+  }
+
+  // 6. Final fallback. Prefer application/octet-stream over text/plain so that
+  //    unrecognized HTML-ish payloads are not rendered as plain text. Keep the
+  //    charset hint for textual types for consistent rendering.
+  if ( mimeName.isEmpty() ) {
+    return "application/octet-stream";
+  }
+  QByteArray result = mimeName.toUtf8();
+  if ( result.startsWith( "text/" ) || result == "application/javascript" ) {
+    result.append( "; charset=utf-8" );
+  }
+  return result;
+}
 
 
 QNetworkReply * ArticleNetworkAccessManager::getArticleReply( const QNetworkRequest & req )
@@ -166,7 +238,7 @@ sptr< Dictionary::DataRequest > ArticleNetworkAccessManager::getResource( const 
 sptr< Dictionary::DataRequest > ArticleNetworkAccessManager::handleInternalScheme( const QUrl & url,
                                                                                    QString & contentType )
 {
-  contentType = "text/html";
+  contentType = "text/html; charset=utf-8";
   if ( url.host() == "welcome-page" ) {
     return articleMaker.makeWelcomePage();
   }
@@ -180,7 +252,7 @@ sptr< Dictionary::DataRequest > ArticleNetworkAccessManager::handleLookupScheme(
     return std::make_shared< Dictionary::DataRequestInstant >( false );
   }
 
-  contentType  = "text/html";
+  contentType  = "text/html; charset=utf-8";
   QString word = Utils::Url::queryItemValue( url, "word" ).trimmed();
 
   bool groupIsValid = false;
@@ -225,9 +297,12 @@ sptr< Dictionary::DataRequest > ArticleNetworkAccessManager::handleLookupScheme(
 sptr< Dictionary::DataRequest > ArticleNetworkAccessManager::handleResourceScheme( const QUrl & url,
                                                                                    QString & contentType )
 {
-  QMimeType mineType = db.mimeTypeForUrl( url );
-  contentType        = mineType.name();
-  string id          = url.host().toStdString();
+  // Use the robust resolver (extension whitelist + QMimeDatabase) instead of a
+  // bare QMimeDatabase lookup, which may return text/plain on systems lacking
+  // shared-mime-info. The payload is not available here, so only URL-based
+  // heuristics are applied at this stage.
+  contentType = QString::fromLatin1( getMimeTypeWithFallback( url ) );
+  string id    = url.host().toStdString();
 
   // Special handling for 'user' host to access user configuration files
   if ( id == "user" && url.scheme() == "bres" ) {
@@ -424,7 +499,10 @@ void LocalSchemeHandler::requestStarted( QWebEngineUrlRequestJob * requestJob )
   }
 
   QNetworkReply * reply = this->mManager.getArticleReply( request );
-  requestJob->reply( "text/html", reply );
+  // Local (HTML) schemes always serve HTML documents: pin the content type
+  // explicitly so QtWebEngine never falls back to text/plain when the system
+  // lacks shared-mime-info, which would render the article as raw source.
+  requestJob->reply( "text/html; charset=utf-8", reply );
   connect( requestJob, &QObject::destroyed, reply, &QObject::deleteLater );
 }
 

--- a/src/article_netmgr.cc
+++ b/src/article_netmgr.cc
@@ -29,34 +29,48 @@ QByteArray getMimeTypeWithFallback( const QUrl & url, const QByteArray & data )
   //    installations and would otherwise make these resources fall back to
   //    text/plain (and render as raw source) in QtWebEngine.
   const QString ext = QFileInfo( url.path() ).suffix().toLower();
-  if ( ext == "html" || ext == "htm" )
+  if ( ext == "html" || ext == "htm" ) {
     return "text/html; charset=utf-8";
-  if ( ext == "css" )
+  }
+  if ( ext == "css" ) {
     return "text/css; charset=utf-8";
-  if ( ext == "js" || ext == "mjs" )
+  }
+  if ( ext == "js" || ext == "mjs" ) {
     return "text/javascript; charset=utf-8";
-  if ( ext == "png" )
+  }
+  if ( ext == "png" ) {
     return "image/png";
-  if ( ext == "jpg" || ext == "jpeg" )
+  }
+  if ( ext == "jpg" || ext == "jpeg" ) {
     return "image/jpeg";
-  if ( ext == "gif" )
+  }
+  if ( ext == "gif" ) {
     return "image/gif";
-  if ( ext == "svg" )
+  }
+  if ( ext == "svg" ) {
     return "image/svg+xml";
-  if ( ext == "webp" )
+  }
+  if ( ext == "webp" ) {
     return "image/webp";
-  if ( ext == "woff" )
+  }
+  if ( ext == "woff" ) {
     return "font/woff";
-  if ( ext == "woff2" )
+  }
+  if ( ext == "woff2" ) {
     return "font/woff2";
-  if ( ext == "ttf" )
+  }
+  if ( ext == "ttf" ) {
     return "font/ttf";
-  if ( ext == "mp3" )
+  }
+  if ( ext == "mp3" ) {
     return "audio/mpeg";
-  if ( ext == "wav" )
+  }
+  if ( ext == "wav" ) {
     return "audio/wav";
-  if ( ext == "ogg" )
+  }
+  if ( ext == "ogg" ) {
     return "audio/ogg";
+  }
 
   // 3. System MIME database (URL/extension based).
   QMimeDatabase mimeDb;

--- a/src/article_netmgr.hh
+++ b/src/article_netmgr.hh
@@ -14,6 +14,16 @@
 
 using std::vector;
 
+/// Robustly resolves the MIME type for an article/resource URL served via a
+/// custom scheme (gdlookup, bres, gdau, ...). It consults an extension
+/// whitelist first so it does not depend on the system's shared-mime-info
+/// database (which may be missing on minimal Linux installs and makes
+/// QtWebEngine fall back to text/plain, rendering HTML as raw source), then
+/// QMimeDatabase, and finally sniffs the payload so HTML documents are never
+/// misreported as text/plain. When \a data is empty (e.g. the payload is not
+/// available yet) only the URL-based heuristics are applied.
+QByteArray getMimeTypeWithFallback( const QUrl & url, const QByteArray & data = QByteArray() );
+
 /// A custom QNetworkAccessManager version which fetches images from the
 /// dictionaries when requested.
 

--- a/src/resourceschemehandler.cc
+++ b/src/resourceschemehandler.cc
@@ -9,33 +9,28 @@ ResourceSchemeHandler::ResourceSchemeHandler( ArticleNetworkAccessManager & arti
 void ResourceSchemeHandler::requestStarted( QWebEngineUrlRequestJob * requestJob )
 {
   const QUrl url = requestJob->requestUrl();
+  // The content type is resolved in replyJob, where the actual payload is
+  // available and can be sniffed. The out-parameter below is therefore unused.
   QString content_type;
   const sptr< Dictionary::DataRequest > reply = this->mManager.getResource( url, content_type );
-
-  if ( content_type.isEmpty() )
-    content_type = db.mimeTypeForUrl( url ).name();
-
-  if ( content_type.startsWith( "text/" ) || content_type == "application/javascript" )
-    content_type.append( "; charset=utf-8" );
 
   if ( reply == nullptr ) {
     qDebug() << "Resource failed to load: " << url.toString();
     requestJob->fail( QWebEngineUrlRequestJob::RequestFailed );
   }
   else if ( reply->isFinished() ) {
-    replyJob( reply, requestJob, content_type );
+    replyJob( reply, requestJob );
   }
   else {
     connect( reply.get(), &Dictionary::DataRequest::finished, requestJob, [ = ]() {
-      replyJob( reply, requestJob, content_type );
+      replyJob( reply, requestJob );
     } );
   }
 }
 
 
 void ResourceSchemeHandler::replyJob( sptr< Dictionary::DataRequest > reply,
-                                      QWebEngineUrlRequestJob * requestJob,
-                                      QString content_type )
+                                      QWebEngineUrlRequestJob * requestJob )
 {
   if ( !reply.get() ) {
     requestJob->fail( QWebEngineUrlRequestJob::UrlNotFound );
@@ -46,13 +41,21 @@ void ResourceSchemeHandler::replyJob( sptr< Dictionary::DataRequest > reply,
     requestJob->fail( QWebEngineUrlRequestJob::UrlNotFound );
     return;
   }
+
+  // Resolve the content type robustly: extension whitelist first (independent
+  // of the system's shared-mime-info), then QMimeDatabase, then sniff the
+  // payload so HTML is never misreported as text/plain on misconfigured
+  // systems. This is where the full data is available, so data sniffing works.
+  const QByteArray contentType =
+    getMimeTypeWithFallback( requestJob->requestUrl(), QByteArray( data.data(), data.size() ) );
+
   QByteArray * ba  = new QByteArray( data.data(), data.size() );
   QBuffer * buffer = new QBuffer( ba );
   buffer->open( QBuffer::ReadOnly );
   buffer->seek( 0 );
 
   // Reply segment
-  requestJob->reply( content_type.toLatin1(), buffer );
+  requestJob->reply( contentType, buffer );
 
   connect( requestJob, &QObject::destroyed, buffer, [ = ]() {
     buffer->close();

--- a/src/resourceschemehandler.cc
+++ b/src/resourceschemehandler.cc
@@ -29,8 +29,7 @@ void ResourceSchemeHandler::requestStarted( QWebEngineUrlRequestJob * requestJob
 }
 
 
-void ResourceSchemeHandler::replyJob( sptr< Dictionary::DataRequest > reply,
-                                      QWebEngineUrlRequestJob * requestJob )
+void ResourceSchemeHandler::replyJob( sptr< Dictionary::DataRequest > reply, QWebEngineUrlRequestJob * requestJob )
 {
   if ( !reply.get() ) {
     requestJob->fail( QWebEngineUrlRequestJob::UrlNotFound );

--- a/src/resourceschemehandler.hh
+++ b/src/resourceschemehandler.hh
@@ -11,9 +11,8 @@ public:
   void requestStarted( QWebEngineUrlRequestJob * requestJob );
 
 protected:
-  void replyJob( sptr< Dictionary::DataRequest > reply, QWebEngineUrlRequestJob * requestJob, QString content_type );
+  void replyJob( sptr< Dictionary::DataRequest > reply, QWebEngineUrlRequestJob * requestJob );
 
 private:
   ArticleNetworkAccessManager & mManager;
-  QMimeDatabase db;
 };


### PR DESCRIPTION
## Problem

On some Linux environments (e.g. Arch) lacking a complete `shared-mime-info`, the content type returned from `QWebEngineUrlSchemeHandler::requestStarted` via `job->reply(contentType, device)` falls back to `text/plain`. As a result, the main window renders raw HTML source instead of the rendered article page

## Root cause

- `LocalSchemeHandler` replied with `"text/html"` (no `charset=utf-8`).
- `handleInternalScheme` / `handleLookupScheme` set `"text/html"` without charset.
- `ResourceSchemeHandler` and `handleResourceScheme` relied solely on `QMimeDatabase::mimeTypeForUrl(url)`, which fails for extension-less resources on systems missing `shared-mime-info`.

## Fix

1. Pin `text/html; charset=utf-8` for all HTML-page schemes (`gdlookup`/`bword`/`entry`/`gdinternal`).
2. Add `getMimeTypeWithFallback(url, data)` with a 5-tier strategy:
   - HTML scheme -> `text/html; charset=utf-8`
   - extension whitelist (css/js/png/svg/woff2/ttf/mp3/wav/ogg/...) independent of the system DB
   - `QMimeDatabase` (URL then data)
   - HTML payload sniffing (`<!DOCTYPE html`/`<html`/`<?xml`) so HTML is never misreported as `text/plain`
   - final fallback `application/octet-stream` (never `text/plain`)
3. `ResourceSchemeHandler::replyJob` now computes MIME where the payload is available, enabling data sniffing.

## Verification

