### PR TITLE
fix zim redirect: support both html-meta and native redirects

### DIFF
--- a/src/dict/zim.cc
+++ b/src/dict/zim.cc
@@ -122,12 +122,10 @@ bool getRedirectFromHtml( const string & html, string & result )
 {
   QString text = QString::fromUtf8( html.c_str() );
 
-  static const QRegularExpression rxMeta( R"(<meta\b[^>]*>)",
-                                          QRegularExpression::CaseInsensitiveOption );
-  static const QRegularExpression rxRefresh(
-    R"(http-equiv\s*=\s*["']?refresh)", QRegularExpression::CaseInsensitiveOption );
-  static const QRegularExpression rxUrl( R"(url\s*=\s*['"]?([^'"\s]+))",
-                                         QRegularExpression::CaseInsensitiveOption );
+  static const QRegularExpression rxMeta( R"(<meta\b[^>]*>)", QRegularExpression::CaseInsensitiveOption );
+  static const QRegularExpression rxRefresh( R"(http-equiv\s*=\s*["']?refresh)",
+                                             QRegularExpression::CaseInsensitiveOption );
+  static const QRegularExpression rxUrl( R"(url\s*=\s*['"]?([^'"\s]+))", QRegularExpression::CaseInsensitiveOption );
 
   auto it = rxMeta.globalMatch( text );
   while ( it.hasNext() ) {
@@ -139,7 +137,7 @@ bool getRedirectFromHtml( const string & html, string & result )
     if ( !m.hasMatch() ) {
       continue;
     }
-    QString url = m.captured( 1 );
+    QString url    = m.captured( 1 );
     const int hash = url.indexOf( '#' );
     if ( hash >= 0 ) {
       url.truncate( hash );
@@ -897,11 +895,10 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
           // "四国地方"->"四国" from lookups.  The mime type still has to be
           // taken from the target, since a redirect entry itself is not a
           // media item.
-          const auto mimeType =
-            entry.isRedirect() ? entry.getRedirect().getMimetype() : entry.getItem().getMimetype();
-          auto url   = entry.getPath();
-          auto title = entry.getTitle();
-          auto index = entry.getIndex();
+          const auto mimeType = entry.isRedirect() ? entry.getRedirect().getMimetype() : entry.getItem().getMimetype();
+          auto url            = entry.getPath();
+          auto title          = entry.getTitle();
+          auto index          = entry.getIndex();
           // Read article url and title
           if ( !isArticleMime( mimeType ) ) {
             continue;

--- a/src/dict/zim.cc
+++ b/src/dict/zim.cc
@@ -113,6 +113,47 @@ bool isArticleMime( const string & mime_type )
   return mime_type == "text/html" /*|| mime_type.compare( "text/plain" ) == 0*/;
 }
 
+/// Wikipedia-style zim redirect entries are tiny html pages containing
+/// <meta http-equiv="refresh" content="0;URL='./Target#Anchor'">.  Resolving
+/// them while reading (instead of leaving the meta in the rendered html)
+/// prevents the web page from auto-navigating and hiding the other
+/// dictionaries' entries on the same article page.
+bool getRedirectFromHtml( const string & html, string & result )
+{
+  QString text = QString::fromUtf8( html.c_str() );
+
+  static const QRegularExpression rxMeta( R"(<meta\b[^>]*>)",
+                                          QRegularExpression::CaseInsensitiveOption );
+  static const QRegularExpression rxRefresh(
+    R"(http-equiv\s*=\s*["']?refresh)", QRegularExpression::CaseInsensitiveOption );
+  static const QRegularExpression rxUrl( R"(url\s*=\s*['"]?([^'"\s]+))",
+                                         QRegularExpression::CaseInsensitiveOption );
+
+  auto it = rxMeta.globalMatch( text );
+  while ( it.hasNext() ) {
+    const QString meta = it.next().captured();
+    if ( !meta.contains( rxRefresh ) ) {
+      continue;
+    }
+    const auto m = rxUrl.match( meta );
+    if ( !m.hasMatch() ) {
+      continue;
+    }
+    QString url = m.captured( 1 );
+    const int hash = url.indexOf( '#' );
+    if ( hash >= 0 ) {
+      url.truncate( hash );
+    }
+    url.remove( RX::Zim::leadingDotSlash );
+    if ( url.isEmpty() || url.startsWith( "//" ) || url.contains( "://" ) ) {
+      continue;
+    }
+    result = url.toStdString();
+    return true;
+  }
+  return false;
+}
+
 quint32 readArticle( const ZimFile & file, quint32 articleNumber, string & result )
 {
   try {
@@ -286,6 +327,19 @@ quint32 ZimDictionary::loadArticle( quint32 address, string & articleText, bool 
     QMutexLocker _( &zimMutex );
     ret = readArticle( df, address, articleText );
   }
+
+  // A zim redirect entry is a tiny page with <meta http-equiv="refresh"> to
+  // its target. Resolve it here so the browser never auto-navigates the whole
+  // article, which would hide other dictionaries' entries on the same page.
+  string target;
+  if ( getRedirectFromHtml( articleText, target ) ) {
+    string targetText;
+    QMutexLocker _( &zimMutex );
+    if ( readArticleByPath( df, target, targetText ) != 0xFFFFFFFF ) {
+      articleText = targetText;
+    }
+  }
+
   if ( !rawText ) {
     articleText = convert( articleText );
   }

--- a/src/dict/zim.cc
+++ b/src/dict/zim.cc
@@ -60,7 +60,7 @@ using ZimFile = zim::Archive;
 
 enum {
   Signature            = 0x584D495A, // ZIMX on little-endian, XMIZ on big-endian
-  CurrentFormatVersion = 4 + BtreeIndexing::FormatVersion + Folding::Version
+  CurrentFormatVersion = 5 + BtreeIndexing::FormatVersion + Folding::Version
 };
 
   #pragma pack( push, 1 )
@@ -891,11 +891,17 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
 
         //only iterate the article
         for ( const auto & entry : df.iterByTitle() ) {
-          auto item     = entry.getItem( true );
-          auto mimeType = item.getMimetype();
-          auto url      = item.getPath();
-          auto title    = item.getTitle();
-          auto index    = item.getIndex();
+          // Index each entry under its own title/path/index.  Zim redirects
+          // must not be followed here: following them would collapse every
+          // redirect alias into its target article, hiding aliases such as
+          // "四国地方"->"四国" from lookups.  The mime type still has to be
+          // taken from the target, since a redirect entry itself is not a
+          // media item.
+          const auto mimeType =
+            entry.isRedirect() ? entry.getRedirect().getMimetype() : entry.getItem().getMimetype();
+          auto url   = entry.getPath();
+          auto title = entry.getTitle();
+          auto index = entry.getIndex();
           // Read article url and title
           if ( !isArticleMime( mimeType ) ) {
             continue;


### PR DESCRIPTION
- **fix zim redirect: for wiki-en 2026, redirect with html refresh**
- **fix zim redirect: for wiki-jp 2023, redirect with traditional flag**

## Problem

Wikipedia zim dumps encode redirects in two different ways, and neither was
handled correctly:

- **Newer dumps use html-meta redirects** (e.g. `wikipedia_en_all_maxi_2026-02`).
  A redirect like `Sebum` is a tiny HTML page containing
  `<meta http-equiv="refresh" content="0;URL='./Sebaceous_gland#Sebum'">`.
  The meta tag made the whole article view auto-navigate, so entering `Sebum`
  also queried `Sebaceous_gland` for every other dictionary. Expected
  behavior: resolve the redirect for this wiki only (`Sebaceous gland`), while
  other dictionaries still look up `Sebum`.

- **Older dumps use native libzim redirects** (e.g.
  `wikipedia_ja_all_maxi_2023-07`). Redirect aliases such as
  `四国地方` → `四国` are native redirect entries, but they were silently
  followed while building the index, so the alias itself was never indexed.
  Entering `四国地方` returned nothing instead of the `四国` article.

## Fix

- Resolve html-meta redirects at read time, so the browser never
  auto-navigates and other dictionaries still receive the original query.
- Index each entry under its own title/path/index instead of following native
  redirects; the mime type is still read from the redirect target.
- Bump the index format version so existing zim indexes are rebuilt.

## Tested

- `wikipedia_en_all_maxi_2026-02`: `Sebum` resolves to `Sebaceous gland` for
  this wiki only.
- `wikipedia_ja_all_maxi_2023-07`: `四国地方` resolves to the `四国` article.
