### PR TITLE
Add preference to disable automatic audio attachment in Anki cards

### DIFF
--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -3508,6 +3508,10 @@ from Stardict, Babylon and GLS dictionaries</source>
         <source>Keep Dock icon visible in background</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Add audio to Anki card when available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ProgramTypeEditor</name>

--- a/src/ankiconnector.cc
+++ b/src/ankiconnector.cc
@@ -56,7 +56,7 @@ void AnkiConnector::sendToAnki( const QString & word,
   }
 
   QJsonArray audioArray;
-  if ( !audio.isEmpty() ) {
+  if ( !audio.isEmpty() && cfg.preferences.ankiConnectServer.addAudio ) {
     audioArray.append( audio );
   }
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -55,7 +55,8 @@ AnkiConnectServer::AnkiConnectServer():
   port( 8765 ),
   word( "word" ),
   text( "selected_text" ),
-  sentence( "marked_sentence" )
+  sentence( "marked_sentence" ),
+  addAudio( true )
 {
 }
 
@@ -932,6 +933,10 @@ Class load()
       c.preferences.ankiConnectServer.word     = ankiConnectServer.namedItem( "word" ).toElement().text();
       c.preferences.ankiConnectServer.text     = ankiConnectServer.namedItem( "text" ).toElement().text();
       c.preferences.ankiConnectServer.sentence = ankiConnectServer.namedItem( "sentence" ).toElement().text();
+
+      if ( !ankiConnectServer.namedItem( "addAudio" ).isNull() ) {
+        c.preferences.ankiConnectServer.addAudio = ( ankiConnectServer.namedItem( "addAudio" ).toElement().text() == "1" );
+      }
     }
 
     if ( !preferences.namedItem( "checkForNewReleases" ).isNull() ) {
@@ -1959,6 +1964,10 @@ void save( const Class & c )
 
       opt = dd.createElement( "sentence" );
       opt.appendChild( dd.createTextNode( c.preferences.ankiConnectServer.sentence ) );
+      proxy.appendChild( opt );
+
+      opt = dd.createElement( "addAudio" );
+      opt.appendChild( dd.createTextNode( c.preferences.ankiConnectServer.addAudio ? "1" : "0" ) );
       proxy.appendChild( opt );
     }
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -935,7 +935,8 @@ Class load()
       c.preferences.ankiConnectServer.sentence = ankiConnectServer.namedItem( "sentence" ).toElement().text();
 
       if ( !ankiConnectServer.namedItem( "addAudio" ).isNull() ) {
-        c.preferences.ankiConnectServer.addAudio = ( ankiConnectServer.namedItem( "addAudio" ).toElement().text() == "1" );
+        c.preferences.ankiConnectServer.addAudio =
+          ( ankiConnectServer.namedItem( "addAudio" ).toElement().text() == "1" );
       }
     }
 

--- a/src/config.hh
+++ b/src/config.hh
@@ -176,6 +176,8 @@ struct AnkiConnectServer
   QString text;
   QString sentence;
 
+  bool addAudio = true;
+
   AnkiConnectServer();
 };
 

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -437,6 +437,12 @@ void ArticleView::sendToAnki( const QString & word,
                               const QByteArray & audioData,
                               const QString & audioFileName )
 {
+  // Allow users to opt out of automatic audio attachments.
+  if ( !cfg.preferences.ankiConnectServer.addAudio ) {
+    ankiConnector->sendToAnki( word, dict_definition, sentence, QJsonObject() );
+    return;
+  }
+
   QJsonObject audioObj;
   QByteArray data = audioData;
   QString url     = audioFileName;

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -376,6 +376,7 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   ui.ankiText->setText( p.ankiConnectServer.text );
   ui.ankiWord->setText( p.ankiConnectServer.word );
   ui.ankiSentence->setText( p.ankiConnectServer.sentence );
+  ui.ankiAddAudio->setChecked( p.ankiConnectServer.addAudio );
 
   connect( ui.customProxy, &QAbstractButton::toggled, this, &Preferences::customProxyToggled );
 
@@ -577,6 +578,7 @@ Config::Preferences Preferences::getPreferences()
   p.ankiConnectServer.text     = ui.ankiText->text();
   p.ankiConnectServer.word     = ui.ankiWord->text();
   p.ankiConnectServer.sentence = ui.ankiSentence->text();
+  p.ankiConnectServer.addAudio = ui.ankiAddAudio->isChecked();
 
   p.checkForNewReleases           = ui.checkForNewReleases->isChecked();
   p.disallowContentFromOtherSites = ui.disallowContentFromOtherSites->isChecked();

--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -1407,6 +1407,16 @@ download page.</string>
             </item>
            </layout>
           </item>
+          <item>
+           <widget class="QCheckBox" name="ankiAddAudio">
+            <property name="text">
+             <string>Add audio to Anki card when available</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>


### PR DESCRIPTION
### What does this PR do?

Adds a checkbox in Preferences ("Add audio to Anki card when available", enabled by default) so users can opt out of automatically attaching audio to Anki cards created via AnkiConnect.

Previously, whenever audio was available for a word it was always attached to the generated card, with no way to disable this.

### Changes

- `config.hh` / `config.cc`: new `AnkiConnectServer::addAudio` preference (default `true`), loaded/saved as `<addAudio>`
- `ankiconnector.cc`: skip appending audio when the preference is off
- `articleview.cc`: skip building the audio object when the preference is off
- `preferences.cc` / `preferences.ui`: new checkbox wired to the preference

Fixes #3067

### Disclaimer
The changes have been made with AI assistant.